### PR TITLE
Fix for #358

### DIFF
--- a/core/impl/src/main/java/com/blazebit/persistence/impl/AbstractCommonQueryBuilder.java
+++ b/core/impl/src/main/java/com/blazebit/persistence/impl/AbstractCommonQueryBuilder.java
@@ -612,7 +612,7 @@ public abstract class AbstractCommonQueryBuilder<QueryResultType, BuilderType, S
         if (type == null) {
             treatFunction = cbf.getTreatFunctions().get(valueClass);
             if (treatFunction == null) {
-                throw new IllegalArgumentException("Unsupported type for VALUES clause: " + valueClass.getName());
+                throw new IllegalArgumentException("Unsupported non-managed type for VALUES clause: " + valueClass.getName());
             }
 
             String sqlType = mainQuery.dbmsDialect.getSqlType(valueClass);

--- a/core/testsuite/src/main/java/com/blazebit/persistence/testsuite/entity/DocumentTupleEntity.java
+++ b/core/testsuite/src/main/java/com/blazebit/persistence/testsuite/entity/DocumentTupleEntity.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2014 - 2017 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.testsuite.entity;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import java.io.Serializable;
+
+/**
+ * @author Moritz Becker (moritz.becker@gmx.at)
+ * @since 1.2
+ */
+@Entity
+public class DocumentTupleEntity implements Serializable {
+    private Document element1;
+    private Document element2;
+
+    public DocumentTupleEntity() { }
+
+    public DocumentTupleEntity(Document element1, Document element2) {
+        this.element1 = element1;
+        this.element2 = element2;
+    }
+
+    @Id
+    @ManyToOne
+    public Document getElement1() {
+        return element1;
+    }
+
+    public void setElement1(Document element1) {
+        this.element1 = element1;
+    }
+
+    @ManyToOne
+    public Document getElement2() {
+        return element2;
+    }
+
+    public void setElement2(Document element2) {
+        this.element2 = element2;
+    }
+}

--- a/core/testsuite/src/main/java/com/blazebit/persistence/testsuite/entity/EmbeddedDocumentTupleEntity.java
+++ b/core/testsuite/src/main/java/com/blazebit/persistence/testsuite/entity/EmbeddedDocumentTupleEntity.java
@@ -16,43 +16,37 @@
 
 package com.blazebit.persistence.testsuite.entity;
 
+import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.ManyToOne;
 import java.io.Serializable;
 
 /**
- * @author Moritz Becker (moritz.becker@gmx.at)
- * @since 1.2
+ * @author Christian Beikov
+ * @since 1.2.0
  */
 @Entity
-public class DocumentTupleEntity implements Serializable {
-    private Document element1;
-    private Document element2;
+public class EmbeddedDocumentTupleEntity implements Serializable {
 
-    public DocumentTupleEntity() { }
+    private EmbeddedDocumentTupleEntityId id;
 
-    public DocumentTupleEntity(Document element1, Document element2) {
-        this.element1 = element1;
-        this.element2 = element2;
+    public EmbeddedDocumentTupleEntity() {
+        this(new EmbeddedDocumentTupleEntityId());
     }
 
-    @Id
-    @ManyToOne(optional = false)
-    public Document getElement1() {
-        return element1;
+    public EmbeddedDocumentTupleEntity(Long element1, Long element2) {
+        this(new EmbeddedDocumentTupleEntityId(element1, element2));
     }
 
-    public void setElement1(Document element1) {
-        this.element1 = element1;
+    public EmbeddedDocumentTupleEntity(EmbeddedDocumentTupleEntityId id) {
+        this.id = id;
     }
 
-    @ManyToOne
-    public Document getElement2() {
-        return element2;
+    @EmbeddedId
+    public EmbeddedDocumentTupleEntityId getId() {
+        return id;
     }
 
-    public void setElement2(Document element2) {
-        this.element2 = element2;
+    public void setId(EmbeddedDocumentTupleEntityId id) {
+        this.id = id;
     }
 }

--- a/core/testsuite/src/main/java/com/blazebit/persistence/testsuite/entity/EmbeddedDocumentTupleEntityId.java
+++ b/core/testsuite/src/main/java/com/blazebit/persistence/testsuite/entity/EmbeddedDocumentTupleEntityId.java
@@ -16,43 +16,42 @@
 
 package com.blazebit.persistence.testsuite.entity;
 
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.ManyToOne;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
 import java.io.Serializable;
 
 /**
- * @author Moritz Becker (moritz.becker@gmx.at)
- * @since 1.2
+ * @author Christian Beikov
+ * @since 1.2.0
  */
-@Entity
-public class DocumentTupleEntity implements Serializable {
-    private Document element1;
-    private Document element2;
+@Embeddable
+public class EmbeddedDocumentTupleEntityId implements Serializable {
 
-    public DocumentTupleEntity() { }
+    private Long element1;
+    private Long element2;
 
-    public DocumentTupleEntity(Document element1, Document element2) {
+    public EmbeddedDocumentTupleEntityId() { }
+
+    public EmbeddedDocumentTupleEntityId(Long element1, Long element2) {
         this.element1 = element1;
         this.element2 = element2;
     }
 
-    @Id
-    @ManyToOne(optional = false)
-    public Document getElement1() {
+    @Column(nullable = false)
+    public Long getElement1() {
         return element1;
     }
 
-    public void setElement1(Document element1) {
+    public void setElement1(Long element1) {
         this.element1 = element1;
     }
 
-    @ManyToOne
-    public Document getElement2() {
+    @Column(nullable = false)
+    public Long getElement2() {
         return element2;
     }
 
-    public void setElement2(Document element2) {
+    public void setElement2(Long element2) {
         this.element2 = element2;
     }
 }

--- a/core/testsuite/src/main/resources/META-INF/persistence.xml
+++ b/core/testsuite/src/main/resources/META-INF/persistence.xml
@@ -77,6 +77,8 @@
         <class>com.blazebit.persistence.testsuite.entity.TestCTE</class>
         <class>com.blazebit.persistence.testsuite.entity.Version</class>
         <class>com.blazebit.persistence.testsuite.entity.Workflow</class>
+        <class>com.blazebit.persistence.testsuite.entity.DocumentTupleEntity</class>
+
         <exclude-unlisted-classes>true</exclude-unlisted-classes>
     </persistence-unit>
 </persistence>

--- a/core/testsuite/src/main/resources/META-INF/persistence.xml
+++ b/core/testsuite/src/main/resources/META-INF/persistence.xml
@@ -21,12 +21,14 @@
         <class>com.blazebit.persistence.testsuite.entity.Document</class>
         <class>com.blazebit.persistence.testsuite.entity.DocumentForEntityKeyMaps</class>
         <class>com.blazebit.persistence.testsuite.entity.DocumentNodeCTE</class>
+        <class>com.blazebit.persistence.testsuite.entity.DocumentTupleEntity</class>
         <class>com.blazebit.persistence.testsuite.entity.EmbeddableTestEntity</class>
         <class>com.blazebit.persistence.testsuite.entity.EmbeddableTestEntityContainer</class>
         <class>com.blazebit.persistence.testsuite.entity.IdHolderCTE</class>
         <class>com.blazebit.persistence.testsuite.entity.IndexedNode</class>
         <class>com.blazebit.persistence.testsuite.entity.IndexedNode2</class>
         <class>com.blazebit.persistence.testsuite.entity.IndexedEmbeddable</class>
+        <class>com.blazebit.persistence.testsuite.entity.EmbeddedDocumentTupleEntity</class>
         <class>com.blazebit.persistence.testsuite.entity.IdHolderCTE</class>
         <class>com.blazebit.persistence.testsuite.entity.IntIdEntity</class>
         <class>com.blazebit.persistence.testsuite.entity.JuniorProjectLeader</class>
@@ -77,7 +79,6 @@
         <class>com.blazebit.persistence.testsuite.entity.TestCTE</class>
         <class>com.blazebit.persistence.testsuite.entity.Version</class>
         <class>com.blazebit.persistence.testsuite.entity.Workflow</class>
-        <class>com.blazebit.persistence.testsuite.entity.DocumentTupleEntity</class>
 
         <exclude-unlisted-classes>true</exclude-unlisted-classes>
     </persistence-unit>

--- a/core/testsuite/src/test/java/com/blazebit/persistence/testsuite/Issue358Test.java
+++ b/core/testsuite/src/test/java/com/blazebit/persistence/testsuite/Issue358Test.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2014 - 2017 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.testsuite;
+
+import com.blazebit.persistence.CriteriaBuilder;
+import com.blazebit.persistence.impl.ConfigurationProperties;
+import com.blazebit.persistence.testsuite.base.category.NoDatanucleus;
+import com.blazebit.persistence.testsuite.base.category.NoEclipselink;
+import com.blazebit.persistence.testsuite.base.category.NoHibernate42;
+import com.blazebit.persistence.testsuite.base.category.NoHibernate43;
+import com.blazebit.persistence.testsuite.base.category.NoHibernate50;
+import com.blazebit.persistence.testsuite.base.category.NoOpenJPA;
+import com.blazebit.persistence.testsuite.entity.Document;
+import com.blazebit.persistence.testsuite.entity.DocumentNodeCTE;
+import com.blazebit.persistence.testsuite.entity.DocumentTupleEntity;
+import com.blazebit.persistence.testsuite.entity.IntIdEntity;
+import com.blazebit.persistence.testsuite.entity.Person;
+import com.blazebit.persistence.testsuite.entity.PersonCTE;
+import com.blazebit.persistence.testsuite.entity.Version;
+import com.blazebit.persistence.testsuite.entity.Workflow;
+import com.blazebit.persistence.testsuite.tx.TxVoidWork;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Tuple;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * @author Moritz Becker (moritz.becker@gmx.at)
+ * @since 1.2
+ */
+public class Issue358Test extends AbstractCoreTest {
+
+    private Person p1;
+    private Document d1;
+    private Document d2;
+    private Document d3;
+
+    @Override
+    protected Class<?>[] getEntityClasses() {
+        return new Class<?>[]{
+                Document.class,
+                Version.class,
+                Person.class,
+                IntIdEntity.class,
+                DocumentTupleEntity.class
+        };
+    }
+
+    @Override
+    public void setUpOnce() {
+        cleanDatabase();
+        transactional(new TxVoidWork() {
+            @Override
+            public void work(EntityManager em) {
+                p1 = new Person("p1");
+                d1 = new Document("doc1", p1);
+                d2 = new Document("doc2", p1);
+                d3 = new Document("doc3", p1);
+
+                em.persist(p1);
+                em.persist(d1);
+                em.persist(d2);
+                em.persist(d3);
+            }
+        });
+    }
+
+    @Before
+    public void setUp() {
+        p1 = cbf.create(em, Person.class).getSingleResult();
+        d1 = cbf.create(em, Document.class).where("name").eq("doc1").getSingleResult();
+        d2 = cbf.create(em, Document.class).where("name").eq("doc2").getSingleResult();
+        d3 = cbf.create(em, Document.class).where("name").eq("doc3").getSingleResult();
+    }
+
+    @Test
+    @Category({ NoDatanucleus.class, NoEclipselink.class, NoOpenJPA.class })
+    public void testValuesEntityFunctionMultiRelation() {
+        CriteriaBuilder<Tuple> cb = cbf.create(em, Tuple.class);
+        cb.setProperty(ConfigurationProperties.VALUES_CLAUSE_FILTER_NULLS, "false");
+
+        cb.fromValues(DocumentTupleEntity.class, "documentTuple", Arrays.asList(new DocumentTupleEntity(d1, d2), new DocumentTupleEntity(d2, d3)));
+        cb.select("documentTuple.element1.id");
+        cb.select("documentTuple.element2.id");
+
+        // Empty values
+        List<Tuple> resultList = cb.getResultList();
+        assertEquals(1, resultList.size());
+
+        assertNull(resultList.get(0).get(0));
+        assertNull(resultList.get(0).get(1));
+    }
+}


### PR DESCRIPTION
Before we simply created an example query containing the plain attributes in the select, but that has the effect that joins are generated for *ToOne relations. I fixed that by using the ids of the *ToOne types instead in the select clause. I also simplified the select column extraction of the example query.