### PR TITLE
#381 Test and fix

### DIFF
--- a/core/testsuite/src/main/java/com/blazebit/persistence/testsuite/entity/TablePerClassBase.java
+++ b/core/testsuite/src/main/java/com/blazebit/persistence/testsuite/entity/TablePerClassBase.java
@@ -25,7 +25,7 @@ import java.io.Serializable;
 /**
  *
  * @author Christian Beikov
- * @since 1.0
+ * @since 1.2.0
  */
 @Entity
 @Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)

--- a/core/testsuite/src/test/java/com/blazebit/persistence/testsuite/AdvancedQueryCachingTest.java
+++ b/core/testsuite/src/test/java/com/blazebit/persistence/testsuite/AdvancedQueryCachingTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014 - 2017 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.testsuite;
+
+import com.blazebit.persistence.testsuite.entity.Document;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+/**
+ * @author Christian Beikov
+ * @since 1.2.0
+ */
+public class AdvancedQueryCachingTest extends AbstractCoreTest {
+
+    /**
+     * Test with two different parameter list sizes to make sure the query cache isn't hit.
+     * If it would, the second query fails because of the different parameter count.
+     *
+     * This test is for issue #381
+     */
+    @Test
+    public void differentParameterListSizesShouldNotResultInQueryCacheHit() {
+        toUpperDocumentNames(Arrays.asList(1L));
+        toUpperDocumentNames(Arrays.asList(1L, 2L));
+    }
+
+    private int toUpperDocumentNames(Collection<Long> ids) {
+        return cbf.update(em, Document.class)
+                .setExpression("name", "UPPER(name)")
+                .where("id").in(ids)
+                .executeWithReturning("id", Long.class)
+                .getUpdateCount();
+    }
+}

--- a/core/testsuite/src/test/java/com/blazebit/persistence/testsuite/EntityInValuesClauseTest.java
+++ b/core/testsuite/src/test/java/com/blazebit/persistence/testsuite/EntityInValuesClauseTest.java
@@ -40,10 +40,12 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 
 /**
- * @author Moritz Becker (moritz.becker@gmx.at)
- * @since 1.2
+ * This test is for issue #358
+ *
+ * @author Moritz Becker
+ * @since 1.2.0
  */
-public class Issue358Test extends AbstractCoreTest {
+public class EntityInValuesClauseTest extends AbstractCoreTest {
 
     private Person p1;
     private Document d1;
@@ -91,7 +93,7 @@ public class Issue358Test extends AbstractCoreTest {
 
     @Test
     @Category({ NoDatanucleus.class, NoEclipselink.class, NoOpenJPA.class })
-    public void testValuesEntityFunctionMultiRelation() {
+    public void entityClassWithMultipleRelationsInValuesClause() {
         CriteriaBuilder<Tuple> cb = cbf.create(em, Tuple.class);
 
         cb.fromValues(DocumentTupleEntity.class, "documentTuple", Arrays.asList(new DocumentTupleEntity(d1, d2), new DocumentTupleEntity(d2, d3)));
@@ -112,7 +114,7 @@ public class Issue358Test extends AbstractCoreTest {
 
     @Test
     @Category({ NoDatanucleus.class, NoEclipselink.class, NoOpenJPA.class })
-    public void testValuesEntityFunctionEmbeddedId() {
+    public void entityClassWithEmbeddedIdInValuesClause() {
         CriteriaBuilder<Tuple> cb = cbf.create(em, Tuple.class);
 
         cb.fromValues(EmbeddedDocumentTupleEntity.class, "documentTuple", Arrays.asList(new EmbeddedDocumentTupleEntity(d1.getId(), d2.getId()), new EmbeddedDocumentTupleEntity(d2.getId(), d3.getId())));

--- a/core/testsuite/src/test/java/com/blazebit/persistence/testsuite/EntitySchemaInTableAnnotationTest.java
+++ b/core/testsuite/src/test/java/com/blazebit/persistence/testsuite/EntitySchemaInTableAnnotationTest.java
@@ -23,11 +23,12 @@ import org.junit.Test;
 import java.util.Properties;
 
 /**
+ * This test is for issue #344
  *
  * @author Christian Beikov
  * @since 1.2.0
  */
-public class Issue344SchemaTest extends AbstractCoreTest {
+public class EntitySchemaInTableAnnotationTest extends AbstractCoreTest {
 
     @Override
     protected Class<?>[] getEntityClasses() {
@@ -46,7 +47,7 @@ public class Issue344SchemaTest extends AbstractCoreTest {
     }
 
     @Test
-    public void testBuild() {
+    public void buildingEntityMetamodelWorksWithSchemaInTableAnnotation() {
         CriteriaBuilder<SchemaEntity> criteria = cbf.create(em, SchemaEntity.class, "d");
         criteria.getQuery();
     }

--- a/core/testsuite/src/test/java/com/blazebit/persistence/testsuite/ImplicitNamingTest.java
+++ b/core/testsuite/src/test/java/com/blazebit/persistence/testsuite/ImplicitNamingTest.java
@@ -27,9 +27,9 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * @author Moritz Becker
- * @since 1.2
+ * @since 1.2.0
  */
-public class Issue372Test extends AbstractCoreTest {
+public class ImplicitNamingTest extends AbstractCoreTest {
 
     @Override
     protected Class<?>[] getEntityClasses() {
@@ -41,9 +41,11 @@ public class Issue372Test extends AbstractCoreTest {
 
     /**
      * Key to the test is to use an entity the name of which contains > 1 camel case part.
+     *
+     * This test is for issue #372
      */
     @Test
-    public void test() {
+    public void camelCaseImplicitNameDoesNotCauseNamingConflict() {
         CriteriaBuilder<PrimitiveDocument> crit = cbf.create(em, PrimitiveDocument.class)
                 .whereNotExists().from(PrimitiveDocument.class)
                     .select("1")

--- a/core/testsuite/src/test/java/com/blazebit/persistence/testsuite/RawTypesTest.java
+++ b/core/testsuite/src/test/java/com/blazebit/persistence/testsuite/RawTypesTest.java
@@ -23,11 +23,12 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 /**
+ * This test is for issue #344
  *
  * @author Christian Beikov
  * @since 1.2.0
  */
-public class Issue344RawTypesTest extends AbstractCoreTest {
+public class RawTypesTest extends AbstractCoreTest {
 
     @Override
     protected Class<?>[] getEntityClasses() {
@@ -39,7 +40,7 @@ public class Issue344RawTypesTest extends AbstractCoreTest {
     // NOTE: Datanucleus does not support the MapKeyClass yet: https://github.com/datanucleus/datanucleus-core/issues/185
     @Test
     @Category({ NoDatanucleus.class })
-    public void testBuild() {
+    public void buildingQueryWithEntityThatUsesRawTypesWorks() {
         CriteriaBuilder<RawTypeEntity> criteria = cbf.create(em, RawTypeEntity.class, "d");
         criteria.select("d.list.id");
         criteria.select("d.set.id");

--- a/core/testsuite/src/test/java/com/blazebit/persistence/testsuite/TablePerClassTest.java
+++ b/core/testsuite/src/test/java/com/blazebit/persistence/testsuite/TablePerClassTest.java
@@ -29,10 +29,12 @@ import javax.persistence.EntityManager;
 import java.util.List;
 
 /**
+ * This test is for issue #336
+ *
  * @author Christian beikov
  * @since 1.2.0
  */
-public class Issue336Test extends AbstractCoreTest {
+public class TablePerClassTest extends AbstractCoreTest {
 
     @Override
     protected Class<?>[] getEntityClasses() {
@@ -58,7 +60,7 @@ public class Issue336Test extends AbstractCoreTest {
     }
 
     @Test
-    public void testBuild() throws Exception {
+    public void buildingEntityMetamodelForTablePerClassEntitiesWorks() throws Exception {
         CriteriaBuilder<TablePerClassBase> cb = cbf.create(em, TablePerClassBase.class);
 
         List<TablePerClassBase> result = cb.getResultList();

--- a/core/testsuite/src/test/java/com/blazebit/persistence/testsuite/ValuesClauseTest.java
+++ b/core/testsuite/src/test/java/com/blazebit/persistence/testsuite/ValuesClauseTest.java
@@ -44,7 +44,7 @@ import static org.junit.Assert.assertNull;
  * @author Christian Beikov
  * @since 1.2.0
  */
-public class EntityFunctionTest extends AbstractCoreTest {
+public class ValuesClauseTest extends AbstractCoreTest {
 
     private Document d1;
     private Person p1;


### PR DESCRIPTION
Fixes the wrong usage of non-expanded query strings for the query cache key. Also did some renamings.

Note: This needs an announcement in the changelog. I'll merge it when you give your ok.