### PR TITLE
Fixed #357 - Added support for a 'this' expression in entity views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Not yet released
 * Support fetches for entity mappings in entity views
 * Automatic rewrites of id expressions in equality predicates to avoid joins
 * Various performance improvements
+* Support referring to `this` in all mapping types for putting values in embedded objects
 
 ### Bug fixes
 

--- a/core/parser/src/main/antlr4/imports/JPQL_lexer.g4
+++ b/core/parser/src/main/antlr4/imports/JPQL_lexer.g4
@@ -147,7 +147,7 @@ Date_literal : '{' 'd' (' ' | '\t')+ '\'' Date_string '\'' (' ' | '\t')* '}';
 
 Time_literal : '{' 't' (' ' | '\t')+ '\'' Time_string '\'' (' ' | '\t')* '}';
 
-Timestamp_literal : '{' 'ts' (' ' | '\t')+ '\'' Date_string ' ' Time_string Nanos_string '\'' (' ' | '\t')* '}';
+Timestamp_literal : '{' 'ts' (' ' | '\t')+ '\'' Date_string ' ' Time_string ('.' DIGIT*)? '\'' (' ' | '\t')* '}';
      
 Boolean_literal
      : [Tt][Rr][Uu][Ee]
@@ -211,8 +211,6 @@ fragment Date_string : DIGIT DIGIT DIGIT DIGIT '-' DIGIT DIGIT '-' DIGIT DIGIT;
 
 fragment Time_string : DIGIT DIGIT? ':' DIGIT DIGIT ':' DIGIT DIGIT;
 
-fragment Nanos_string : ('.' DIGIT*)?;
- 
 fragment DIGIT: '0'..'9';
 fragment DIGIT_NOT_ZERO: '1'..'9';
 fragment ZERO: '0';

--- a/core/parser/src/main/java/com/blazebit/persistence/impl/PrefixingAndAliasReplacementQueryGenerator.java
+++ b/core/parser/src/main/java/com/blazebit/persistence/impl/PrefixingAndAliasReplacementQueryGenerator.java
@@ -33,16 +33,14 @@ public class PrefixingAndAliasReplacementQueryGenerator extends SimpleQueryGener
     private final String substitute;
     private final String alias;
     private final String aliasToSkip;
+    private final boolean skipPrefix;
 
-    public PrefixingAndAliasReplacementQueryGenerator(String prefix, String substitute, String alias) {
-        this(prefix, substitute, alias, null);
-    }
-
-    public PrefixingAndAliasReplacementQueryGenerator(String prefix, String substitute, String alias, String aliasToSkip) {
+    public PrefixingAndAliasReplacementQueryGenerator(String prefix, String substitute, String alias, String aliasToSkip, boolean skipPrefix) {
         this.prefix = prefix;
         this.substitute = substitute;
         this.alias = alias;
         this.aliasToSkip = aliasToSkip;
+        this.skipPrefix = skipPrefix;
     }
 
     @Override
@@ -53,8 +51,13 @@ public class PrefixingAndAliasReplacementQueryGenerator extends SimpleQueryGener
         if (size == 1) {
             PathElementExpression elementExpression = expressions.get(0);
             if (elementExpression instanceof PropertyExpression) {
-                if (alias.equals(((PropertyExpression) elementExpression).getProperty())) {
+                String property = ((PropertyExpression) elementExpression).getProperty();
+                if (alias.equals(property)) {
                     sb.append(substitute);
+                    return;
+                }
+                if (skipPrefix && prefix.equals(property)) {
+                    super.visit(expression);
                     return;
                 }
             }
@@ -68,6 +71,7 @@ public class PrefixingAndAliasReplacementQueryGenerator extends SimpleQueryGener
             }
         }
         sb.append(prefix);
+        sb.append('.');
         super.visit(expression);
     }
 

--- a/core/parser/src/main/java/com/blazebit/persistence/impl/expression/ExpressionModifierCollectingResultVisitorAdapter.java
+++ b/core/parser/src/main/java/com/blazebit/persistence/impl/expression/ExpressionModifierCollectingResultVisitorAdapter.java
@@ -62,6 +62,10 @@ import com.blazebit.persistence.impl.predicate.UnaryExpressionPredicate;
 import java.util.List;
 
 /**
+ * This is a visitor that can be used to collect expression modifier references into an expression.
+ * When a visit method returns {@linkplain Boolean#TRUE}, an expression modifier for the expression is generated
+ * and the {@link #onModifier(ExpressionModifier)} method is called. The modifier is bound to the embedding expression
+ * i.e. the parent expression and can be used for reading or replacing the expression.
  *
  * @author Moritz Becker
  * @author Christian Beikov

--- a/core/parser/src/main/java/com/blazebit/persistence/impl/expression/InplaceModificationResultVisitorAdapter.java
+++ b/core/parser/src/main/java/com/blazebit/persistence/impl/expression/InplaceModificationResultVisitorAdapter.java
@@ -36,6 +36,9 @@ import com.blazebit.persistence.impl.predicate.Predicate;
 import java.util.List;
 
 /**
+ * This is a visitor that can be used to do inplace changes to an expression.
+ * This is quite similar to {@link ExpressionModifierCollectingResultVisitorAdapter},
+ * but more targeted for multiple possibly nested replacements.
  *
  * @author Moritz Becker
  * @author Christian Beikov

--- a/documentation/src/main/asciidoc/entity-view/manual/en_US/04_mappings.adoc
+++ b/documentation/src/main/asciidoc/entity-view/manual/en_US/04_mappings.adoc
@@ -873,6 +873,56 @@ There is also the possibility to specify a <<anchor-fetch-strategies,_fetch stra
 {projectname} entity views generally supports the full set of link:{core_doc}#expressions[expressions] that JPQL and {projectname} core module supports,
 but in addition to that, also offers some expression extensions.
 
+==== THIS
+
+Similar to the `this` expression in Java, in a mapping expression within entity views the `this` expression can be used to refer to the entity type backing the entity view.
+The expression can be used to implement embedded objects that are able to refer to the entity type of the entity view.
+
+[source,java]
+----
+@EntityView(Cat.class)
+interface EmbeddedCatView {
+
+    @IdMapping("id")
+    Long getId();
+
+    String getName();
+}
+
+@EmbeddableEntityView(Cat.class)
+interface ExternalInterfaceView {
+
+    @Mapping("name")
+    String getExternalName();
+}
+
+@EntityView(Cat.class)
+interface CatView {
+
+    @IdMapping("id")
+    Long getId();
+
+    @Mapping("this")
+    EmbeddedCatView getEmbedded();
+
+    @Mapping("this")
+    ExternalInterfaceView getAdapter();
+}
+----
+
+Bothe `EmbeddedCatView` and `ExternalInterfaceView` refer to the same `Cat` as their parent `CatView`.
+The query looks as if the types were directly embedded into the entity view.
+
+[source,sql]
+----
+SELECT
+    cat.id,
+    cat.id,
+    cat.name,
+    cat.name
+FROM Cat cat
+----
+
 ==== OUTER
 
 In {projectname} core the `OUTER` function can be used to refer to the query root of a parent query from within a subquery.
@@ -1008,9 +1058,6 @@ TIP: Make sure you understand the <<anchor-select-fetch-strategy-view-root,impli
 
 // ==== QUERY_ROOT
 // TODO: add a macro for referencing the query root
-
-// ==== THIS
-// TODO: add a macro for referencing "this"
 
 [[anchor-constructor-mapping]]
 === Entity View constructor mapping

--- a/entity-view/impl/pom.xml
+++ b/entity-view/impl/pom.xml
@@ -66,6 +66,12 @@
             <artifactId>javaee-api</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     
     <build>

--- a/entity-view/impl/src/main/java/com/blazebit/persistence/view/impl/metamodel/AbstractAttribute.java
+++ b/entity-view/impl/src/main/java/com/blazebit/persistence/view/impl/metamodel/AbstractAttribute.java
@@ -20,6 +20,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.*;
+import java.util.regex.Pattern;
 
 import javax.persistence.metamodel.ManagedType;
 
@@ -53,6 +54,9 @@ import com.blazebit.reflection.ReflectionUtils;
 public abstract class AbstractAttribute<X, Y> implements Attribute<X, Y> {
 
     private static final String[] EMPTY = new String[0];
+    private static final String THIS = "this";
+    private static final Pattern PLAIN_THIS_REPLACE_PATTERN = Pattern.compile("([^a-zA-Z0-9\\.])this[^\\.\\(\\[]");
+    private static final Pattern PREFIX_THIS_REPLACE_PATTERN = Pattern.compile("([^a-zA-Z0-9\\.])this\\.");
 
     protected final ManagedViewType<X> declaringType;
     protected final Class<Y> javaType;
@@ -192,6 +196,9 @@ public abstract class AbstractAttribute<X, Y> implements Attribute<X, Y> {
             if (correlationProvider.getEnclosingClass() != null && !Modifier.isStatic(correlationProvider.getModifiers())) {
                 context.addError("The correlation provider is defined as non-static inner class. Make it static, otherwise it can't be instantiated: " + errorLocation);
             }
+            if (mappingCorrelated.correlationBasis().isEmpty()) {
+                context.addError("Illegal empty correlation basis in the " + getLocation());
+            }
         } else if (mapping instanceof MappingCorrelatedSimple) {
             MappingCorrelatedSimple mappingCorrelated = (MappingCorrelatedSimple) mapping;
             this.mapping = null;
@@ -215,6 +222,10 @@ public abstract class AbstractAttribute<X, Y> implements Attribute<X, Y> {
             this.correlated = mappingCorrelated.correlated();
             this.correlationKeyAlias = mappingCorrelated.correlationKeyAlias();
             this.correlationExpression = mappingCorrelated.correlationExpression();
+
+            if (mappingCorrelated.correlationBasis().isEmpty()) {
+                context.addError("Illegal empty correlation basis in the " + getLocation());
+            }
         } else {
             context.addError("No mapping annotation could be found " + errorLocation);
             this.mapping = null;
@@ -234,7 +245,52 @@ public abstract class AbstractAttribute<X, Y> implements Attribute<X, Y> {
             this.correlationExpression = null;
         }
     }
-    
+
+    public static String stripThisFromMapping(String mapping) {
+        return replaceThisFromMapping(mapping, "");
+    }
+
+    public static String replaceThisFromMapping(String mapping, String root) {
+        if (mapping == null) {
+            return null;
+        }
+        mapping = mapping.trim();
+        if (mapping.startsWith(THIS)) {
+            // Special case when the mapping start with "this"
+            if (mapping.length() == THIS.length()) {
+                // Return the empty string if it essentially equals "this"
+                return root;
+            }
+            if (root.isEmpty()) {
+                char nextChar = mapping.charAt(THIS.length());
+                if (nextChar == '.') {
+                    // Only replace if it isn't a prefix
+                    mapping = mapping.substring(THIS.length() + 1);
+                }
+            } else {
+                mapping = root + mapping.substring(THIS.length());
+            }
+        }
+
+        String replacement;
+        if (root.isEmpty()) {
+            replacement = "$1";
+        } else {
+            replacement = "$1" + root + ".";
+        }
+        mapping = PREFIX_THIS_REPLACE_PATTERN.matcher(mapping)
+                .replaceAll(replacement);
+
+        return mapping;
+    }
+
+    /**
+     * Collects all mappings that involve the use of a collection attribute for duplicate usage checks.
+     *
+     * @param managedType The JPA type against which to evaluate the mapping
+     * @param context The metamodel context
+     * @return The mappings which contain collection attribute uses
+     */
     public Set<String> getCollectionJoinMappings(ManagedType<?> managedType, MetamodelBuildingContext context) {
         if (mapping == null || queryParameter) {
             // Subqueries and parameters can't be checked
@@ -242,7 +298,12 @@ public abstract class AbstractAttribute<X, Y> implements Attribute<X, Y> {
         }
         
         CollectionJoinMappingGathererExpressionVisitor visitor = new CollectionJoinMappingGathererExpressionVisitor(managedType, context.getEntityMetamodel());
-        context.getExpressionFactory().createSimpleExpression(mapping, false).accept(visitor);
+        String expression = stripThisFromMapping(mapping);
+        if (expression.isEmpty()) {
+            return Collections.emptySet();
+        }
+
+        context.getExpressionFactory().createSimpleExpression(expression, false).accept(visitor);
         Set<String> mappings = new HashSet<String>();
         
         for (String s : visitor.getPaths()) {
@@ -253,7 +314,6 @@ public abstract class AbstractAttribute<X, Y> implements Attribute<X, Y> {
     }
 
     public void checkAttributeCorrelationUsage(Map<Class<?>, ManagedViewTypeImpl<?>> managedViews, Set<ManagedViewType<?>> seenViewTypes, Set<MappingConstructor<?>> seenConstructors, MetamodelBuildingContext context) {
-
         if (isSubview()) {
             ManagedViewTypeImpl<?> subviewType;
             if (isCollection()) {
@@ -495,18 +555,15 @@ public abstract class AbstractAttribute<X, Y> implements Attribute<X, Y> {
         }
 
         if (isCorrelated()) {
-            if (correlationBasis.isEmpty()) {
-                context.addError("Illegal empty correlation basis in the " + getLocation());
-            }
             if (isUpdatable()) {
                 context.addError("Illegal updatable correlated attribute " + getLocation());
             }
             // Validate that resolving "correlationBasis" on "managedType" is valid
-            validateTypesCompatible(managedType, correlationBasis, Object.class, null, true, context, ExpressionLocation.CORRELATION_BASIS, getLocation());
+            validateTypesCompatible(managedType, stripThisFromMapping(correlationBasis), Object.class, null, true, context, ExpressionLocation.CORRELATION_BASIS, getLocation());
 
             if (correlated != null) {
                 // Validate that resolving "correlationResult" on "correlated" is compatible with "expressionType" and "elementType"
-                validateTypesCompatible(context.getEntityMetamodel().managedType(correlated), correlationResult, expressionType, elementType, true, context, ExpressionLocation.CORRELATION_RESULT, getLocation());
+                validateTypesCompatible(context.getEntityMetamodel().managedType(correlated), stripThisFromMapping(correlationResult), expressionType, elementType, true, context, ExpressionLocation.CORRELATION_RESULT, getLocation());
 
                 // TODO: Validate the "correlationExpression" when https://github.com/Blazebit/blaze-persistence/issues/212 is implemented
                 try {
@@ -529,12 +586,18 @@ public abstract class AbstractAttribute<X, Y> implements Attribute<X, Y> {
                 elementType = typeArguments[typeArguments.length - 1];
             }
 
+            String mapping = stripThisFromMapping(this.mapping);
             // Validate that resolving "mapping" on "managedType" is compatible with "expressionType" and "elementType"
             validateTypesCompatible(managedType, mapping, expressionType, elementType, subtypesAllowed, context, ExpressionLocation.MAPPING, getLocation());
 
             if (isUpdatable()) {
                 UpdatableExpressionVisitor visitor = new UpdatableExpressionVisitor(managedType.getJavaType());
                 try {
+                    // NOTE: Not supporting "this" here because it doesn't make sense to have an updatable mapping that refers to this
+                    // The only thing that might be interesting is supporting "this" when we support cascading as properties could be nested
+                    // But not sure yet if the embeddable attributes would then be modeled as "updatable".
+                    // I guess these attributes are not "updatable" but that probably depends on the decision regarding collections as they have a similar problem
+                    // A collection itself might not be "updatable" but it's elements could be. This is roughly the same problem
                     context.getExpressionFactory().createPathExpression(mapping).accept(visitor);
                     Map<Method, Class<?>[]> possibleTargets = visitor.getPossibleTargets();
 

--- a/entity-view/impl/src/main/java/com/blazebit/persistence/view/impl/metamodel/EmbeddableViewTypeImpl.java
+++ b/entity-view/impl/src/main/java/com/blazebit/persistence/view/impl/metamodel/EmbeddableViewTypeImpl.java
@@ -20,8 +20,6 @@ import com.blazebit.annotation.AnnotationUtils;
 import com.blazebit.persistence.view.EmbeddableEntityView;
 import com.blazebit.persistence.view.metamodel.EmbeddableViewType;
 
-import javax.persistence.metamodel.EmbeddableType;
-
 /**
  *
  * @author Christian Beikov
@@ -44,10 +42,11 @@ public class EmbeddableViewTypeImpl<X> extends ManagedViewTypeImpl<X> implements
 
         Class<?> entityClass = entityViewAnnot.value();
 
-        if (!(context.getEntityMetamodel().getManagedType(entityClass) instanceof EmbeddableType<?>)) {
-            context.addError("The class which is referenced by the EmbeddableEntityView annotation of the class '" + clazz.getName() + "' is not an embeddable!");
-            return null;
-        }
+        // This class will be removed as part of #356 and #376 so for now we will comment this out
+//        if (!(context.getEntityMetamodel().getManagedType(entityClass) instanceof EmbeddableType<?>)) {
+//            context.addError("The class which is referenced by the EmbeddableEntityView annotation of the class '" + clazz.getName() + "' is not an embeddable!");
+//            return null;
+//        }
         
         return entityClass;
     }

--- a/entity-view/impl/src/main/java/com/blazebit/persistence/view/impl/metamodel/MetamodelUtils.java
+++ b/entity-view/impl/src/main/java/com/blazebit/persistence/view/impl/metamodel/MetamodelUtils.java
@@ -36,11 +36,6 @@ import com.blazebit.annotation.AnnotationUtils;
 import com.blazebit.persistence.impl.EntityMetamodel;
 import com.blazebit.persistence.impl.expression.ExpressionFactory;
 import com.blazebit.persistence.view.CollectionMapping;
-import com.blazebit.persistence.view.IdMapping;
-import com.blazebit.persistence.view.Mapping;
-import com.blazebit.persistence.view.MappingCorrelated;
-import com.blazebit.persistence.view.MappingParameter;
-import com.blazebit.persistence.view.MappingSubquery;
 import com.blazebit.persistence.impl.PathTargetResolvingExpressionVisitor;
 import com.blazebit.persistence.view.metamodel.MappingConstructor;
 import com.blazebit.reflection.ReflectionUtils;
@@ -113,19 +108,9 @@ public final class MetamodelUtils {
         }
     }
 
-    public static boolean isIndexedList(EntityMetamodel metamodel, ExpressionFactory expressionFactory, Class<?> entityClass, Annotation mappingAnnotation) {
-        if (mappingAnnotation instanceof MappingSubquery || mappingAnnotation instanceof MappingParameter || mappingAnnotation instanceof MappingCorrelated) {
+    public static boolean isIndexedList(EntityMetamodel metamodel, ExpressionFactory expressionFactory, Class<?> entityClass, String mapping) {
+        if (mapping == null || mapping.isEmpty()) {
             return false;
-        }
-        
-        String mapping;
-        
-        if (mappingAnnotation instanceof IdMapping) {
-            mapping = ((IdMapping) mappingAnnotation).value();
-        } else if (mappingAnnotation instanceof Mapping) {
-            mapping = ((Mapping) mappingAnnotation).value();
-        } else {
-            throw new IllegalArgumentException("Unkown mapping encountered: " + mappingAnnotation);
         }
 
         PathTargetResolvingExpressionVisitor visitor = new PathTargetResolvingExpressionVisitor(metamodel, entityClass, null);

--- a/entity-view/impl/src/main/java/com/blazebit/persistence/view/impl/metamodel/attribute/AbstractMethodListAttribute.java
+++ b/entity-view/impl/src/main/java/com/blazebit/persistence/view/impl/metamodel/attribute/AbstractMethodListAttribute.java
@@ -41,7 +41,7 @@ public abstract class AbstractMethodListAttribute<X, Y> extends AbstractMethodPl
         if (isIgnoreIndex()) {
             this.isIndexed = false;
         } else {
-            this.isIndexed = MetamodelUtils.isIndexedList(context.getEntityMetamodel(), context.getExpressionFactory(), viewType.getEntityClass(), mapping);
+            this.isIndexed = MetamodelUtils.isIndexedList(context.getEntityMetamodel(), context.getExpressionFactory(), viewType.getEntityClass(), stripThisFromMapping(getMapping()));
         }
     }
 

--- a/entity-view/impl/src/main/java/com/blazebit/persistence/view/impl/metamodel/attribute/AbstractParameterListAttribute.java
+++ b/entity-view/impl/src/main/java/com/blazebit/persistence/view/impl/metamodel/attribute/AbstractParameterListAttribute.java
@@ -40,7 +40,7 @@ public abstract class AbstractParameterListAttribute<X, Y> extends AbstractParam
         if (isIgnoreIndex()) {
             this.isIndexed = false;
         } else {
-            this.isIndexed = MetamodelUtils.isIndexedList(context.getEntityMetamodel(), context.getExpressionFactory(), mappingConstructor.getDeclaringType().getEntityClass(), mapping);
+            this.isIndexed = MetamodelUtils.isIndexedList(context.getEntityMetamodel(), context.getExpressionFactory(), mappingConstructor.getDeclaringType().getEntityClass(), stripThisFromMapping(getMapping()));
         }
     }
 

--- a/entity-view/impl/src/main/java/com/blazebit/persistence/view/impl/objectbuilder/ViewTypeObjectBuilderTemplate.java
+++ b/entity-view/impl/src/main/java/com/blazebit/persistence/view/impl/objectbuilder/ViewTypeObjectBuilderTemplate.java
@@ -32,6 +32,7 @@ import com.blazebit.persistence.impl.PathTargetResolvingExpressionVisitor;
 import com.blazebit.persistence.view.impl.PrefixingQueryGenerator;
 import com.blazebit.persistence.view.impl.SubqueryProviderFactory;
 import com.blazebit.persistence.view.impl.SubqueryProviderHelper;
+import com.blazebit.persistence.view.impl.metamodel.AbstractAttribute;
 import com.blazebit.persistence.view.impl.objectbuilder.mapper.AliasExpressionSubqueryTupleElementMapper;
 import com.blazebit.persistence.view.impl.objectbuilder.mapper.AliasExpressionTupleElementMapper;
 import com.blazebit.persistence.view.impl.objectbuilder.mapper.AliasSubqueryTupleElementMapper;
@@ -191,7 +192,7 @@ public class ViewTypeObjectBuilderTemplate<T> {
             }
             
             if (idAttributeType == null) {
-                throw new IllegalArgumentException("The id attribute type is not resolvable " + "for the attribute '" + jpaIdAttr.getName() + "' of the class '" + managedViewType.getEntityClass().getName() + "'!");
+                throw new IllegalArgumentException("The id attribute type is not resolvable for the attribute '" + jpaIdAttr.getName() + "' of the class '" + managedViewType.getEntityClass().getName() + "'!");
             }
         }
         
@@ -219,7 +220,7 @@ public class ViewTypeObjectBuilderTemplate<T> {
             MethodAttribute<?, ?> idAttribute = viewType.getIdAttribute();
             MappingAttribute<?, ?> idMappingAttribute = (MappingAttribute<?, ?>) idAttribute;
 
-            if (!idAttributeName.equals(idMappingAttribute.getMapping())) {
+            if (!idAttributeName.equals(AbstractAttribute.stripThisFromMapping(idMappingAttribute.getMapping()))) {
                 throw new IllegalArgumentException("Invalid id mapping '" + idMappingAttribute.getMapping() + "' for entity view '" + viewType.getJavaType().getName() + "'! Expected '" + idAttributeName + "'!");
             }
 
@@ -538,7 +539,7 @@ public class ViewTypeObjectBuilderTemplate<T> {
             @SuppressWarnings("unchecked")
             ManagedViewType<Object[]> managedViewType = (ManagedViewType<Object[]>) evm.getMetamodel().managedView(subviewClass);
             String subviewAliasPrefix = getAlias(aliasPrefix, correlatedAttribute, false);
-            String correlationBasis = getMapping(mappingPrefix, correlatedAttribute.getCorrelationBasis());
+            String correlationBasis = getMapping(mappingPrefix, AbstractAttribute.stripThisFromMapping(correlatedAttribute.getCorrelationBasis()));
             String subviewIdPrefix;
             if (correlationResult.isEmpty()) {
                 subviewIdPrefix = CorrelationProviderHelper.getDefaultCorrelationAlias(attributePath);
@@ -571,10 +572,10 @@ public class ViewTypeObjectBuilderTemplate<T> {
         } else if (correlatedAttribute.getFetchStrategy() == FetchStrategy.SELECT) {
             String subviewAliasPrefix = getAlias(aliasPrefix, correlatedAttribute, false);
             int startIndex = tupleOffset + mappingList.size();
-            Class<?> correlationBasisType = getCorrelationBasisType(correlatedAttribute.getCorrelationBasis());
-            Class<?> correlationBasisEntity = getCorrelationBasisEntityType(correlatedAttribute.getCorrelationBasis(), correlationBasisType);
+            Class<?> correlationBasisType = getCorrelationBasisType(AbstractAttribute.stripThisFromMapping(correlatedAttribute.getCorrelationBasis()));
+            Class<?> correlationBasisEntity = getCorrelationBasisEntityType(AbstractAttribute.stripThisFromMapping(correlatedAttribute.getCorrelationBasis()), correlationBasisType);
 
-            mappingList.add(createMapper(getMapping(mappingPrefix, correlatedAttribute.getCorrelationBasis(), correlationBasisEntity), subviewAliasPrefix, correlatedAttribute.getFetches()));
+            mappingList.add(createMapper(getMapping(mappingPrefix, AbstractAttribute.stripThisFromMapping(correlatedAttribute.getCorrelationBasis()), correlationBasisEntity), subviewAliasPrefix, correlatedAttribute.getFetches()));
             parameterMappingList.add(null);
 
             @SuppressWarnings("unchecked")
@@ -639,9 +640,9 @@ public class ViewTypeObjectBuilderTemplate<T> {
         } else if (correlatedAttribute.getFetchStrategy() == FetchStrategy.SUBSELECT) {
             String subviewAliasPrefix = getAlias(aliasPrefix, correlatedAttribute, false);
             int startIndex = tupleOffset + mappingList.size();
-            Class<?> correlationBasisType = getCorrelationBasisType(correlatedAttribute.getCorrelationBasis());
-            Class<?> correlationBasisEntity = getCorrelationBasisEntityType(correlatedAttribute.getCorrelationBasis(), correlationBasisType);
-            String correlationKeyExpression = getMapping(mappingPrefix, correlatedAttribute.getCorrelationBasis());
+            Class<?> correlationBasisType = getCorrelationBasisType(AbstractAttribute.stripThisFromMapping(correlatedAttribute.getCorrelationBasis()));
+            Class<?> correlationBasisEntity = getCorrelationBasisEntityType(AbstractAttribute.stripThisFromMapping(correlatedAttribute.getCorrelationBasis()), correlationBasisType);
+            String correlationKeyExpression = getMapping(mappingPrefix, AbstractAttribute.stripThisFromMapping(correlatedAttribute.getCorrelationBasis()));
 
             mappingList.add(createMapper(correlationKeyExpression, subviewAliasPrefix, correlatedAttribute.getFetches()));
             parameterMappingList.add(null);
@@ -763,7 +764,7 @@ public class ViewTypeObjectBuilderTemplate<T> {
             @SuppressWarnings("unchecked")
             CorrelationProviderFactory factory = CorrelationProviderHelper.getFactory(correlatedAttribute.getCorrelationProvider());
             String alias = getAlias(aliasPrefix, correlatedAttribute, false);
-            String correlationBasis = getMapping(mappingPrefix, correlatedAttribute.getCorrelationBasis());
+            String correlationBasis = getMapping(mappingPrefix, AbstractAttribute.stripThisFromMapping(correlatedAttribute.getCorrelationBasis()));
 
             TupleElementMapper mapper;
             if (factory.isParameterized()) {
@@ -776,9 +777,9 @@ public class ViewTypeObjectBuilderTemplate<T> {
         } else if (correlatedAttribute.getFetchStrategy() == FetchStrategy.SELECT) {
             String subviewAliasPrefix = getAlias(aliasPrefix, correlatedAttribute, false);
             int startIndex = tupleOffset + mappingList.size();
-            Class<?> correlationBasisType = getCorrelationBasisType(correlatedAttribute.getCorrelationBasis());
-            Class<?> correlationBasisEntity = getCorrelationBasisEntityType(correlatedAttribute.getCorrelationBasis(), correlationBasisType);
-            String correlationKeyExpression = getMapping(mappingPrefix, correlatedAttribute.getCorrelationBasis(), correlationBasisEntity);
+            Class<?> correlationBasisType = getCorrelationBasisType(AbstractAttribute.stripThisFromMapping(correlatedAttribute.getCorrelationBasis()));
+            Class<?> correlationBasisEntity = getCorrelationBasisEntityType(AbstractAttribute.stripThisFromMapping(correlatedAttribute.getCorrelationBasis()), correlationBasisType);
+            String correlationKeyExpression = getMapping(mappingPrefix, AbstractAttribute.stripThisFromMapping(correlatedAttribute.getCorrelationBasis()), correlationBasisEntity);
 
             mappingList.add(createMapper(correlationKeyExpression, subviewAliasPrefix, correlatedAttribute.getFetches()));
             parameterMappingList.add(null);
@@ -849,9 +850,9 @@ public class ViewTypeObjectBuilderTemplate<T> {
         } else if (correlatedAttribute.getFetchStrategy() == FetchStrategy.SUBSELECT) {
             String subviewAliasPrefix = getAlias(aliasPrefix, correlatedAttribute, false);
             int startIndex = tupleOffset + mappingList.size();
-            Class<?> correlationBasisType = getCorrelationBasisType(correlatedAttribute.getCorrelationBasis());
-            Class<?> correlationBasisEntity = getCorrelationBasisEntityType(correlatedAttribute.getCorrelationBasis(), correlationBasisType);
-            String correlationKeyExpression = getMapping(mappingPrefix, correlatedAttribute.getCorrelationBasis());
+            Class<?> correlationBasisType = getCorrelationBasisType(AbstractAttribute.stripThisFromMapping(correlatedAttribute.getCorrelationBasis()));
+            Class<?> correlationBasisEntity = getCorrelationBasisEntityType(AbstractAttribute.stripThisFromMapping(correlatedAttribute.getCorrelationBasis()), correlationBasisType);
+            String correlationKeyExpression = getMapping(mappingPrefix, AbstractAttribute.stripThisFromMapping(correlatedAttribute.getCorrelationBasis()));
 
             mappingList.add(createMapper(correlationKeyExpression, subviewAliasPrefix, correlatedAttribute.getFetches()));
             parameterMappingList.add(null);
@@ -920,7 +921,14 @@ public class ViewTypeObjectBuilderTemplate<T> {
 
     private List<String> createSubviewMappingPrefix(List<String> prefixParts, String mapping) {
         if (prefixParts == null || prefixParts.isEmpty()) {
+            if (mapping.isEmpty()) {
+                return Collections.emptyList();
+            }
             return Collections.singletonList(mapping);
+        }
+
+        if (mapping.isEmpty()) {
+            return new ArrayList<>(prefixParts);
         }
 
         List<String> subviewMappingPrefix = new ArrayList<String>(prefixParts.size() + 1);
@@ -930,7 +938,7 @@ public class ViewTypeObjectBuilderTemplate<T> {
     }
 
     private List<String> createSubviewMappingPrefix(List<String> prefixParts, MappingAttribute<?, ?> mappingAttribute, boolean isKey) {
-        List<String> prefix = createSubviewMappingPrefix(prefixParts, mappingAttribute.getMapping());
+        List<String> prefix = createSubviewMappingPrefix(prefixParts, AbstractAttribute.stripThisFromMapping(mappingAttribute.getMapping()));
         if (isKey) {
             List<String> subviewMappingPrefix = new ArrayList<String>();
             StringBuilder sb = new StringBuilder();
@@ -944,6 +952,9 @@ public class ViewTypeObjectBuilderTemplate<T> {
     }
 
     private Class<?> getCorrelationBasisType(String correlationBasis) {
+        if (correlationBasis.isEmpty()) {
+            return managedTypeClass;
+        }
         EntityMetamodel entityMetamodel = evm.getMetamodel().getEntityMetamodel();
         PathTargetResolvingExpressionVisitor visitor = new PathTargetResolvingExpressionVisitor(entityMetamodel, managedTypeClass, null);
         ef.createPathExpression(correlationBasis).accept(visitor);
@@ -986,10 +997,31 @@ public class ViewTypeObjectBuilderTemplate<T> {
 
         IdentifiableType<?> identifiableType = (IdentifiableType<?>) managedType;
         javax.persistence.metamodel.SingularAttribute<?, ?> idAttr = identifiableType.getId(identifiableType.getIdType().getJavaType());
-        return getMapping(prefixParts, mapping + '.' + idAttr.getName());
+        if (mapping.isEmpty()) {
+            return getMapping(prefixParts, idAttr.getName());
+        } else {
+            return getMapping(prefixParts, mapping + '.' + idAttr.getName());
+        }
     }
 
     private String getMapping(List<String> prefixParts, String mapping) {
+        if (mapping.isEmpty()) {
+            if (prefixParts != null && prefixParts.size() > 0) {
+                StringBuilder sb = new StringBuilder();
+                for (int i = 0; i < prefixParts.size(); i++) {
+                    String s = AbstractAttribute.stripThisFromMapping(prefixParts.get(i));
+                    if (!s.isEmpty()) {
+                        sb.append(s);
+                        sb.append('.');
+                    }
+                }
+                if (sb.length() != 0) {
+                    return sb.substring(0, sb.length() - 1);
+                }
+            }
+
+            return "";
+        }
         if (prefixParts != null && prefixParts.size() > 0) {
             Expression expr = ef.createSimpleExpression(mapping, false);
             SimpleQueryGenerator generator = new PrefixingQueryGenerator(prefixParts);
@@ -1003,7 +1035,7 @@ public class ViewTypeObjectBuilderTemplate<T> {
     }
 
     private String getMapping(List<String> prefixParts, MappingAttribute<?, ?> mappingAttribute) {
-        return getMapping(prefixParts, mappingAttribute.getMapping());
+        return getMapping(prefixParts, AbstractAttribute.stripThisFromMapping(mappingAttribute.getMapping()));
     }
 
     private String getMapping(String prefix, String mapping) {
@@ -1015,7 +1047,7 @@ public class ViewTypeObjectBuilderTemplate<T> {
     }
 
     private String getMapping(String prefix, MappingAttribute<?, ?> mappingAttribute, boolean isKey) {
-        String mapping = getMapping(prefix, mappingAttribute.getMapping());
+        String mapping = getMapping(prefix, AbstractAttribute.stripThisFromMapping(mappingAttribute.getMapping()));
         if (isKey) {
             return "KEY(" + mapping + ")";
         }

--- a/entity-view/impl/src/test/java/com/blazebit/persistence/view/impl/metamodel/AbstractAttributeTest.java
+++ b/entity-view/impl/src/test/java/com/blazebit/persistence/view/impl/metamodel/AbstractAttributeTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014 - 2017 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.view.impl.metamodel;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ *
+ * @author Christian Beikov
+ * @since 1.2.0
+ */
+public class AbstractAttributeTest {
+
+    @Test
+    public void stripThisFromMappingTests() {
+        assertEquals("", AbstractAttribute.stripThisFromMapping("this"));
+        assertEquals("this[]", AbstractAttribute.stripThisFromMapping("this[]"));
+        assertEquals("this()", AbstractAttribute.stripThisFromMapping("this()"));
+        assertEquals("this", AbstractAttribute.stripThisFromMapping("this.this"));
+        assertEquals("this.this", AbstractAttribute.stripThisFromMapping("this.this.this"));
+        assertEquals("", AbstractAttribute.stripThisFromMapping(" this"));
+        assertEquals("thisa", AbstractAttribute.stripThisFromMapping("thisa"));
+
+        assertEquals("this MEMBER OF abc", AbstractAttribute.stripThisFromMapping("this MEMBER OF abc"));
+        assertEquals("CASE WHEN this = owner THEN true ELSE false END", AbstractAttribute.stripThisFromMapping("CASE WHEN this = owner THEN true ELSE false END"));
+        assertEquals("TYPE(this)", AbstractAttribute.stripThisFromMapping("TYPE(this)"));
+        assertEquals("TREAT(this AS Subtype)", AbstractAttribute.stripThisFromMapping("TREAT(this AS Subtype)"));
+    }
+
+}

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/collections/singleton/SingletonCollectionsTest.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/collections/singleton/SingletonCollectionsTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2014 - 2017 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.view.testsuite.collections.singleton;
+
+import com.blazebit.persistence.CriteriaBuilder;
+import com.blazebit.persistence.testsuite.base.category.NoDatanucleus;
+import com.blazebit.persistence.testsuite.base.category.NoEclipselink;
+import com.blazebit.persistence.testsuite.tx.TxVoidWork;
+import com.blazebit.persistence.view.EntityViewManager;
+import com.blazebit.persistence.view.EntityViewSetting;
+import com.blazebit.persistence.view.EntityViews;
+import com.blazebit.persistence.view.spi.EntityViewConfiguration;
+import com.blazebit.persistence.view.testsuite.AbstractEntityViewTest;
+import com.blazebit.persistence.view.testsuite.collections.singleton.model.SingletonDocumentCollectionsView;
+import com.blazebit.persistence.view.testsuite.collections.singleton.model.SingletonPersonView;
+import com.blazebit.persistence.view.testsuite.entity.Document;
+import com.blazebit.persistence.view.testsuite.entity.Person;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests mapping relations as singleton collections
+ *
+ * @author Christian Beikov
+ * @since 1.2.0
+ */
+public class SingletonCollectionsTest extends AbstractEntityViewTest {
+
+    protected Document doc1;
+    protected Document doc2;
+    protected Document doc3;
+    protected Document doc4;
+
+    @Override
+    public void setUpOnce() {
+        cleanDatabase();
+        transactional(new TxVoidWork() {
+            @Override
+            public void work(EntityManager em) {
+                doc1 = new Document("doc1");
+                doc2 = new Document("doc2");
+                doc3 = new Document("doc3");
+                doc4 = new Document("doc4");
+
+                Person o1 = new Person("pers1");
+                Person o2 = new Person("pers2");
+                Person o3 = new Person("pers3");
+
+                doc1.setOwner(o1);
+                doc2.setOwner(o2);
+                doc3.setOwner(o2);
+                doc4.setOwner(o2);
+
+                em.persist(o1);
+                em.persist(o2);
+                em.persist(o3);
+
+                em.persist(doc1);
+                em.persist(doc2);
+                em.persist(doc3);
+                em.persist(doc4);
+            }
+        });
+    }
+
+    @Before
+    public void setUp() {
+        doc1 = cbf.create(em, Document.class).where("name").eq("doc1").getSingleResult();
+        doc2 = cbf.create(em, Document.class).where("name").eq("doc2").getSingleResult();
+        doc3 = cbf.create(em, Document.class).where("name").eq("doc3").getSingleResult();
+        doc4 = cbf.create(em, Document.class).where("name").eq("doc4").getSingleResult();
+    }
+
+    @Test
+    public void testSingletonCollections() {
+        EntityViewConfiguration cfg = EntityViews.createDefaultConfiguration();
+        cfg.addEntityView(SingletonDocumentCollectionsView.class);
+        cfg.addEntityView(SingletonPersonView.class);
+        EntityViewManager evm = cfg.createEntityViewManager(cbf);
+
+        CriteriaBuilder<Document> criteria = cbf.create(em, Document.class, "d")
+            .orderByAsc("id");
+        CriteriaBuilder<SingletonDocumentCollectionsView> cb = evm.applySetting(EntityViewSetting.create(SingletonDocumentCollectionsView.class), criteria);
+        List<SingletonDocumentCollectionsView> results = cb.getResultList();
+
+        assertEquals(4, results.size());
+        assertThisAndOwnerMappings(doc1, results.get(0));
+        assertThisAndOwnerMappings(doc2, results.get(1));
+        assertThisAndOwnerMappings(doc3, results.get(2));
+        assertThisAndOwnerMappings(doc4, results.get(3));
+    }
+
+    private void assertThisAndOwnerMappings(Document doc, SingletonDocumentCollectionsView view) {
+        assertEquals(doc.getId(), view.getId());
+        assertEquals(doc.getName(), view.getName());
+
+        assertEquals(doc.getOwner(), view.getOwnerEntity());
+        assertEquals(doc.getOwner().getId(), view.getOwnerEntityId());
+        assertPersonEqualsView(doc.getOwner(), view.getOwnerEntityView());
+
+        assertEquals(1, view.getOwnerEntityList().size());
+        assertEquals(doc.getOwner(), view.getOwnerEntityList().get(0));
+
+        assertEquals(1, view.getOwnerEntityIdList().size());
+        assertEquals(doc.getOwner().getId(), view.getOwnerEntityIdList().get(0));
+
+        assertEquals(1, view.getOwnerEntityViewList().size());
+        assertPersonEqualsView(doc.getOwner(), view.getOwnerEntityViewList().get(0));
+    }
+
+    private void assertPersonEqualsView(Person pers, SingletonPersonView view) {
+        assertEquals(pers.getId(), view.getId());
+        assertEquals(pers.getName().toUpperCase(), view.getName());
+    }
+}

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/collections/singleton/model/SingletonDocumentCollectionsView.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/collections/singleton/model/SingletonDocumentCollectionsView.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2014 - 2017 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.view.testsuite.collections.singleton.model;
+
+import com.blazebit.persistence.view.EntityView;
+import com.blazebit.persistence.view.IdMapping;
+import com.blazebit.persistence.view.Mapping;
+import com.blazebit.persistence.view.testsuite.entity.Document;
+import com.blazebit.persistence.view.testsuite.entity.Person;
+
+import java.util.List;
+
+/**
+ *
+ * @author Christian Beikov
+ * @since 1.2.0
+ */
+@EntityView(Document.class)
+public interface SingletonDocumentCollectionsView {
+    
+    @IdMapping("id")
+    public Long getId();
+
+    public String getName();
+
+    @Mapping("owner.id")
+    public Long getOwnerEntityId();
+
+    @Mapping("owner")
+    public Person getOwnerEntity();
+
+    @Mapping("owner")
+    public SingletonPersonView getOwnerEntityView();
+
+    @Mapping("owner.id")
+    public List<Long> getOwnerEntityIdList();
+
+    @Mapping("owner")
+    public List<Person> getOwnerEntityList();
+
+    @Mapping("owner")
+    public List<SingletonPersonView> getOwnerEntityViewList();
+}

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/collections/singleton/model/SingletonPersonView.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/collections/singleton/model/SingletonPersonView.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014 - 2017 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.view.testsuite.collections.singleton.model;
+
+import com.blazebit.persistence.view.AttributeFilter;
+import com.blazebit.persistence.view.EntityView;
+import com.blazebit.persistence.view.IdMapping;
+import com.blazebit.persistence.view.Mapping;
+import com.blazebit.persistence.view.filter.ContainsFilter;
+import com.blazebit.persistence.view.testsuite.entity.Person;
+
+/**
+ *
+ * @author Christian Beikov
+ * @since 1.2.0
+ */
+@EntityView(Person.class)
+public interface SingletonPersonView {
+    
+    @IdMapping("id")
+    public Long getId();
+
+    @Mapping("UPPER(name)")
+    @AttributeFilter(ContainsFilter.class)
+    public String getName();
+}

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/AbstractCorrelationTest.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/AbstractCorrelationTest.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2014 - 2017 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.view.testsuite.correlation;
+
+import com.blazebit.persistence.CriteriaBuilder;
+import com.blazebit.persistence.testsuite.base.category.NoDatanucleus;
+import com.blazebit.persistence.testsuite.base.category.NoDatanucleus4;
+import com.blazebit.persistence.testsuite.base.category.NoEclipselink;
+import com.blazebit.persistence.testsuite.base.category.NoHibernate42;
+import com.blazebit.persistence.testsuite.base.category.NoHibernate43;
+import com.blazebit.persistence.testsuite.base.category.NoHibernate50;
+import com.blazebit.persistence.testsuite.base.category.NoOpenJPA;
+import com.blazebit.persistence.testsuite.tx.TxVoidWork;
+import com.blazebit.persistence.view.EntityViewManager;
+import com.blazebit.persistence.view.EntityViewSetting;
+import com.blazebit.persistence.view.EntityViews;
+import com.blazebit.persistence.view.impl.ConfigurationProperties;
+import com.blazebit.persistence.view.spi.EntityViewConfiguration;
+import com.blazebit.persistence.view.testsuite.AbstractEntityViewTest;
+import com.blazebit.persistence.view.testsuite.correlation.general.model.DocumentCorrelationViewJoinId;
+import com.blazebit.persistence.view.testsuite.correlation.general.model.DocumentCorrelationViewJoinNormal;
+import com.blazebit.persistence.view.testsuite.correlation.general.model.DocumentCorrelationViewSubqueryId;
+import com.blazebit.persistence.view.testsuite.correlation.general.model.DocumentCorrelationViewSubqueryNormal;
+import com.blazebit.persistence.view.testsuite.correlation.general.model.DocumentCorrelationViewSubselectId;
+import com.blazebit.persistence.view.testsuite.correlation.general.model.DocumentCorrelationViewSubselectNormal;
+import com.blazebit.persistence.view.testsuite.correlation.model.DocumentCorrelationView;
+import com.blazebit.persistence.view.testsuite.correlation.model.SimpleDocumentCorrelatedView;
+import com.blazebit.persistence.view.testsuite.correlation.model.SimplePersonCorrelatedSubView;
+import com.blazebit.persistence.view.testsuite.entity.Document;
+import com.blazebit.persistence.view.testsuite.entity.Person;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import javax.persistence.EntityManager;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ *
+ * @author Christian Beikov
+ * @since 1.2.0
+ */
+public abstract class AbstractCorrelationTest extends AbstractEntityViewTest {
+
+    protected Document doc1;
+    protected Document doc2;
+    protected Document doc3;
+    protected Document doc4;
+
+    @Override
+    public void setUpOnce() {
+        cleanDatabase();
+        transactional(new TxVoidWork() {
+            @Override
+            public void work(EntityManager em) {
+            doc1 = new Document("doc1");
+            doc2 = new Document("doc2");
+            doc3 = new Document("doc3");
+            doc4 = new Document("doc4");
+
+            Person o1 = new Person("pers1");
+            Person o2 = new Person("pers2");
+            Person o3 = new Person("pers3");
+
+            doc1.setOwner(o1);
+            doc2.setOwner(o2);
+            doc3.setOwner(o2);
+            doc4.setOwner(o2);
+
+            em.persist(o1);
+            em.persist(o2);
+            em.persist(o3);
+
+            em.persist(doc1);
+            em.persist(doc2);
+            em.persist(doc3);
+            em.persist(doc4);
+            }
+        });
+    }
+
+    @Before
+    public void setUp() {
+        doc1 = cbf.create(em, Document.class).where("name").eq("doc1").getSingleResult();
+        doc2 = cbf.create(em, Document.class).where("name").eq("doc2").getSingleResult();
+        doc3 = cbf.create(em, Document.class).where("name").eq("doc3").getSingleResult();
+        doc4 = cbf.create(em, Document.class).where("name").eq("doc4").getSingleResult();
+    }
+
+    protected <T extends DocumentCorrelationView> void testCorrelation(Class<T> entityView, Integer batchSize) {
+        EntityViewConfiguration cfg = EntityViews.createDefaultConfiguration();
+        cfg.addEntityView(entityView);
+        cfg.addEntityView(SimpleDocumentCorrelatedView.class);
+        cfg.addEntityView(SimplePersonCorrelatedSubView.class);
+        EntityViewManager evm = cfg.createEntityViewManager(cbf);
+
+        CriteriaBuilder<Document> criteria = cbf.create(em, Document.class, "d").orderByAsc("id");
+        EntityViewSetting<T, CriteriaBuilder<T>> setting = EntityViewSetting.create(entityView);
+        if (batchSize != null) {
+            setting.setProperty(ConfigurationProperties.DEFAULT_BATCH_SIZE + ".ownerRelatedDocumentIds", batchSize);
+        }
+        CriteriaBuilder<T> cb = evm.applySetting(setting, criteria);
+        List<T> results = cb.getResultList();
+
+        assertEquals(4, results.size());
+
+        // Doc1
+        assertEquals(doc1.getName(), results.get(0).getName());
+        assertThisAndOwnerMappings(doc1, results.get(0));
+
+        assertEquals(0, results.get(0).getOwnerRelatedDocumentViews().size());
+        assertEquals(0, results.get(0).getOwnerRelatedDocumentIds().size());
+
+        assertEquals(1, results.get(0).getOwnerOnlyRelatedDocumentViews().size());
+        assertRemovedByName(doc1.getName(), results.get(0).getOwnerOnlyRelatedDocumentViews());
+        assertEquals(1, results.get(0).getOwnerOnlyRelatedDocumentIds().size());
+        assertRemoved(doc1.getId(), results.get(0).getOwnerOnlyRelatedDocumentIds());
+
+        // Doc2
+        assertEquals(doc2.getName(), results.get(1).getName());
+        assertThisAndOwnerMappings(doc2, results.get(1));
+
+        assertEquals(2, results.get(1).getOwnerRelatedDocumentViews().size());
+        assertRemovedByName(doc3.getName(), results.get(1).getOwnerRelatedDocumentViews());
+        assertRemovedByName(doc4.getName(), results.get(1).getOwnerRelatedDocumentViews());
+        assertEquals(2, results.get(1).getOwnerRelatedDocumentIds().size());
+        assertRemoved(doc3.getId(), results.get(1).getOwnerRelatedDocumentIds());
+        assertRemoved(doc4.getId(), results.get(1).getOwnerRelatedDocumentIds());
+
+        assertEquals(3, results.get(1).getOwnerOnlyRelatedDocumentViews().size());
+        assertRemovedByName(doc2.getName(), results.get(1).getOwnerOnlyRelatedDocumentViews());
+        assertRemovedByName(doc3.getName(), results.get(1).getOwnerOnlyRelatedDocumentViews());
+        assertRemovedByName(doc4.getName(), results.get(1).getOwnerOnlyRelatedDocumentViews());
+        assertEquals(3, results.get(1).getOwnerOnlyRelatedDocumentIds().size());
+        assertRemoved(doc2.getId(), results.get(1).getOwnerOnlyRelatedDocumentIds());
+        assertRemoved(doc3.getId(), results.get(1).getOwnerOnlyRelatedDocumentIds());
+        assertRemoved(doc4.getId(), results.get(1).getOwnerOnlyRelatedDocumentIds());
+
+        // Doc3
+        assertEquals(doc3.getName(), results.get(2).getName());
+        assertThisAndOwnerMappings(doc3, results.get(2));
+
+        assertEquals(2, results.get(2).getOwnerRelatedDocumentViews().size());
+        assertRemovedByName(doc2.getName(), results.get(2).getOwnerRelatedDocumentViews());
+        assertRemovedByName(doc4.getName(), results.get(2).getOwnerRelatedDocumentViews());
+        assertEquals(2, results.get(2).getOwnerRelatedDocumentIds().size());
+        assertRemoved(doc2.getId(), results.get(2).getOwnerRelatedDocumentIds());
+        assertRemoved(doc4.getId(), results.get(2).getOwnerRelatedDocumentIds());
+
+        assertEquals(3, results.get(2).getOwnerOnlyRelatedDocumentViews().size());
+        assertRemovedByName(doc2.getName(), results.get(2).getOwnerOnlyRelatedDocumentViews());
+        assertRemovedByName(doc3.getName(), results.get(2).getOwnerOnlyRelatedDocumentViews());
+        assertRemovedByName(doc4.getName(), results.get(2).getOwnerOnlyRelatedDocumentViews());
+        assertEquals(3, results.get(2).getOwnerOnlyRelatedDocumentIds().size());
+        assertRemoved(doc2.getId(), results.get(2).getOwnerOnlyRelatedDocumentIds());
+        assertRemoved(doc3.getId(), results.get(2).getOwnerOnlyRelatedDocumentIds());
+        assertRemoved(doc4.getId(), results.get(2).getOwnerOnlyRelatedDocumentIds());
+
+        // Doc4
+        assertEquals(doc4.getName(), results.get(3).getName());
+        assertThisAndOwnerMappings(doc4, results.get(3));
+
+        assertEquals(2, results.get(3).getOwnerRelatedDocumentViews().size());
+        assertRemovedByName(doc2.getName(), results.get(3).getOwnerRelatedDocumentViews());
+        assertRemovedByName(doc3.getName(), results.get(3).getOwnerRelatedDocumentViews());
+        assertEquals(2, results.get(3).getOwnerRelatedDocumentIds().size());
+        assertRemoved(doc2.getId(), results.get(3).getOwnerRelatedDocumentIds());
+        assertRemoved(doc3.getId(), results.get(3).getOwnerRelatedDocumentIds());
+
+        assertEquals(3, results.get(3).getOwnerOnlyRelatedDocumentViews().size());
+        assertRemovedByName(doc2.getName(), results.get(3).getOwnerOnlyRelatedDocumentViews());
+        assertRemovedByName(doc3.getName(), results.get(3).getOwnerOnlyRelatedDocumentViews());
+        assertRemovedByName(doc4.getName(), results.get(3).getOwnerOnlyRelatedDocumentViews());
+        assertEquals(3, results.get(3).getOwnerOnlyRelatedDocumentIds().size());
+        assertRemoved(doc2.getId(), results.get(3).getOwnerOnlyRelatedDocumentIds());
+        assertRemoved(doc3.getId(), results.get(3).getOwnerOnlyRelatedDocumentIds());
+        assertRemoved(doc4.getId(), results.get(3).getOwnerOnlyRelatedDocumentIds());
+    }
+
+    private void assertRemovedByName(String expectedName, Collection<SimpleDocumentCorrelatedView> views) {
+        Iterator<SimpleDocumentCorrelatedView> iter = views.iterator();
+        while (iter.hasNext()) {
+            SimpleDocumentCorrelatedView v = iter.next();
+            if (expectedName.equals(v.getName())) {
+                iter.remove();
+                return;
+            }
+        }
+
+        Assert.fail("Could not find '" + expectedName + "' in: " + views);
+    }
+
+    private <T> void assertRemoved(T expectedValue, Collection<T> collection) {
+        if (!collection.remove(expectedValue)) {
+            Assert.fail("Could not find '" + expectedValue + "' in: " + collection);
+        }
+    }
+
+    private void assertThisAndOwnerMappings(Document doc, DocumentCorrelationView view) {
+        // ThisCorrelated variants
+        assertEquals(doc, view.getThisCorrelatedEntity());
+        assertEquals(doc.getId(), view.getThisCorrelatedId());
+        assertDocumentEqualsView(doc, view.getThisCorrelatedView());
+
+        assertEquals(1, view.getThisCorrelatedEntityList().size());
+        assertEquals(doc, view.getThisCorrelatedEntityList().iterator().next());
+
+        assertEquals(1, view.getThisCorrelatedIdList().size());
+        assertEquals(doc.getId(), view.getThisCorrelatedIdList().iterator().next());
+
+        assertEquals(1, view.getThisCorrelatedViewList().size());
+        assertDocumentEqualsView(doc, view.getThisCorrelatedViewList().iterator().next());
+
+        // CorrelatedOwner variants
+        assertEquals(doc.getOwner(), view.getCorrelatedOwner());
+        assertEquals(doc.getOwner().getId(), view.getCorrelatedOwnerId());
+        assertDocumentEqualsView(doc.getOwner(), view.getCorrelatedOwnerView());
+
+        assertEquals(1, view.getCorrelatedOwnerList().size());
+        assertEquals(doc.getOwner(), view.getCorrelatedOwnerList().iterator().next());
+
+        assertEquals(1, view.getCorrelatedOwnerIdList().size());
+        assertEquals(doc.getOwner().getId(), view.getCorrelatedOwnerIdList().iterator().next());
+
+        assertEquals(1, view.getCorrelatedOwnerViewList().size());
+        assertDocumentEqualsView(doc.getOwner(), view.getCorrelatedOwnerViewList().iterator().next());
+    }
+
+    private void assertDocumentEqualsView(Document doc, SimpleDocumentCorrelatedView view) {
+        assertEquals(doc.getId(), view.getId());
+        assertEquals(doc.getName(), view.getName());
+        assertDocumentEqualsView(doc.getOwner(), view.getOwner());
+    }
+
+    private void assertDocumentEqualsView(Person pers, SimplePersonCorrelatedSubView view) {
+        assertEquals(pers.getId(), view.getId());
+        assertEquals(pers.getName().toUpperCase(), view.getName());
+    }
+}

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/general/GeneralCorrelationTest.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/general/GeneralCorrelationTest.java
@@ -16,88 +16,29 @@
 
 package com.blazebit.persistence.view.testsuite.correlation.general;
 
-import com.blazebit.persistence.CriteriaBuilder;
-import com.blazebit.persistence.testsuite.base.category.*;
-import com.blazebit.persistence.testsuite.tx.TxVoidWork;
-import com.blazebit.persistence.view.EntityViewManager;
-import com.blazebit.persistence.view.EntityViewSetting;
-import com.blazebit.persistence.view.EntityViews;
-import com.blazebit.persistence.view.impl.ConfigurationProperties;
-import com.blazebit.persistence.view.spi.EntityViewConfiguration;
-import com.blazebit.persistence.view.testsuite.AbstractEntityViewTest;
-import com.blazebit.persistence.view.testsuite.correlation.general.model.DocumentCorrelationView;
+import com.blazebit.persistence.testsuite.base.category.NoDatanucleus;
+import com.blazebit.persistence.testsuite.base.category.NoDatanucleus4;
+import com.blazebit.persistence.testsuite.base.category.NoEclipselink;
+import com.blazebit.persistence.testsuite.base.category.NoHibernate42;
+import com.blazebit.persistence.testsuite.base.category.NoHibernate43;
+import com.blazebit.persistence.testsuite.base.category.NoHibernate50;
+import com.blazebit.persistence.testsuite.base.category.NoOpenJPA;
+import com.blazebit.persistence.view.testsuite.correlation.AbstractCorrelationTest;
 import com.blazebit.persistence.view.testsuite.correlation.general.model.DocumentCorrelationViewJoinId;
 import com.blazebit.persistence.view.testsuite.correlation.general.model.DocumentCorrelationViewJoinNormal;
 import com.blazebit.persistence.view.testsuite.correlation.general.model.DocumentCorrelationViewSubqueryId;
 import com.blazebit.persistence.view.testsuite.correlation.general.model.DocumentCorrelationViewSubqueryNormal;
 import com.blazebit.persistence.view.testsuite.correlation.general.model.DocumentCorrelationViewSubselectId;
 import com.blazebit.persistence.view.testsuite.correlation.general.model.DocumentCorrelationViewSubselectNormal;
-import com.blazebit.persistence.view.testsuite.entity.Document;
-import com.blazebit.persistence.view.testsuite.entity.Person;
-import com.blazebit.persistence.view.testsuite.subview.model.*;
-import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-
-import javax.persistence.EntityManager;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  *
  * @author Christian Beikov
  * @since 1.2.0
  */
-public class GeneralCorrelationTest extends AbstractEntityViewTest {
-
-    private Document doc1;
-    private Document doc2;
-    private Document doc3;
-    private Document doc4;
-
-    @Override
-    public void setUpOnce() {
-        cleanDatabase();
-        transactional(new TxVoidWork() {
-            @Override
-            public void work(EntityManager em) {
-            doc1 = new Document("doc1");
-            doc2 = new Document("doc2");
-            doc3 = new Document("doc3");
-            doc4 = new Document("doc4");
-
-            Person o1 = new Person("pers1");
-            Person o2 = new Person("pers2");
-            Person o3 = new Person("pers3");
-
-            doc1.setOwner(o1);
-            doc2.setOwner(o2);
-            doc3.setOwner(o2);
-            doc4.setOwner(o2);
-
-            em.persist(o1);
-            em.persist(o2);
-            em.persist(o3);
-
-            em.persist(doc1);
-            em.persist(doc2);
-            em.persist(doc3);
-            em.persist(doc4);
-            }
-        });
-    }
-
-    @Before
-    public void setUp() {
-        doc1 = cbf.create(em, Document.class).where("name").eq("doc1").getSingleResult();
-        doc2 = cbf.create(em, Document.class).where("name").eq("doc2").getSingleResult();
-        doc3 = cbf.create(em, Document.class).where("name").eq("doc3").getSingleResult();
-        doc4 = cbf.create(em, Document.class).where("name").eq("doc4").getSingleResult();
-    }
+public class GeneralCorrelationTest extends AbstractCorrelationTest {
 
     @Test
     // NOTE: Datenucleus issue: https://github.com/datanucleus/datanucleus-api-jpa/issues/77
@@ -107,48 +48,50 @@ public class GeneralCorrelationTest extends AbstractEntityViewTest {
     }
 
     @Test
+    // NOTE: Datenucleus issue: https://github.com/datanucleus/datanucleus-api-jpa/issues/77
+    @Category({ NoDatanucleus.class })
     public void testSubqueryCorrelationId() {
         testCorrelation(DocumentCorrelationViewSubqueryId.class, null);
     }
 
     @Test
     // NOTE: Requires values clause which currently is only available for Hibernate
-    @Category({ NoHibernate42.class, NoHibernate43.class, NoHibernate50.class, NoDatanucleus4.class, NoDatanucleus.class, NoOpenJPA.class, NoEclipselink.class})
+    @Category({ NoDatanucleus4.class, NoDatanucleus.class, NoOpenJPA.class, NoEclipselink.class})
     public void testSubqueryBatchedCorrelationNormalSize2() {
         testCorrelation(DocumentCorrelationViewSubqueryNormal.class, 2);
     }
 
     @Test
     // NOTE: Requires values clause which currently is only available for Hibernate
-    @Category({ NoHibernate42.class, NoHibernate43.class, NoHibernate50.class, NoDatanucleus4.class, NoDatanucleus.class, NoOpenJPA.class, NoEclipselink.class})
+    @Category({ NoDatanucleus4.class, NoDatanucleus.class, NoOpenJPA.class, NoEclipselink.class})
     public void testSubqueryBatchedCorrelationIdSize2() {
         testCorrelation(DocumentCorrelationViewSubqueryId.class, 2);
     }
 
     @Test
     // NOTE: Requires values clause which currently is only available for Hibernate
-    @Category({ NoHibernate42.class, NoHibernate43.class, NoHibernate50.class, NoDatanucleus4.class, NoDatanucleus.class, NoOpenJPA.class, NoEclipselink.class})
+    @Category({ NoDatanucleus4.class, NoDatanucleus.class, NoOpenJPA.class, NoEclipselink.class})
     public void testSubqueryBatchedCorrelationNormalSize4() {
         testCorrelation(DocumentCorrelationViewSubqueryNormal.class, 4);
     }
 
     @Test
     // NOTE: Requires values clause which currently is only available for Hibernate
-    @Category({ NoHibernate42.class, NoHibernate43.class, NoHibernate50.class, NoDatanucleus4.class, NoDatanucleus.class, NoOpenJPA.class, NoEclipselink.class})
+    @Category({ NoDatanucleus4.class, NoDatanucleus.class, NoOpenJPA.class, NoEclipselink.class})
     public void testSubqueryBatchedCorrelationIdSize4() {
         testCorrelation(DocumentCorrelationViewSubqueryId.class, 4);
     }
 
     @Test
     // NOTE: Requires values clause which currently is only available for Hibernate
-    @Category({ NoHibernate42.class, NoHibernate43.class, NoHibernate50.class, NoDatanucleus.class, NoOpenJPA.class, NoEclipselink.class})
+    @Category({ NoDatanucleus.class, NoOpenJPA.class, NoEclipselink.class})
     public void testSubqueryBatchedCorrelationNormalSize20() {
         testCorrelation(DocumentCorrelationViewSubqueryNormal.class, 20);
     }
 
     @Test
     // NOTE: Requires values clause which currently is only available for Hibernate
-    @Category({ NoHibernate42.class, NoHibernate43.class, NoHibernate50.class, NoDatanucleus.class, NoOpenJPA.class, NoEclipselink.class})
+    @Category({ NoDatanucleus.class, NoOpenJPA.class, NoEclipselink.class})
     public void testSubqueryBatchedCorrelationIdSize20() {
         testCorrelation(DocumentCorrelationViewSubqueryId.class, 20);
     }
@@ -182,103 +125,4 @@ public class GeneralCorrelationTest extends AbstractEntityViewTest {
         testCorrelation(DocumentCorrelationViewJoinId.class, null);
     }
 
-    private <T extends DocumentCorrelationView> void testCorrelation(Class<T> entityView, Integer batchSize) {
-        EntityViewConfiguration cfg = EntityViews.createDefaultConfiguration();
-        cfg.addEntityView(entityView);
-        cfg.addEntityView(DocumentRelatedView.class);
-        cfg.addEntityView(SimplePersonSubView.class);
-        EntityViewManager evm = cfg.createEntityViewManager(cbf);
-
-        CriteriaBuilder<Document> criteria = cbf.create(em, Document.class, "d").orderByAsc("id");
-        EntityViewSetting<T, CriteriaBuilder<T>> setting = EntityViewSetting.create(entityView);
-        if (batchSize != null) {
-            setting.setProperty(ConfigurationProperties.DEFAULT_BATCH_SIZE + ".ownerRelatedDocumentIds", batchSize);
-        }
-        CriteriaBuilder<T> cb = evm.applySetting(setting, criteria);
-        List<T> results = cb.getResultList();
-
-        assertEquals(4, results.size());
-        // Doc1
-        assertEquals(doc1.getName(), results.get(0).getName());
-        assertEquals(0, results.get(0).getOwnerRelatedDocuments().size());
-        assertEquals(0, results.get(0).getOwnerRelatedDocumentIds().size());
-
-        assertEquals(1, results.get(0).getOwnerOnlyRelatedDocuments().size());
-        assertRemovedByName(doc1.getName(), results.get(0).getOwnerOnlyRelatedDocuments());
-        assertEquals(1, results.get(0).getOwnerOnlyRelatedDocumentIds().size());
-        assertRemoved(doc1.getId(), results.get(0).getOwnerOnlyRelatedDocumentIds());
-
-        // Doc2
-        assertEquals(doc2.getName(), results.get(1).getName());
-        assertEquals(2, results.get(1).getOwnerRelatedDocuments().size());
-        assertRemovedByName(doc3.getName(), results.get(1).getOwnerRelatedDocuments());
-        assertRemovedByName(doc4.getName(), results.get(1).getOwnerRelatedDocuments());
-        assertEquals(2, results.get(1).getOwnerRelatedDocumentIds().size());
-        assertRemoved(doc3.getId(), results.get(1).getOwnerRelatedDocumentIds());
-        assertRemoved(doc4.getId(), results.get(1).getOwnerRelatedDocumentIds());
-
-        assertEquals(3, results.get(1).getOwnerOnlyRelatedDocuments().size());
-        assertRemovedByName(doc2.getName(), results.get(1).getOwnerOnlyRelatedDocuments());
-        assertRemovedByName(doc3.getName(), results.get(1).getOwnerOnlyRelatedDocuments());
-        assertRemovedByName(doc4.getName(), results.get(1).getOwnerOnlyRelatedDocuments());
-        assertEquals(3, results.get(1).getOwnerOnlyRelatedDocumentIds().size());
-        assertRemoved(doc2.getId(), results.get(1).getOwnerOnlyRelatedDocumentIds());
-        assertRemoved(doc3.getId(), results.get(1).getOwnerOnlyRelatedDocumentIds());
-        assertRemoved(doc4.getId(), results.get(1).getOwnerOnlyRelatedDocumentIds());
-
-        // Doc3
-        assertEquals(doc3.getName(), results.get(2).getName());
-        assertEquals(2, results.get(2).getOwnerRelatedDocuments().size());
-        assertRemovedByName(doc2.getName(), results.get(2).getOwnerRelatedDocuments());
-        assertRemovedByName(doc4.getName(), results.get(2).getOwnerRelatedDocuments());
-        assertEquals(2, results.get(2).getOwnerRelatedDocumentIds().size());
-        assertRemoved(doc2.getId(), results.get(2).getOwnerRelatedDocumentIds());
-        assertRemoved(doc4.getId(), results.get(2).getOwnerRelatedDocumentIds());
-
-        assertEquals(3, results.get(2).getOwnerOnlyRelatedDocuments().size());
-        assertRemovedByName(doc2.getName(), results.get(2).getOwnerOnlyRelatedDocuments());
-        assertRemovedByName(doc3.getName(), results.get(2).getOwnerOnlyRelatedDocuments());
-        assertRemovedByName(doc4.getName(), results.get(2).getOwnerOnlyRelatedDocuments());
-        assertEquals(3, results.get(2).getOwnerOnlyRelatedDocumentIds().size());
-        assertRemoved(doc2.getId(), results.get(2).getOwnerOnlyRelatedDocumentIds());
-        assertRemoved(doc3.getId(), results.get(2).getOwnerOnlyRelatedDocumentIds());
-        assertRemoved(doc4.getId(), results.get(2).getOwnerOnlyRelatedDocumentIds());
-
-        // Doc4
-        assertEquals(doc4.getName(), results.get(3).getName());
-        assertEquals(2, results.get(3).getOwnerRelatedDocuments().size());
-        assertRemovedByName(doc2.getName(), results.get(3).getOwnerRelatedDocuments());
-        assertRemovedByName(doc3.getName(), results.get(3).getOwnerRelatedDocuments());
-        assertEquals(2, results.get(3).getOwnerRelatedDocumentIds().size());
-        assertRemoved(doc2.getId(), results.get(3).getOwnerRelatedDocumentIds());
-        assertRemoved(doc3.getId(), results.get(3).getOwnerRelatedDocumentIds());
-
-        assertEquals(3, results.get(3).getOwnerOnlyRelatedDocuments().size());
-        assertRemovedByName(doc2.getName(), results.get(3).getOwnerOnlyRelatedDocuments());
-        assertRemovedByName(doc3.getName(), results.get(3).getOwnerOnlyRelatedDocuments());
-        assertRemovedByName(doc4.getName(), results.get(3).getOwnerOnlyRelatedDocuments());
-        assertEquals(3, results.get(3).getOwnerOnlyRelatedDocumentIds().size());
-        assertRemoved(doc2.getId(), results.get(3).getOwnerOnlyRelatedDocumentIds());
-        assertRemoved(doc3.getId(), results.get(3).getOwnerOnlyRelatedDocumentIds());
-        assertRemoved(doc4.getId(), results.get(3).getOwnerOnlyRelatedDocumentIds());
-    }
-
-    private void assertRemovedByName(String expectedName, Collection<DocumentRelatedView> views) {
-        Iterator<DocumentRelatedView> iter = views.iterator();
-        while (iter.hasNext()) {
-            DocumentRelatedView v = iter.next();
-            if (expectedName.equals(v.getName())) {
-                iter.remove();
-                return;
-            }
-        }
-
-        Assert.fail("Could not find '" + expectedName + "' in: " + views);
-    }
-
-    private <T> void assertRemoved(T expectedValue, Collection<T> collection) {
-        if (!collection.remove(expectedValue)) {
-            Assert.fail("Could not find '" + expectedValue + "' in: " + collection);
-        }
-    }
 }

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/general/model/DocumentCorrelationViewJoinId.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/general/model/DocumentCorrelationViewJoinId.java
@@ -19,8 +19,11 @@ package com.blazebit.persistence.view.testsuite.correlation.general.model;
 import com.blazebit.persistence.view.FetchStrategy;
 import com.blazebit.persistence.view.EntityView;
 import com.blazebit.persistence.view.MappingCorrelated;
+import com.blazebit.persistence.view.testsuite.correlation.model.DocumentCorrelationView;
+import com.blazebit.persistence.view.testsuite.correlation.model.SimpleDocumentCorrelatedView;
+import com.blazebit.persistence.view.testsuite.correlation.model.SimplePersonCorrelatedSubView;
 import com.blazebit.persistence.view.testsuite.entity.Document;
-import com.blazebit.persistence.view.testsuite.subview.model.DocumentRelatedView;
+import com.blazebit.persistence.view.testsuite.entity.Person;
 
 import java.util.Set;
 
@@ -35,16 +38,58 @@ import java.util.Set;
 @EntityView(Document.class)
 public interface DocumentCorrelationViewJoinId extends DocumentCorrelationView {
 
-    @MappingCorrelated(correlationBasis = "owner.id", correlationResult = "id", correlator = OwnerRelatedCorrelationIdProviderId.class, fetch = FetchStrategy.JOIN)
+    @MappingCorrelated(correlationBasis = "owner.id", correlationResult = "id", correlator = OwnerCorrelationProviderId.class, fetch = FetchStrategy.JOIN)
+    public Long getCorrelatedOwnerId();
+
+    @MappingCorrelated(correlationBasis = "owner.id", correlator = OwnerCorrelationProviderId.class, fetch = FetchStrategy.JOIN)
+    public Person getCorrelatedOwner();
+
+    @MappingCorrelated(correlationBasis = "owner.id", correlator = OwnerCorrelationProviderId.class, fetch = FetchStrategy.JOIN)
+    public SimplePersonCorrelatedSubView getCorrelatedOwnerView();
+
+    @MappingCorrelated(correlationBasis = "owner.id", correlationResult = "id", correlator = OwnerCorrelationProviderId.class, fetch = FetchStrategy.JOIN)
+    public Set<Long> getCorrelatedOwnerIdList();
+
+    @MappingCorrelated(correlationBasis = "owner.id", correlator = OwnerCorrelationProviderId.class, fetch = FetchStrategy.JOIN)
+    public Set<Person> getCorrelatedOwnerList();
+
+    @MappingCorrelated(correlationBasis = "owner.id", correlator = OwnerCorrelationProviderId.class, fetch = FetchStrategy.JOIN)
+    public Set<SimplePersonCorrelatedSubView> getCorrelatedOwnerViewList();
+
+    @MappingCorrelated(correlationBasis = "owner.id", correlationResult = "id", correlator = OwnerRelatedCorrelationProviderId.class, fetch = FetchStrategy.JOIN)
     public Set<Long> getOwnerRelatedDocumentIds();
 
     @MappingCorrelated(correlationBasis = "owner.id", correlator = OwnerRelatedCorrelationProviderId.class, fetch = FetchStrategy.JOIN)
-    public Set<DocumentRelatedView> getOwnerRelatedDocuments();
+    public Set<Document> getOwnerRelatedDocuments();
 
-    @MappingCorrelated(correlationBasis = "owner.id", correlationResult = "id", correlator = OwnerOnlyRelatedCorrelationIdProviderId.class, fetch = FetchStrategy.JOIN)
+    @MappingCorrelated(correlationBasis = "owner.id", correlator = OwnerRelatedCorrelationProviderId.class, fetch = FetchStrategy.JOIN)
+    public Set<SimpleDocumentCorrelatedView> getOwnerRelatedDocumentViews();
+
+    @MappingCorrelated(correlationBasis = "owner.id", correlationResult = "id", correlator = OwnerOnlyRelatedCorrelationProviderId.class, fetch = FetchStrategy.JOIN)
     public Set<Long> getOwnerOnlyRelatedDocumentIds();
 
     @MappingCorrelated(correlationBasis = "owner.id", correlator = OwnerOnlyRelatedCorrelationProviderId.class, fetch = FetchStrategy.JOIN)
-    public Set<DocumentRelatedView> getOwnerOnlyRelatedDocuments();
+    public Set<Document> getOwnerOnlyRelatedDocuments();
+
+    @MappingCorrelated(correlationBasis = "owner.id", correlator = OwnerOnlyRelatedCorrelationProviderId.class, fetch = FetchStrategy.JOIN)
+    public Set<SimpleDocumentCorrelatedView> getOwnerOnlyRelatedDocumentViews();
+
+    @MappingCorrelated(correlationBasis = "this", correlator = ThisCorrelationProviderNormal.class, correlationResult = "id", fetch = FetchStrategy.JOIN)
+    public Long getThisCorrelatedId();
+
+    @MappingCorrelated(correlationBasis = "this", correlator = ThisCorrelationProviderNormal.class, fetch = FetchStrategy.JOIN)
+    public Document getThisCorrelatedEntity();
+
+    @MappingCorrelated(correlationBasis = "this", correlator = ThisCorrelationProviderNormal.class, fetch = FetchStrategy.JOIN)
+    public SimpleDocumentCorrelatedView getThisCorrelatedView();
+
+    @MappingCorrelated(correlationBasis = "this", correlator = ThisCorrelationProviderNormal.class, correlationResult = "id", fetch = FetchStrategy.JOIN)
+    public Set<Long> getThisCorrelatedIdList();
+
+    @MappingCorrelated(correlationBasis = "this", correlator = ThisCorrelationProviderNormal.class, fetch = FetchStrategy.JOIN)
+    public Set<Document> getThisCorrelatedEntityList();
+
+    @MappingCorrelated(correlationBasis = "this", correlator = ThisCorrelationProviderNormal.class, fetch = FetchStrategy.JOIN)
+    public Set<SimpleDocumentCorrelatedView> getThisCorrelatedViewList();
 
 }

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/general/model/DocumentCorrelationViewJoinNormal.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/general/model/DocumentCorrelationViewJoinNormal.java
@@ -16,11 +16,14 @@
 
 package com.blazebit.persistence.view.testsuite.correlation.general.model;
 
-import com.blazebit.persistence.view.FetchStrategy;
 import com.blazebit.persistence.view.EntityView;
+import com.blazebit.persistence.view.FetchStrategy;
 import com.blazebit.persistence.view.MappingCorrelated;
+import com.blazebit.persistence.view.testsuite.correlation.model.DocumentCorrelationView;
+import com.blazebit.persistence.view.testsuite.correlation.model.SimpleDocumentCorrelatedView;
+import com.blazebit.persistence.view.testsuite.correlation.model.SimplePersonCorrelatedSubView;
 import com.blazebit.persistence.view.testsuite.entity.Document;
-import com.blazebit.persistence.view.testsuite.subview.model.DocumentRelatedView;
+import com.blazebit.persistence.view.testsuite.entity.Person;
 
 import java.util.Set;
 
@@ -34,16 +37,58 @@ import java.util.Set;
 @EntityView(Document.class)
 public interface DocumentCorrelationViewJoinNormal extends DocumentCorrelationView {
 
-    @MappingCorrelated(correlationBasis = "owner", correlationResult = "id", correlator = OwnerRelatedCorrelationIdProviderNormal.class, fetch = FetchStrategy.JOIN)
+    @MappingCorrelated(correlationBasis = "owner", correlationResult = "id", correlator = OwnerCorrelationProviderNormal.class, fetch = FetchStrategy.JOIN)
+    public Long getCorrelatedOwnerId();
+
+    @MappingCorrelated(correlationBasis = "owner", correlator = OwnerCorrelationProviderNormal.class, fetch = FetchStrategy.JOIN)
+    public Person getCorrelatedOwner();
+
+    @MappingCorrelated(correlationBasis = "owner", correlator = OwnerCorrelationProviderNormal.class, fetch = FetchStrategy.JOIN)
+    public SimplePersonCorrelatedSubView getCorrelatedOwnerView();
+
+    @MappingCorrelated(correlationBasis = "owner", correlationResult = "id", correlator = OwnerCorrelationProviderNormal.class, fetch = FetchStrategy.JOIN)
+    public Set<Long> getCorrelatedOwnerIdList();
+
+    @MappingCorrelated(correlationBasis = "owner", correlator = OwnerCorrelationProviderNormal.class, fetch = FetchStrategy.JOIN)
+    public Set<Person> getCorrelatedOwnerList();
+
+    @MappingCorrelated(correlationBasis = "owner", correlator = OwnerCorrelationProviderNormal.class, fetch = FetchStrategy.JOIN)
+    public Set<SimplePersonCorrelatedSubView> getCorrelatedOwnerViewList();
+
+    @MappingCorrelated(correlationBasis = "owner", correlationResult = "id", correlator = OwnerRelatedCorrelationProviderNormal.class, fetch = FetchStrategy.JOIN)
     public Set<Long> getOwnerRelatedDocumentIds();
 
     @MappingCorrelated(correlationBasis = "owner", correlator = OwnerRelatedCorrelationProviderNormal.class, fetch = FetchStrategy.JOIN)
-    public Set<DocumentRelatedView> getOwnerRelatedDocuments();
+    public Set<Document> getOwnerRelatedDocuments();
 
-    @MappingCorrelated(correlationBasis = "owner", correlationResult = "id", correlator = OwnerOnlyRelatedCorrelationIdProviderNormal.class, fetch = FetchStrategy.JOIN)
+    @MappingCorrelated(correlationBasis = "owner", correlator = OwnerRelatedCorrelationProviderNormal.class, fetch = FetchStrategy.JOIN)
+    public Set<SimpleDocumentCorrelatedView> getOwnerRelatedDocumentViews();
+
+    @MappingCorrelated(correlationBasis = "owner", correlationResult = "id", correlator = OwnerOnlyRelatedCorrelationProviderNormal.class, fetch = FetchStrategy.JOIN)
     public Set<Long> getOwnerOnlyRelatedDocumentIds();
 
     @MappingCorrelated(correlationBasis = "owner", correlator = OwnerOnlyRelatedCorrelationProviderNormal.class, fetch = FetchStrategy.JOIN)
-    public Set<DocumentRelatedView> getOwnerOnlyRelatedDocuments();
+    public Set<Document> getOwnerOnlyRelatedDocuments();
+
+    @MappingCorrelated(correlationBasis = "owner", correlator = OwnerOnlyRelatedCorrelationProviderNormal.class, fetch = FetchStrategy.JOIN)
+    public Set<SimpleDocumentCorrelatedView> getOwnerOnlyRelatedDocumentViews();
+
+    @MappingCorrelated(correlationBasis = "this", correlator = ThisCorrelationProviderNormal.class, correlationResult = "id", fetch = FetchStrategy.JOIN)
+    public Long getThisCorrelatedId();
+
+    @MappingCorrelated(correlationBasis = "this", correlator = ThisCorrelationProviderNormal.class, fetch = FetchStrategy.JOIN)
+    public Document getThisCorrelatedEntity();
+
+    @MappingCorrelated(correlationBasis = "this", correlator = ThisCorrelationProviderNormal.class, fetch = FetchStrategy.JOIN)
+    public SimpleDocumentCorrelatedView getThisCorrelatedView();
+
+    @MappingCorrelated(correlationBasis = "this", correlator = ThisCorrelationProviderNormal.class, correlationResult = "id", fetch = FetchStrategy.JOIN)
+    public Set<Long> getThisCorrelatedIdList();
+
+    @MappingCorrelated(correlationBasis = "this", correlator = ThisCorrelationProviderNormal.class, fetch = FetchStrategy.JOIN)
+    public Set<Document> getThisCorrelatedEntityList();
+
+    @MappingCorrelated(correlationBasis = "this", correlator = ThisCorrelationProviderNormal.class, fetch = FetchStrategy.JOIN)
+    public Set<SimpleDocumentCorrelatedView> getThisCorrelatedViewList();
 
 }

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/general/model/DocumentCorrelationViewSubqueryId.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/general/model/DocumentCorrelationViewSubqueryId.java
@@ -16,9 +16,14 @@
 
 package com.blazebit.persistence.view.testsuite.correlation.general.model;
 
-import com.blazebit.persistence.view.*;
+import com.blazebit.persistence.view.EntityView;
+import com.blazebit.persistence.view.FetchStrategy;
+import com.blazebit.persistence.view.MappingCorrelated;
+import com.blazebit.persistence.view.testsuite.correlation.model.DocumentCorrelationView;
+import com.blazebit.persistence.view.testsuite.correlation.model.SimpleDocumentCorrelatedView;
+import com.blazebit.persistence.view.testsuite.correlation.model.SimplePersonCorrelatedSubView;
 import com.blazebit.persistence.view.testsuite.entity.Document;
-import com.blazebit.persistence.view.testsuite.subview.model.DocumentRelatedView;
+import com.blazebit.persistence.view.testsuite.entity.Person;
 
 import java.util.Set;
 
@@ -33,16 +38,58 @@ import java.util.Set;
 @EntityView(Document.class)
 public interface DocumentCorrelationViewSubqueryId extends DocumentCorrelationView {
 
-    @MappingCorrelated(correlationBasis = "owner.id", correlationResult = "id", correlator = OwnerRelatedCorrelationIdProviderId.class, fetch = FetchStrategy.SELECT)
+    @MappingCorrelated(correlationBasis = "owner.id", correlationResult = "id", correlator = OwnerCorrelationProviderId.class, fetch = FetchStrategy.SELECT)
+    public Long getCorrelatedOwnerId();
+
+    @MappingCorrelated(correlationBasis = "owner.id", correlator = OwnerCorrelationProviderId.class, fetch = FetchStrategy.SELECT)
+    public Person getCorrelatedOwner();
+
+    @MappingCorrelated(correlationBasis = "owner.id", correlator = OwnerCorrelationProviderId.class, fetch = FetchStrategy.SELECT)
+    public SimplePersonCorrelatedSubView getCorrelatedOwnerView();
+
+    @MappingCorrelated(correlationBasis = "owner.id", correlationResult = "id", correlator = OwnerCorrelationProviderId.class, fetch = FetchStrategy.SELECT)
+    public Set<Long> getCorrelatedOwnerIdList();
+
+    @MappingCorrelated(correlationBasis = "owner.id", correlator = OwnerCorrelationProviderId.class, fetch = FetchStrategy.SELECT)
+    public Set<Person> getCorrelatedOwnerList();
+
+    @MappingCorrelated(correlationBasis = "owner.id", correlator = OwnerCorrelationProviderId.class, fetch = FetchStrategy.SELECT)
+    public Set<SimplePersonCorrelatedSubView> getCorrelatedOwnerViewList();
+
+    @MappingCorrelated(correlationBasis = "owner.id", correlationResult = "id", correlator = OwnerRelatedCorrelationProviderId.class, fetch = FetchStrategy.SELECT)
     public Set<Long> getOwnerRelatedDocumentIds();
 
     @MappingCorrelated(correlationBasis = "owner.id", correlator = OwnerRelatedCorrelationProviderId.class, fetch = FetchStrategy.SELECT)
-    public Set<DocumentRelatedView> getOwnerRelatedDocuments();
+    public Set<Document> getOwnerRelatedDocuments();
 
-    @MappingCorrelated(correlationBasis = "owner.id", correlationResult = "id", correlator = OwnerOnlyRelatedCorrelationIdProviderId.class, fetch = FetchStrategy.SELECT)
+    @MappingCorrelated(correlationBasis = "owner.id", correlator = OwnerRelatedCorrelationProviderId.class, fetch = FetchStrategy.SELECT)
+    public Set<SimpleDocumentCorrelatedView> getOwnerRelatedDocumentViews();
+
+    @MappingCorrelated(correlationBasis = "owner.id", correlationResult = "id", correlator = OwnerOnlyRelatedCorrelationProviderId.class, fetch = FetchStrategy.SELECT)
     public Set<Long> getOwnerOnlyRelatedDocumentIds();
 
     @MappingCorrelated(correlationBasis = "owner.id", correlator = OwnerOnlyRelatedCorrelationProviderId.class, fetch = FetchStrategy.SELECT)
-    public Set<DocumentRelatedView> getOwnerOnlyRelatedDocuments();
+    public Set<Document> getOwnerOnlyRelatedDocuments();
+
+    @MappingCorrelated(correlationBasis = "owner.id", correlator = OwnerOnlyRelatedCorrelationProviderId.class, fetch = FetchStrategy.SELECT)
+    public Set<SimpleDocumentCorrelatedView> getOwnerOnlyRelatedDocumentViews();
+
+    @MappingCorrelated(correlationBasis = "this", correlator = ThisCorrelationProviderNormal.class, correlationResult = "id", fetch = FetchStrategy.SELECT)
+    public Long getThisCorrelatedId();
+
+    @MappingCorrelated(correlationBasis = "this", correlator = ThisCorrelationProviderNormal.class, fetch = FetchStrategy.SELECT)
+    public Document getThisCorrelatedEntity();
+
+    @MappingCorrelated(correlationBasis = "this", correlator = ThisCorrelationProviderNormal.class, fetch = FetchStrategy.SELECT)
+    public SimpleDocumentCorrelatedView getThisCorrelatedView();
+
+    @MappingCorrelated(correlationBasis = "this", correlator = ThisCorrelationProviderNormal.class, correlationResult = "id", fetch = FetchStrategy.SELECT)
+    public Set<Long> getThisCorrelatedIdList();
+
+    @MappingCorrelated(correlationBasis = "this", correlator = ThisCorrelationProviderNormal.class, fetch = FetchStrategy.SELECT)
+    public Set<Document> getThisCorrelatedEntityList();
+
+    @MappingCorrelated(correlationBasis = "this", correlator = ThisCorrelationProviderNormal.class, fetch = FetchStrategy.SELECT)
+    public Set<SimpleDocumentCorrelatedView> getThisCorrelatedViewList();
 
 }

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/general/model/DocumentCorrelationViewSubqueryNormal.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/general/model/DocumentCorrelationViewSubqueryNormal.java
@@ -19,8 +19,11 @@ package com.blazebit.persistence.view.testsuite.correlation.general.model;
 import com.blazebit.persistence.view.EntityView;
 import com.blazebit.persistence.view.FetchStrategy;
 import com.blazebit.persistence.view.MappingCorrelated;
+import com.blazebit.persistence.view.testsuite.correlation.model.DocumentCorrelationView;
+import com.blazebit.persistence.view.testsuite.correlation.model.SimpleDocumentCorrelatedView;
+import com.blazebit.persistence.view.testsuite.correlation.model.SimplePersonCorrelatedSubView;
 import com.blazebit.persistence.view.testsuite.entity.Document;
-import com.blazebit.persistence.view.testsuite.subview.model.DocumentRelatedView;
+import com.blazebit.persistence.view.testsuite.entity.Person;
 
 import java.util.Set;
 
@@ -34,16 +37,58 @@ import java.util.Set;
 @EntityView(Document.class)
 public interface DocumentCorrelationViewSubqueryNormal extends DocumentCorrelationView {
 
-    @MappingCorrelated(correlationBasis = "owner", correlationResult = "id", correlator = OwnerRelatedCorrelationIdProviderNormal.class, fetch = FetchStrategy.SELECT)
+    @MappingCorrelated(correlationBasis = "owner", correlationResult = "id", correlator = OwnerCorrelationProviderNormal.class, fetch = FetchStrategy.SELECT)
+    public Long getCorrelatedOwnerId();
+
+    @MappingCorrelated(correlationBasis = "owner", correlator = OwnerCorrelationProviderNormal.class, fetch = FetchStrategy.SELECT)
+    public Person getCorrelatedOwner();
+
+    @MappingCorrelated(correlationBasis = "owner", correlator = OwnerCorrelationProviderNormal.class, fetch = FetchStrategy.SELECT)
+    public SimplePersonCorrelatedSubView getCorrelatedOwnerView();
+
+    @MappingCorrelated(correlationBasis = "owner", correlationResult = "id", correlator = OwnerCorrelationProviderNormal.class, fetch = FetchStrategy.SELECT)
+    public Set<Long> getCorrelatedOwnerIdList();
+
+    @MappingCorrelated(correlationBasis = "owner", correlator = OwnerCorrelationProviderNormal.class, fetch = FetchStrategy.SELECT)
+    public Set<Person> getCorrelatedOwnerList();
+
+    @MappingCorrelated(correlationBasis = "owner", correlator = OwnerCorrelationProviderNormal.class, fetch = FetchStrategy.SELECT)
+    public Set<SimplePersonCorrelatedSubView> getCorrelatedOwnerViewList();
+
+    @MappingCorrelated(correlationBasis = "owner", correlationResult = "id", correlator = OwnerRelatedCorrelationProviderNormal.class, fetch = FetchStrategy.SELECT)
     public Set<Long> getOwnerRelatedDocumentIds();
 
     @MappingCorrelated(correlationBasis = "owner", correlator = OwnerRelatedCorrelationProviderNormal.class, fetch = FetchStrategy.SELECT)
-    public Set<DocumentRelatedView> getOwnerRelatedDocuments();
+    public Set<Document> getOwnerRelatedDocuments();
 
-    @MappingCorrelated(correlationBasis = "owner", correlationResult = "id", correlator = OwnerOnlyRelatedCorrelationIdProviderNormal.class, fetch = FetchStrategy.SELECT)
+    @MappingCorrelated(correlationBasis = "owner", correlator = OwnerRelatedCorrelationProviderNormal.class, fetch = FetchStrategy.SELECT)
+    public Set<SimpleDocumentCorrelatedView> getOwnerRelatedDocumentViews();
+
+    @MappingCorrelated(correlationBasis = "owner", correlationResult = "id", correlator = OwnerOnlyRelatedCorrelationProviderNormal.class, fetch = FetchStrategy.SELECT)
     public Set<Long> getOwnerOnlyRelatedDocumentIds();
 
     @MappingCorrelated(correlationBasis = "owner", correlator = OwnerOnlyRelatedCorrelationProviderNormal.class, fetch = FetchStrategy.SELECT)
-    public Set<DocumentRelatedView> getOwnerOnlyRelatedDocuments();
+    public Set<Document> getOwnerOnlyRelatedDocuments();
+
+    @MappingCorrelated(correlationBasis = "owner", correlator = OwnerOnlyRelatedCorrelationProviderNormal.class, fetch = FetchStrategy.SELECT)
+    public Set<SimpleDocumentCorrelatedView> getOwnerOnlyRelatedDocumentViews();
+
+    @MappingCorrelated(correlationBasis = "this", correlator = ThisCorrelationProviderNormal.class, correlationResult = "id", fetch = FetchStrategy.SELECT)
+    public Long getThisCorrelatedId();
+
+    @MappingCorrelated(correlationBasis = "this", correlator = ThisCorrelationProviderNormal.class, fetch = FetchStrategy.SELECT)
+    public Document getThisCorrelatedEntity();
+
+    @MappingCorrelated(correlationBasis = "this", correlator = ThisCorrelationProviderNormal.class, fetch = FetchStrategy.SELECT)
+    public SimpleDocumentCorrelatedView getThisCorrelatedView();
+
+    @MappingCorrelated(correlationBasis = "this", correlator = ThisCorrelationProviderNormal.class, correlationResult = "id", fetch = FetchStrategy.SELECT)
+    public Set<Long> getThisCorrelatedIdList();
+
+    @MappingCorrelated(correlationBasis = "this", correlator = ThisCorrelationProviderNormal.class, fetch = FetchStrategy.SELECT)
+    public Set<Document> getThisCorrelatedEntityList();
+
+    @MappingCorrelated(correlationBasis = "this", correlator = ThisCorrelationProviderNormal.class, fetch = FetchStrategy.SELECT)
+    public Set<SimpleDocumentCorrelatedView> getThisCorrelatedViewList();
 
 }

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/general/model/DocumentCorrelationViewSubselectId.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/general/model/DocumentCorrelationViewSubselectId.java
@@ -19,8 +19,11 @@ package com.blazebit.persistence.view.testsuite.correlation.general.model;
 import com.blazebit.persistence.view.EntityView;
 import com.blazebit.persistence.view.FetchStrategy;
 import com.blazebit.persistence.view.MappingCorrelated;
+import com.blazebit.persistence.view.testsuite.correlation.model.DocumentCorrelationView;
+import com.blazebit.persistence.view.testsuite.correlation.model.SimpleDocumentCorrelatedView;
+import com.blazebit.persistence.view.testsuite.correlation.model.SimplePersonCorrelatedSubView;
 import com.blazebit.persistence.view.testsuite.entity.Document;
-import com.blazebit.persistence.view.testsuite.subview.model.DocumentRelatedView;
+import com.blazebit.persistence.view.testsuite.entity.Person;
 
 import java.util.Set;
 
@@ -35,16 +38,58 @@ import java.util.Set;
 @EntityView(Document.class)
 public interface DocumentCorrelationViewSubselectId extends DocumentCorrelationView {
 
-    @MappingCorrelated(correlationBasis = "owner.id", correlationResult = "id", correlator = OwnerRelatedCorrelationIdProviderId.class, fetch = FetchStrategy.SUBSELECT)
+    @MappingCorrelated(correlationBasis = "owner.id", correlationResult = "id", correlator = OwnerCorrelationProviderId.class, fetch = FetchStrategy.SUBSELECT)
+    public Long getCorrelatedOwnerId();
+
+    @MappingCorrelated(correlationBasis = "owner.id", correlator = OwnerCorrelationProviderId.class, fetch = FetchStrategy.SUBSELECT)
+    public Person getCorrelatedOwner();
+
+    @MappingCorrelated(correlationBasis = "owner.id", correlator = OwnerCorrelationProviderId.class, fetch = FetchStrategy.SUBSELECT)
+    public SimplePersonCorrelatedSubView getCorrelatedOwnerView();
+
+    @MappingCorrelated(correlationBasis = "owner.id", correlationResult = "id", correlator = OwnerCorrelationProviderId.class, fetch = FetchStrategy.SUBSELECT)
+    public Set<Long> getCorrelatedOwnerIdList();
+
+    @MappingCorrelated(correlationBasis = "owner.id", correlator = OwnerCorrelationProviderId.class, fetch = FetchStrategy.SUBSELECT)
+    public Set<Person> getCorrelatedOwnerList();
+
+    @MappingCorrelated(correlationBasis = "owner.id", correlator = OwnerCorrelationProviderId.class, fetch = FetchStrategy.SUBSELECT)
+    public Set<SimplePersonCorrelatedSubView> getCorrelatedOwnerViewList();
+
+    @MappingCorrelated(correlationBasis = "owner.id", correlationResult = "id", correlator = OwnerRelatedCorrelationProviderId.class, fetch = FetchStrategy.SUBSELECT)
     public Set<Long> getOwnerRelatedDocumentIds();
 
     @MappingCorrelated(correlationBasis = "owner.id", correlator = OwnerRelatedCorrelationProviderId.class, fetch = FetchStrategy.SUBSELECT)
-    public Set<DocumentRelatedView> getOwnerRelatedDocuments();
+    public Set<Document> getOwnerRelatedDocuments();
 
-    @MappingCorrelated(correlationBasis = "owner.id", correlationResult = "id", correlator = OwnerOnlyRelatedCorrelationIdProviderId.class, fetch = FetchStrategy.SUBSELECT)
+    @MappingCorrelated(correlationBasis = "owner.id", correlator = OwnerRelatedCorrelationProviderId.class, fetch = FetchStrategy.SUBSELECT)
+    public Set<SimpleDocumentCorrelatedView> getOwnerRelatedDocumentViews();
+
+    @MappingCorrelated(correlationBasis = "owner.id", correlationResult = "id", correlator = OwnerOnlyRelatedCorrelationProviderId.class, fetch = FetchStrategy.SUBSELECT)
     public Set<Long> getOwnerOnlyRelatedDocumentIds();
 
     @MappingCorrelated(correlationBasis = "owner.id", correlator = OwnerOnlyRelatedCorrelationProviderId.class, fetch = FetchStrategy.SUBSELECT)
-    public Set<DocumentRelatedView> getOwnerOnlyRelatedDocuments();
+    public Set<Document> getOwnerOnlyRelatedDocuments();
+
+    @MappingCorrelated(correlationBasis = "owner.id", correlator = OwnerOnlyRelatedCorrelationProviderId.class, fetch = FetchStrategy.SUBSELECT)
+    public Set<SimpleDocumentCorrelatedView> getOwnerOnlyRelatedDocumentViews();
+
+    @MappingCorrelated(correlationBasis = "this", correlator = ThisCorrelationProviderNormal.class, correlationResult = "id", fetch = FetchStrategy.SUBSELECT)
+    public Long getThisCorrelatedId();
+
+    @MappingCorrelated(correlationBasis = "this", correlator = ThisCorrelationProviderNormal.class, fetch = FetchStrategy.SUBSELECT)
+    public Document getThisCorrelatedEntity();
+
+    @MappingCorrelated(correlationBasis = "this", correlator = ThisCorrelationProviderNormal.class, fetch = FetchStrategy.SUBSELECT)
+    public SimpleDocumentCorrelatedView getThisCorrelatedView();
+
+    @MappingCorrelated(correlationBasis = "this", correlator = ThisCorrelationProviderNormal.class, correlationResult = "id", fetch = FetchStrategy.SUBSELECT)
+    public Set<Long> getThisCorrelatedIdList();
+
+    @MappingCorrelated(correlationBasis = "this", correlator = ThisCorrelationProviderNormal.class, fetch = FetchStrategy.SUBSELECT)
+    public Set<Document> getThisCorrelatedEntityList();
+
+    @MappingCorrelated(correlationBasis = "this", correlator = ThisCorrelationProviderNormal.class, fetch = FetchStrategy.SUBSELECT)
+    public Set<SimpleDocumentCorrelatedView> getThisCorrelatedViewList();
 
 }

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/general/model/DocumentCorrelationViewSubselectNormal.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/general/model/DocumentCorrelationViewSubselectNormal.java
@@ -16,11 +16,14 @@
 
 package com.blazebit.persistence.view.testsuite.correlation.general.model;
 
-import com.blazebit.persistence.view.FetchStrategy;
 import com.blazebit.persistence.view.EntityView;
+import com.blazebit.persistence.view.FetchStrategy;
 import com.blazebit.persistence.view.MappingCorrelated;
+import com.blazebit.persistence.view.testsuite.correlation.model.DocumentCorrelationView;
+import com.blazebit.persistence.view.testsuite.correlation.model.SimpleDocumentCorrelatedView;
+import com.blazebit.persistence.view.testsuite.correlation.model.SimplePersonCorrelatedSubView;
 import com.blazebit.persistence.view.testsuite.entity.Document;
-import com.blazebit.persistence.view.testsuite.subview.model.DocumentRelatedView;
+import com.blazebit.persistence.view.testsuite.entity.Person;
 
 import java.util.Set;
 
@@ -34,16 +37,58 @@ import java.util.Set;
 @EntityView(Document.class)
 public interface DocumentCorrelationViewSubselectNormal extends DocumentCorrelationView {
 
-    @MappingCorrelated(correlationBasis = "owner", correlationResult = "id", correlator = OwnerRelatedCorrelationIdProviderNormal.class, fetch = FetchStrategy.SUBSELECT)
+    @MappingCorrelated(correlationBasis = "owner", correlationResult = "id", correlator = OwnerCorrelationProviderNormal.class, fetch = FetchStrategy.SUBSELECT)
+    public Long getCorrelatedOwnerId();
+
+    @MappingCorrelated(correlationBasis = "owner", correlator = OwnerCorrelationProviderNormal.class, fetch = FetchStrategy.SUBSELECT)
+    public Person getCorrelatedOwner();
+
+    @MappingCorrelated(correlationBasis = "owner", correlator = OwnerCorrelationProviderNormal.class, fetch = FetchStrategy.SUBSELECT)
+    public SimplePersonCorrelatedSubView getCorrelatedOwnerView();
+
+    @MappingCorrelated(correlationBasis = "owner", correlationResult = "id", correlator = OwnerCorrelationProviderNormal.class, fetch = FetchStrategy.SUBSELECT)
+    public Set<Long> getCorrelatedOwnerIdList();
+
+    @MappingCorrelated(correlationBasis = "owner", correlator = OwnerCorrelationProviderNormal.class, fetch = FetchStrategy.SUBSELECT)
+    public Set<Person> getCorrelatedOwnerList();
+
+    @MappingCorrelated(correlationBasis = "owner", correlator = OwnerCorrelationProviderNormal.class, fetch = FetchStrategy.SUBSELECT)
+    public Set<SimplePersonCorrelatedSubView> getCorrelatedOwnerViewList();
+
+    @MappingCorrelated(correlationBasis = "owner", correlationResult = "id", correlator = OwnerRelatedCorrelationProviderNormal.class, fetch = FetchStrategy.SUBSELECT)
     public Set<Long> getOwnerRelatedDocumentIds();
 
     @MappingCorrelated(correlationBasis = "owner", correlator = OwnerRelatedCorrelationProviderNormal.class, fetch = FetchStrategy.SUBSELECT)
-    public Set<DocumentRelatedView> getOwnerRelatedDocuments();
+    public Set<Document> getOwnerRelatedDocuments();
 
-    @MappingCorrelated(correlationBasis = "owner", correlationResult = "id", correlator = OwnerOnlyRelatedCorrelationIdProviderNormal.class, fetch = FetchStrategy.SUBSELECT)
+    @MappingCorrelated(correlationBasis = "owner", correlator = OwnerRelatedCorrelationProviderNormal.class, fetch = FetchStrategy.SUBSELECT)
+    public Set<SimpleDocumentCorrelatedView> getOwnerRelatedDocumentViews();
+
+    @MappingCorrelated(correlationBasis = "owner", correlationResult = "id", correlator = OwnerOnlyRelatedCorrelationProviderNormal.class, fetch = FetchStrategy.SUBSELECT)
     public Set<Long> getOwnerOnlyRelatedDocumentIds();
 
     @MappingCorrelated(correlationBasis = "owner", correlator = OwnerOnlyRelatedCorrelationProviderNormal.class, fetch = FetchStrategy.SUBSELECT)
-    public Set<DocumentRelatedView> getOwnerOnlyRelatedDocuments();
+    public Set<Document> getOwnerOnlyRelatedDocuments();
+
+    @MappingCorrelated(correlationBasis = "owner", correlator = OwnerOnlyRelatedCorrelationProviderNormal.class, fetch = FetchStrategy.SUBSELECT)
+    public Set<SimpleDocumentCorrelatedView> getOwnerOnlyRelatedDocumentViews();
+
+    @MappingCorrelated(correlationBasis = "this", correlator = ThisCorrelationProviderNormal.class, correlationResult = "id", fetch = FetchStrategy.SUBSELECT)
+    public Long getThisCorrelatedId();
+
+    @MappingCorrelated(correlationBasis = "this", correlator = ThisCorrelationProviderNormal.class, fetch = FetchStrategy.SUBSELECT)
+    public Document getThisCorrelatedEntity();
+
+    @MappingCorrelated(correlationBasis = "this", correlator = ThisCorrelationProviderNormal.class, fetch = FetchStrategy.SUBSELECT)
+    public SimpleDocumentCorrelatedView getThisCorrelatedView();
+
+    @MappingCorrelated(correlationBasis = "this", correlator = ThisCorrelationProviderNormal.class, correlationResult = "id", fetch = FetchStrategy.SUBSELECT)
+    public Set<Long> getThisCorrelatedIdList();
+
+    @MappingCorrelated(correlationBasis = "this", correlator = ThisCorrelationProviderNormal.class, fetch = FetchStrategy.SUBSELECT)
+    public Set<Document> getThisCorrelatedEntityList();
+
+    @MappingCorrelated(correlationBasis = "this", correlator = ThisCorrelationProviderNormal.class, fetch = FetchStrategy.SUBSELECT)
+    public Set<SimpleDocumentCorrelatedView> getThisCorrelatedViewList();
 
 }

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/general/model/OwnerCorrelationProviderId.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/general/model/OwnerCorrelationProviderId.java
@@ -18,20 +18,20 @@ package com.blazebit.persistence.view.testsuite.correlation.general.model;
 
 import com.blazebit.persistence.view.CorrelationBuilder;
 import com.blazebit.persistence.view.CorrelationProvider;
-import com.blazebit.persistence.view.testsuite.entity.Document;
+import com.blazebit.persistence.view.testsuite.entity.Person;
 
 /**
  *
  * @author Christian Beikov
  * @since 1.2.0
  */
-public class OwnerOnlyRelatedCorrelationIdProviderId implements CorrelationProvider {
+public class OwnerCorrelationProviderId implements CorrelationProvider {
 
     @Override
     public void applyCorrelation(CorrelationBuilder correlationBuilder, String correlationExpression) {
-        String correlatedDocument = correlationBuilder.getCorrelationAlias();
-        correlationBuilder.correlate(Document.class)
-            .on(correlatedDocument + ".owner.id").inExpressions(correlationExpression)
+        String correlatedPerson = correlationBuilder.getCorrelationAlias();
+        correlationBuilder.correlate(Person.class)
+            .on(correlatedPerson + ".id").inExpressions(correlationExpression)
         .end();
     }
 }

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/general/model/OwnerCorrelationProviderNormal.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/general/model/OwnerCorrelationProviderNormal.java
@@ -16,29 +16,23 @@
 
 package com.blazebit.persistence.view.testsuite.correlation.general.model;
 
-import com.blazebit.persistence.view.IdMapping;
-import com.blazebit.persistence.view.testsuite.subview.model.DocumentRelatedView;
-
-import java.util.Set;
+import com.blazebit.persistence.view.CorrelationBuilder;
+import com.blazebit.persistence.view.CorrelationProvider;
+import com.blazebit.persistence.view.testsuite.entity.Document;
+import com.blazebit.persistence.view.testsuite.entity.Person;
 
 /**
  *
  * @author Christian Beikov
  * @since 1.2.0
  */
-public interface DocumentCorrelationView {
+public class OwnerCorrelationProviderNormal implements CorrelationProvider {
 
-    @IdMapping("id")
-    public Long getId();
-
-    public String getName();
-
-    public Set<Long> getOwnerRelatedDocumentIds();
-
-    public Set<DocumentRelatedView> getOwnerRelatedDocuments();
-
-    public Set<Long> getOwnerOnlyRelatedDocumentIds();
-
-    public Set<DocumentRelatedView> getOwnerOnlyRelatedDocuments();
-
+    @Override
+    public void applyCorrelation(CorrelationBuilder correlationBuilder, String correlationExpression) {
+        String correlatedPerson = correlationBuilder.getCorrelationAlias();
+        correlationBuilder.correlate(Person.class)
+            .on(correlatedPerson).inExpressions(correlationExpression)
+        .end();
+    }
 }

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/general/model/ThisCorrelationProviderNormal.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/general/model/ThisCorrelationProviderNormal.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2014 - 2017 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.view.testsuite.correlation.general.model;
+
+import com.blazebit.persistence.view.CorrelationBuilder;
+import com.blazebit.persistence.view.CorrelationProvider;
+import com.blazebit.persistence.view.testsuite.entity.Document;
+
+/**
+ *
+ * @author Christian Beikov
+ * @since 1.2.0
+ */
+public class ThisCorrelationProviderNormal implements CorrelationProvider {
+
+    @Override
+    public void applyCorrelation(CorrelationBuilder correlationBuilder, String correlationExpression) {
+        String correlatedDocument = correlationBuilder.getCorrelationAlias();
+        correlationBuilder.correlate(Document.class)
+            .on(correlatedDocument).inExpressions(correlationExpression)
+        .end();
+    }
+}

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/model/DocumentCorrelationView.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/model/DocumentCorrelationView.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2014 - 2017 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.view.testsuite.correlation.model;
+
+import com.blazebit.persistence.view.IdMapping;
+import com.blazebit.persistence.view.testsuite.entity.Document;
+import com.blazebit.persistence.view.testsuite.entity.Person;
+
+import java.util.Set;
+
+/**
+ *
+ * @author Christian Beikov
+ * @since 1.2.0
+ */
+public interface DocumentCorrelationView {
+
+    @IdMapping("id")
+    public Long getId();
+
+    public String getName();
+
+    public Long getCorrelatedOwnerId();
+
+    public Person getCorrelatedOwner();
+
+    public SimplePersonCorrelatedSubView getCorrelatedOwnerView();
+
+    public Set<Long> getCorrelatedOwnerIdList();
+
+    public Set<Person> getCorrelatedOwnerList();
+
+    public Set<SimplePersonCorrelatedSubView> getCorrelatedOwnerViewList();
+
+    public Set<Long> getOwnerRelatedDocumentIds();
+
+    public Set<Document> getOwnerRelatedDocuments();
+
+    public Set<SimpleDocumentCorrelatedView> getOwnerRelatedDocumentViews();
+
+    public Set<Long> getOwnerOnlyRelatedDocumentIds();
+
+    public Set<Document> getOwnerOnlyRelatedDocuments();
+
+    public Set<SimpleDocumentCorrelatedView> getOwnerOnlyRelatedDocumentViews();
+
+    public Long getThisCorrelatedId();
+
+    public Document getThisCorrelatedEntity();
+
+    public SimpleDocumentCorrelatedView getThisCorrelatedView();
+
+    public Set<Long> getThisCorrelatedIdList();
+
+    public Set<Document> getThisCorrelatedEntityList();
+
+    public Set<SimpleDocumentCorrelatedView> getThisCorrelatedViewList();
+
+}

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/model/SimpleDocumentCorrelatedView.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/model/SimpleDocumentCorrelatedView.java
@@ -14,25 +14,29 @@
  * limitations under the License.
  */
 
-package com.blazebit.persistence.view.testsuite.correlation.general.model;
+package com.blazebit.persistence.view.testsuite.correlation.model;
 
-import com.blazebit.persistence.view.CorrelationBuilder;
-import com.blazebit.persistence.view.CorrelationProvider;
+import com.blazebit.persistence.view.EntityView;
+import com.blazebit.persistence.view.IdMapping;
 import com.blazebit.persistence.view.testsuite.entity.Document;
+
+import java.util.Set;
 
 /**
  *
  * @author Christian Beikov
  * @since 1.2.0
  */
-public class OwnerRelatedCorrelationIdProviderNormal implements CorrelationProvider {
+@EntityView(Document.class)
+public interface SimpleDocumentCorrelatedView {
+    
+    @IdMapping("id")
+    public Long getId();
 
-    @Override
-    public void applyCorrelation(CorrelationBuilder correlationBuilder, String correlationExpression) {
-        String correlatedDocument = correlationBuilder.getCorrelationAlias();
-        correlationBuilder.correlate(Document.class)
-            .on(correlatedDocument + ".owner").inExpressions(correlationExpression)
-            .on(correlatedDocument).notInExpressions("VIEW_ROOT()")
-        .end();
-    }
+    public String getName();
+
+    public SimplePersonCorrelatedSubView getOwner();
+
+    public Set<SimplePersonCorrelatedSubView> getPartners();
+
 }

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/model/SimplePersonCorrelatedSubView.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/model/SimplePersonCorrelatedSubView.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014 - 2017 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.view.testsuite.correlation.model;
+
+import com.blazebit.persistence.view.AttributeFilter;
+import com.blazebit.persistence.view.EntityView;
+import com.blazebit.persistence.view.IdMapping;
+import com.blazebit.persistence.view.Mapping;
+import com.blazebit.persistence.view.filter.ContainsFilter;
+import com.blazebit.persistence.view.testsuite.entity.Person;
+
+/**
+ *
+ * @author Christian Beikov
+ * @since 1.2.0
+ */
+@EntityView(Person.class)
+public interface SimplePersonCorrelatedSubView {
+    
+    @IdMapping("id")
+    public Long getId();
+
+    @Mapping("UPPER(name)")
+    @AttributeFilter(ContainsFilter.class)
+    public String getName();
+}

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/simple/SimpleCorrelationTest.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/simple/SimpleCorrelationTest.java
@@ -16,7 +16,6 @@
 
 package com.blazebit.persistence.view.testsuite.correlation.simple;
 
-import com.blazebit.persistence.CriteriaBuilder;
 import com.blazebit.persistence.testsuite.base.category.NoDatanucleus;
 import com.blazebit.persistence.testsuite.base.category.NoDatanucleus4;
 import com.blazebit.persistence.testsuite.base.category.NoEclipselink;
@@ -24,87 +23,22 @@ import com.blazebit.persistence.testsuite.base.category.NoHibernate42;
 import com.blazebit.persistence.testsuite.base.category.NoHibernate43;
 import com.blazebit.persistence.testsuite.base.category.NoHibernate50;
 import com.blazebit.persistence.testsuite.base.category.NoOpenJPA;
-import com.blazebit.persistence.testsuite.tx.TxVoidWork;
-import com.blazebit.persistence.view.EntityViewManager;
-import com.blazebit.persistence.view.EntityViewSetting;
-import com.blazebit.persistence.view.EntityViews;
-import com.blazebit.persistence.view.impl.ConfigurationProperties;
-import com.blazebit.persistence.view.spi.EntityViewConfiguration;
-import com.blazebit.persistence.view.testsuite.AbstractEntityViewTest;
-import com.blazebit.persistence.view.testsuite.correlation.simple.model.DocumentSimpleCorrelationView;
+import com.blazebit.persistence.view.testsuite.correlation.AbstractCorrelationTest;
 import com.blazebit.persistence.view.testsuite.correlation.simple.model.DocumentSimpleCorrelationViewJoinId;
 import com.blazebit.persistence.view.testsuite.correlation.simple.model.DocumentSimpleCorrelationViewJoinNormal;
 import com.blazebit.persistence.view.testsuite.correlation.simple.model.DocumentSimpleCorrelationViewSubqueryId;
 import com.blazebit.persistence.view.testsuite.correlation.simple.model.DocumentSimpleCorrelationViewSubqueryNormal;
 import com.blazebit.persistence.view.testsuite.correlation.simple.model.DocumentSimpleCorrelationViewSubselectId;
 import com.blazebit.persistence.view.testsuite.correlation.simple.model.DocumentSimpleCorrelationViewSubselectNormal;
-import com.blazebit.persistence.view.testsuite.entity.Document;
-import com.blazebit.persistence.view.testsuite.entity.Person;
-import com.blazebit.persistence.view.testsuite.subview.model.DocumentRelatedView;
-import com.blazebit.persistence.view.testsuite.subview.model.SimplePersonSubView;
-import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-
-import javax.persistence.EntityManager;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  *
  * @author Christian Beikov
  * @since 1.2.0
  */
-public class SimpleCorrelationTest extends AbstractEntityViewTest {
-
-    private Document doc1;
-    private Document doc2;
-    private Document doc3;
-    private Document doc4;
-
-    @Override
-    public void setUpOnce() {
-        cleanDatabase();
-        transactional(new TxVoidWork() {
-            @Override
-            public void work(EntityManager em) {
-            doc1 = new Document("doc1");
-            doc2 = new Document("doc2");
-            doc3 = new Document("doc3");
-            doc4 = new Document("doc4");
-
-            Person o1 = new Person("pers1");
-            Person o2 = new Person("pers2");
-            Person o3 = new Person("pers3");
-
-            doc1.setOwner(o1);
-            doc2.setOwner(o2);
-            doc3.setOwner(o2);
-            doc4.setOwner(o2);
-
-            em.persist(o1);
-            em.persist(o2);
-            em.persist(o3);
-
-            em.persist(doc1);
-            em.persist(doc2);
-            em.persist(doc3);
-            em.persist(doc4);
-            }
-        });
-    }
-
-    @Before
-    public void setUp() {
-        doc1 = cbf.create(em, Document.class).where("name").eq("doc1").getSingleResult();
-        doc2 = cbf.create(em, Document.class).where("name").eq("doc2").getSingleResult();
-        doc3 = cbf.create(em, Document.class).where("name").eq("doc3").getSingleResult();
-        doc4 = cbf.create(em, Document.class).where("name").eq("doc4").getSingleResult();
-    }
+public class SimpleCorrelationTest extends AbstractCorrelationTest {
 
     @Test
     // NOTE: Datenucleus issue: https://github.com/datanucleus/datanucleus-api-jpa/issues/77
@@ -114,48 +48,50 @@ public class SimpleCorrelationTest extends AbstractEntityViewTest {
     }
 
     @Test
+    // NOTE: Datenucleus issue: https://github.com/datanucleus/datanucleus-api-jpa/issues/77
+    @Category({ NoDatanucleus.class })
     public void testSubqueryCorrelationId() {
         testCorrelation(DocumentSimpleCorrelationViewSubqueryId.class, null);
     }
 
     @Test
     // NOTE: Requires values clause which currently is only available for Hibernate
-    @Category({ NoHibernate42.class, NoHibernate43.class, NoHibernate50.class, NoDatanucleus4.class, NoDatanucleus.class, NoOpenJPA.class, NoEclipselink.class})
+    @Category({ NoDatanucleus4.class, NoDatanucleus.class, NoOpenJPA.class, NoEclipselink.class})
     public void testSubqueryBatchedCorrelationNormalSize2() {
         testCorrelation(DocumentSimpleCorrelationViewSubqueryNormal.class, 2);
     }
 
     @Test
     // NOTE: Requires values clause which currently is only available for Hibernate
-    @Category({ NoHibernate42.class, NoHibernate43.class, NoHibernate50.class, NoDatanucleus4.class, NoDatanucleus.class, NoOpenJPA.class, NoEclipselink.class})
+    @Category({ NoDatanucleus4.class, NoDatanucleus.class, NoOpenJPA.class, NoEclipselink.class})
     public void testSubqueryBatchedCorrelationIdSize2() {
         testCorrelation(DocumentSimpleCorrelationViewSubqueryId.class, 2);
     }
 
     @Test
     // NOTE: Requires values clause which currently is only available for Hibernate
-    @Category({ NoHibernate42.class, NoHibernate43.class, NoHibernate50.class, NoDatanucleus4.class, NoDatanucleus.class, NoOpenJPA.class, NoEclipselink.class})
+    @Category({ NoDatanucleus4.class, NoDatanucleus.class, NoOpenJPA.class, NoEclipselink.class})
     public void testSubqueryBatchedCorrelationNormalSize4() {
         testCorrelation(DocumentSimpleCorrelationViewSubqueryNormal.class, 4);
     }
 
     @Test
     // NOTE: Requires values clause which currently is only available for Hibernate
-    @Category({ NoHibernate42.class, NoHibernate43.class, NoHibernate50.class, NoDatanucleus4.class, NoDatanucleus.class, NoOpenJPA.class, NoEclipselink.class})
+    @Category({ NoDatanucleus4.class, NoDatanucleus.class, NoOpenJPA.class, NoEclipselink.class})
     public void testSubqueryBatchedCorrelationIdSize4() {
         testCorrelation(DocumentSimpleCorrelationViewSubqueryId.class, 4);
     }
 
     @Test
     // NOTE: Requires values clause which currently is only available for Hibernate
-    @Category({ NoHibernate42.class, NoHibernate43.class, NoHibernate50.class, NoDatanucleus.class, NoOpenJPA.class, NoEclipselink.class})
+    @Category({ NoDatanucleus.class, NoOpenJPA.class, NoEclipselink.class})
     public void testSubqueryBatchedCorrelationNormalSize20() {
         testCorrelation(DocumentSimpleCorrelationViewSubqueryNormal.class, 20);
     }
 
     @Test
     // NOTE: Requires values clause which currently is only available for Hibernate
-    @Category({ NoHibernate42.class, NoHibernate43.class, NoHibernate50.class, NoDatanucleus.class, NoOpenJPA.class, NoEclipselink.class})
+    @Category({ NoDatanucleus.class, NoOpenJPA.class, NoEclipselink.class})
     public void testSubqueryBatchedCorrelationIdSize20() {
         testCorrelation(DocumentSimpleCorrelationViewSubqueryId.class, 20);
     }
@@ -189,103 +125,4 @@ public class SimpleCorrelationTest extends AbstractEntityViewTest {
         testCorrelation(DocumentSimpleCorrelationViewJoinId.class, null);
     }
 
-    private <T extends DocumentSimpleCorrelationView> void testCorrelation(Class<T> entityView, Integer batchSize) {
-        EntityViewConfiguration cfg = EntityViews.createDefaultConfiguration();
-        cfg.addEntityView(entityView);
-        cfg.addEntityView(DocumentRelatedView.class);
-        cfg.addEntityView(SimplePersonSubView.class);
-        EntityViewManager evm = cfg.createEntityViewManager(cbf);
-
-        CriteriaBuilder<Document> criteria = cbf.create(em, Document.class, "d").orderByAsc("id");
-        EntityViewSetting<T, CriteriaBuilder<T>> setting = EntityViewSetting.create(entityView);
-        if (batchSize != null) {
-            setting.setProperty(ConfigurationProperties.DEFAULT_BATCH_SIZE + ".ownerRelatedDocumentIds", batchSize);
-        }
-        CriteriaBuilder<T> cb = evm.applySetting(setting, criteria);
-        List<T> results = cb.getResultList();
-
-        assertEquals(4, results.size());
-        // Doc1
-        assertEquals(doc1.getName(), results.get(0).getName());
-        assertEquals(0, results.get(0).getOwnerRelatedDocuments().size());
-        assertEquals(0, results.get(0).getOwnerRelatedDocumentIds().size());
-
-        assertEquals(1, results.get(0).getOwnerOnlyRelatedDocuments().size());
-        assertRemovedByName(doc1.getName(), results.get(0).getOwnerOnlyRelatedDocuments());
-        assertEquals(1, results.get(0).getOwnerOnlyRelatedDocumentIds().size());
-        assertRemoved(doc1.getId(), results.get(0).getOwnerOnlyRelatedDocumentIds());
-
-        // Doc2
-        assertEquals(doc2.getName(), results.get(1).getName());
-        assertEquals(2, results.get(1).getOwnerRelatedDocuments().size());
-        assertRemovedByName(doc3.getName(), results.get(1).getOwnerRelatedDocuments());
-        assertRemovedByName(doc4.getName(), results.get(1).getOwnerRelatedDocuments());
-        assertEquals(2, results.get(1).getOwnerRelatedDocumentIds().size());
-        assertRemoved(doc3.getId(), results.get(1).getOwnerRelatedDocumentIds());
-        assertRemoved(doc4.getId(), results.get(1).getOwnerRelatedDocumentIds());
-
-        assertEquals(3, results.get(1).getOwnerOnlyRelatedDocuments().size());
-        assertRemovedByName(doc2.getName(), results.get(1).getOwnerOnlyRelatedDocuments());
-        assertRemovedByName(doc3.getName(), results.get(1).getOwnerOnlyRelatedDocuments());
-        assertRemovedByName(doc4.getName(), results.get(1).getOwnerOnlyRelatedDocuments());
-        assertEquals(3, results.get(1).getOwnerOnlyRelatedDocumentIds().size());
-        assertRemoved(doc2.getId(), results.get(1).getOwnerOnlyRelatedDocumentIds());
-        assertRemoved(doc3.getId(), results.get(1).getOwnerOnlyRelatedDocumentIds());
-        assertRemoved(doc4.getId(), results.get(1).getOwnerOnlyRelatedDocumentIds());
-
-        // Doc3
-        assertEquals(doc3.getName(), results.get(2).getName());
-        assertEquals(2, results.get(2).getOwnerRelatedDocuments().size());
-        assertRemovedByName(doc2.getName(), results.get(2).getOwnerRelatedDocuments());
-        assertRemovedByName(doc4.getName(), results.get(2).getOwnerRelatedDocuments());
-        assertEquals(2, results.get(2).getOwnerRelatedDocumentIds().size());
-        assertRemoved(doc2.getId(), results.get(2).getOwnerRelatedDocumentIds());
-        assertRemoved(doc4.getId(), results.get(2).getOwnerRelatedDocumentIds());
-
-        assertEquals(3, results.get(2).getOwnerOnlyRelatedDocuments().size());
-        assertRemovedByName(doc2.getName(), results.get(2).getOwnerOnlyRelatedDocuments());
-        assertRemovedByName(doc3.getName(), results.get(2).getOwnerOnlyRelatedDocuments());
-        assertRemovedByName(doc4.getName(), results.get(2).getOwnerOnlyRelatedDocuments());
-        assertEquals(3, results.get(2).getOwnerOnlyRelatedDocumentIds().size());
-        assertRemoved(doc2.getId(), results.get(2).getOwnerOnlyRelatedDocumentIds());
-        assertRemoved(doc3.getId(), results.get(2).getOwnerOnlyRelatedDocumentIds());
-        assertRemoved(doc4.getId(), results.get(2).getOwnerOnlyRelatedDocumentIds());
-
-        // Doc4
-        assertEquals(doc4.getName(), results.get(3).getName());
-        assertEquals(2, results.get(3).getOwnerRelatedDocuments().size());
-        assertRemovedByName(doc2.getName(), results.get(3).getOwnerRelatedDocuments());
-        assertRemovedByName(doc3.getName(), results.get(3).getOwnerRelatedDocuments());
-        assertEquals(2, results.get(3).getOwnerRelatedDocumentIds().size());
-        assertRemoved(doc2.getId(), results.get(3).getOwnerRelatedDocumentIds());
-        assertRemoved(doc3.getId(), results.get(3).getOwnerRelatedDocumentIds());
-
-        assertEquals(3, results.get(3).getOwnerOnlyRelatedDocuments().size());
-        assertRemovedByName(doc2.getName(), results.get(3).getOwnerOnlyRelatedDocuments());
-        assertRemovedByName(doc3.getName(), results.get(3).getOwnerOnlyRelatedDocuments());
-        assertRemovedByName(doc4.getName(), results.get(3).getOwnerOnlyRelatedDocuments());
-        assertEquals(3, results.get(3).getOwnerOnlyRelatedDocumentIds().size());
-        assertRemoved(doc2.getId(), results.get(3).getOwnerOnlyRelatedDocumentIds());
-        assertRemoved(doc3.getId(), results.get(3).getOwnerOnlyRelatedDocumentIds());
-        assertRemoved(doc4.getId(), results.get(3).getOwnerOnlyRelatedDocumentIds());
-    }
-
-    private void assertRemovedByName(String expectedName, Collection<DocumentRelatedView> views) {
-        Iterator<DocumentRelatedView> iter = views.iterator();
-        while (iter.hasNext()) {
-            DocumentRelatedView v = iter.next();
-            if (expectedName.equals(v.getName())) {
-                iter.remove();
-                return;
-            }
-        }
-
-        Assert.fail("Could not find '" + expectedName + "' in: " + views);
-    }
-
-    private <T> void assertRemoved(T expectedValue, Collection<T> collection) {
-        if (!collection.remove(expectedValue)) {
-            Assert.fail("Could not find '" + expectedValue + "' in: " + collection);
-        }
-    }
 }

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/simple/model/DocumentSimpleCorrelationViewJoinId.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/simple/model/DocumentSimpleCorrelationViewJoinId.java
@@ -19,8 +19,11 @@ package com.blazebit.persistence.view.testsuite.correlation.simple.model;
 import com.blazebit.persistence.view.EntityView;
 import com.blazebit.persistence.view.FetchStrategy;
 import com.blazebit.persistence.view.MappingCorrelatedSimple;
+import com.blazebit.persistence.view.testsuite.correlation.model.DocumentCorrelationView;
+import com.blazebit.persistence.view.testsuite.correlation.model.SimpleDocumentCorrelatedView;
+import com.blazebit.persistence.view.testsuite.correlation.model.SimplePersonCorrelatedSubView;
 import com.blazebit.persistence.view.testsuite.entity.Document;
-import com.blazebit.persistence.view.testsuite.subview.model.DocumentRelatedView;
+import com.blazebit.persistence.view.testsuite.entity.Person;
 
 import java.util.Set;
 
@@ -33,18 +36,60 @@ import java.util.Set;
  * @since 1.2.0
  */
 @EntityView(Document.class)
-public interface DocumentSimpleCorrelationViewJoinId extends DocumentSimpleCorrelationView {
+public interface DocumentSimpleCorrelationViewJoinId extends DocumentCorrelationView {
+
+    @MappingCorrelatedSimple(correlationBasis = "owner.id", correlationResult = "id", correlated = Person.class, correlationExpression = "id IN correlationKey", fetch = FetchStrategy.JOIN)
+    public Long getCorrelatedOwnerId();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner.id", correlated = Person.class, correlationExpression = "id IN correlationKey", fetch = FetchStrategy.JOIN)
+    public Person getCorrelatedOwner();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner.id", correlated = Person.class, correlationExpression = "id IN correlationKey", fetch = FetchStrategy.JOIN)
+    public SimplePersonCorrelatedSubView getCorrelatedOwnerView();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner.id", correlationResult = "id", correlated = Person.class, correlationExpression = "id IN correlationKey", fetch = FetchStrategy.JOIN)
+    public Set<Long> getCorrelatedOwnerIdList();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner.id", correlated = Person.class, correlationExpression = "id IN correlationKey", fetch = FetchStrategy.JOIN)
+    public Set<Person> getCorrelatedOwnerList();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner.id", correlated = Person.class, correlationExpression = "id IN correlationKey", fetch = FetchStrategy.JOIN)
+    public Set<SimplePersonCorrelatedSubView> getCorrelatedOwnerViewList();
 
     @MappingCorrelatedSimple(correlationBasis = "owner.id", correlationResult = "id", correlated = Document.class, correlationExpression = "owner.id IN correlationKey AND id NOT IN VIEW_ROOT(id)", fetch = FetchStrategy.JOIN)
     public Set<Long> getOwnerRelatedDocumentIds();
 
     @MappingCorrelatedSimple(correlationBasis = "owner.id", correlated = Document.class, correlationExpression = "owner.id IN correlationKey AND id NOT IN VIEW_ROOT(id)", fetch = FetchStrategy.JOIN)
-    public Set<DocumentRelatedView> getOwnerRelatedDocuments();
+    public Set<Document> getOwnerRelatedDocuments();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner.id", correlated = Document.class, correlationExpression = "owner.id IN correlationKey AND id NOT IN VIEW_ROOT(id)", fetch = FetchStrategy.JOIN)
+    public Set<SimpleDocumentCorrelatedView> getOwnerRelatedDocumentViews();
 
     @MappingCorrelatedSimple(correlationBasis = "owner.id", correlationResult = "id", correlated = Document.class, correlationExpression = "owner.id IN correlationKey", fetch = FetchStrategy.JOIN)
     public Set<Long> getOwnerOnlyRelatedDocumentIds();
 
     @MappingCorrelatedSimple(correlationBasis = "owner.id", correlated = Document.class, correlationExpression = "owner.id IN correlationKey", fetch = FetchStrategy.JOIN)
-    public Set<DocumentRelatedView> getOwnerOnlyRelatedDocuments();
+    public Set<Document> getOwnerOnlyRelatedDocuments();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner.id", correlated = Document.class, correlationExpression = "owner.id IN correlationKey", fetch = FetchStrategy.JOIN)
+    public Set<SimpleDocumentCorrelatedView> getOwnerOnlyRelatedDocumentViews();
+
+    @MappingCorrelatedSimple(correlationBasis = "this", correlationResult = "id", correlated = Document.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.JOIN)
+    public Long getThisCorrelatedId();
+
+    @MappingCorrelatedSimple(correlationBasis = "this", correlated = Document.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.JOIN)
+    public Document getThisCorrelatedEntity();
+
+    @MappingCorrelatedSimple(correlationBasis = "this", correlated = Document.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.JOIN)
+    public SimpleDocumentCorrelatedView getThisCorrelatedView();
+
+    @MappingCorrelatedSimple(correlationBasis = "this", correlationResult = "id", correlated = Document.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.JOIN)
+    public Set<Long> getThisCorrelatedIdList();
+
+    @MappingCorrelatedSimple(correlationBasis = "this", correlated = Document.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.JOIN)
+    public Set<Document> getThisCorrelatedEntityList();
+
+    @MappingCorrelatedSimple(correlationBasis = "this", correlated = Document.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.JOIN)
+    public Set<SimpleDocumentCorrelatedView> getThisCorrelatedViewList();
 
 }

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/simple/model/DocumentSimpleCorrelationViewJoinNormal.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/simple/model/DocumentSimpleCorrelationViewJoinNormal.java
@@ -19,8 +19,11 @@ package com.blazebit.persistence.view.testsuite.correlation.simple.model;
 import com.blazebit.persistence.view.EntityView;
 import com.blazebit.persistence.view.FetchStrategy;
 import com.blazebit.persistence.view.MappingCorrelatedSimple;
+import com.blazebit.persistence.view.testsuite.correlation.model.DocumentCorrelationView;
+import com.blazebit.persistence.view.testsuite.correlation.model.SimpleDocumentCorrelatedView;
+import com.blazebit.persistence.view.testsuite.correlation.model.SimplePersonCorrelatedSubView;
 import com.blazebit.persistence.view.testsuite.entity.Document;
-import com.blazebit.persistence.view.testsuite.subview.model.DocumentRelatedView;
+import com.blazebit.persistence.view.testsuite.entity.Person;
 
 import java.util.Set;
 
@@ -32,18 +35,60 @@ import java.util.Set;
  * @since 1.2.0
  */
 @EntityView(Document.class)
-public interface DocumentSimpleCorrelationViewJoinNormal extends DocumentSimpleCorrelationView {
+public interface DocumentSimpleCorrelationViewJoinNormal extends DocumentCorrelationView {
+
+    @MappingCorrelatedSimple(correlationBasis = "owner", correlationResult = "id", correlated = Person.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.JOIN)
+    public Long getCorrelatedOwnerId();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner", correlated = Person.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.JOIN)
+    public Person getCorrelatedOwner();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner", correlated = Person.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.JOIN)
+    public SimplePersonCorrelatedSubView getCorrelatedOwnerView();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner", correlationResult = "id", correlated = Person.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.JOIN)
+    public Set<Long> getCorrelatedOwnerIdList();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner", correlated = Person.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.JOIN)
+    public Set<Person> getCorrelatedOwnerList();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner", correlated = Person.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.JOIN)
+    public Set<SimplePersonCorrelatedSubView> getCorrelatedOwnerViewList();
 
     @MappingCorrelatedSimple(correlationBasis = "owner", correlationResult = "id", correlated = Document.class, correlationExpression = "owner IN correlationKey AND id NOT IN VIEW_ROOT(id)", fetch = FetchStrategy.JOIN)
     public Set<Long> getOwnerRelatedDocumentIds();
 
     @MappingCorrelatedSimple(correlationBasis = "owner", correlated = Document.class, correlationExpression = "owner IN correlationKey AND id NOT IN VIEW_ROOT(id)", fetch = FetchStrategy.JOIN)
-    public Set<DocumentRelatedView> getOwnerRelatedDocuments();
+    public Set<Document> getOwnerRelatedDocuments();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner", correlated = Document.class, correlationExpression = "owner IN correlationKey AND id NOT IN VIEW_ROOT(id)", fetch = FetchStrategy.JOIN)
+    public Set<SimpleDocumentCorrelatedView> getOwnerRelatedDocumentViews();
 
     @MappingCorrelatedSimple(correlationBasis = "owner", correlationResult = "id", correlated = Document.class, correlationExpression = "owner IN correlationKey", fetch = FetchStrategy.JOIN)
     public Set<Long> getOwnerOnlyRelatedDocumentIds();
 
     @MappingCorrelatedSimple(correlationBasis = "owner", correlated = Document.class, correlationExpression = "owner IN correlationKey", fetch = FetchStrategy.JOIN)
-    public Set<DocumentRelatedView> getOwnerOnlyRelatedDocuments();
+    public Set<Document> getOwnerOnlyRelatedDocuments();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner", correlated = Document.class, correlationExpression = "owner IN correlationKey", fetch = FetchStrategy.JOIN)
+    public Set<SimpleDocumentCorrelatedView> getOwnerOnlyRelatedDocumentViews();
+
+    @MappingCorrelatedSimple(correlationBasis = "this", correlated = Document.class, correlationExpression = "this IN correlationKey", correlationResult = "id", fetch = FetchStrategy.JOIN)
+    public Long getThisCorrelatedId();
+
+    @MappingCorrelatedSimple(correlationBasis = "this", correlated = Document.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.JOIN)
+    public Document getThisCorrelatedEntity();
+
+    @MappingCorrelatedSimple(correlationBasis = "this", correlated = Document.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.JOIN)
+    public SimpleDocumentCorrelatedView getThisCorrelatedView();
+
+    @MappingCorrelatedSimple(correlationBasis = "this", correlated = Document.class, correlationExpression = "this IN correlationKey", correlationResult = "id", fetch = FetchStrategy.JOIN)
+    public Set<Long> getThisCorrelatedIdList();
+
+    @MappingCorrelatedSimple(correlationBasis = "this", correlated = Document.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.JOIN)
+    public Set<Document> getThisCorrelatedEntityList();
+
+    @MappingCorrelatedSimple(correlationBasis = "this", correlated = Document.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.JOIN)
+    public Set<SimpleDocumentCorrelatedView> getThisCorrelatedViewList();
 
 }

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/simple/model/DocumentSimpleCorrelationViewSubqueryId.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/simple/model/DocumentSimpleCorrelationViewSubqueryId.java
@@ -19,8 +19,11 @@ package com.blazebit.persistence.view.testsuite.correlation.simple.model;
 import com.blazebit.persistence.view.EntityView;
 import com.blazebit.persistence.view.FetchStrategy;
 import com.blazebit.persistence.view.MappingCorrelatedSimple;
+import com.blazebit.persistence.view.testsuite.correlation.model.DocumentCorrelationView;
+import com.blazebit.persistence.view.testsuite.correlation.model.SimpleDocumentCorrelatedView;
+import com.blazebit.persistence.view.testsuite.correlation.model.SimplePersonCorrelatedSubView;
 import com.blazebit.persistence.view.testsuite.entity.Document;
-import com.blazebit.persistence.view.testsuite.subview.model.DocumentRelatedView;
+import com.blazebit.persistence.view.testsuite.entity.Person;
 
 import java.util.Set;
 
@@ -33,18 +36,60 @@ import java.util.Set;
  * @since 1.2.0
  */
 @EntityView(Document.class)
-public interface DocumentSimpleCorrelationViewSubqueryId extends DocumentSimpleCorrelationView {
+public interface DocumentSimpleCorrelationViewSubqueryId extends DocumentCorrelationView {
+
+    @MappingCorrelatedSimple(correlationBasis = "owner.id", correlationResult = "id", correlated = Person.class, correlationExpression = "id IN correlationKey", fetch = FetchStrategy.SELECT)
+    public Long getCorrelatedOwnerId();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner.id", correlated = Person.class, correlationExpression = "id IN correlationKey", fetch = FetchStrategy.SELECT)
+    public Person getCorrelatedOwner();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner.id", correlated = Person.class, correlationExpression = "id IN correlationKey", fetch = FetchStrategy.SELECT)
+    public SimplePersonCorrelatedSubView getCorrelatedOwnerView();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner.id", correlationResult = "id", correlated = Person.class, correlationExpression = "id IN correlationKey", fetch = FetchStrategy.SELECT)
+    public Set<Long> getCorrelatedOwnerIdList();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner.id", correlated = Person.class, correlationExpression = "id IN correlationKey", fetch = FetchStrategy.SELECT)
+    public Set<Person> getCorrelatedOwnerList();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner.id", correlated = Person.class, correlationExpression = "id IN correlationKey", fetch = FetchStrategy.SELECT)
+    public Set<SimplePersonCorrelatedSubView> getCorrelatedOwnerViewList();
 
     @MappingCorrelatedSimple(correlationBasis = "owner.id", correlationResult = "id", correlated = Document.class, correlationExpression = "owner.id IN correlationKey AND id NOT IN VIEW_ROOT(id)", fetch = FetchStrategy.SELECT)
     public Set<Long> getOwnerRelatedDocumentIds();
 
     @MappingCorrelatedSimple(correlationBasis = "owner.id", correlated = Document.class, correlationExpression = "owner.id IN correlationKey AND id NOT IN VIEW_ROOT(id)", fetch = FetchStrategy.SELECT)
-    public Set<DocumentRelatedView> getOwnerRelatedDocuments();
+    public Set<Document> getOwnerRelatedDocuments();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner.id", correlated = Document.class, correlationExpression = "owner.id IN correlationKey AND id NOT IN VIEW_ROOT(id)", fetch = FetchStrategy.SELECT)
+    public Set<SimpleDocumentCorrelatedView> getOwnerRelatedDocumentViews();
 
     @MappingCorrelatedSimple(correlationBasis = "owner.id", correlationResult = "id", correlated = Document.class, correlationExpression = "owner.id IN correlationKey", fetch = FetchStrategy.SELECT)
     public Set<Long> getOwnerOnlyRelatedDocumentIds();
 
     @MappingCorrelatedSimple(correlationBasis = "owner.id", correlated = Document.class, correlationExpression = "owner.id IN correlationKey", fetch = FetchStrategy.SELECT)
-    public Set<DocumentRelatedView> getOwnerOnlyRelatedDocuments();
+    public Set<Document> getOwnerOnlyRelatedDocuments();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner.id", correlated = Document.class, correlationExpression = "owner.id IN correlationKey", fetch = FetchStrategy.SELECT)
+    public Set<SimpleDocumentCorrelatedView> getOwnerOnlyRelatedDocumentViews();
+
+    @MappingCorrelatedSimple(correlationBasis = "this", correlationResult = "id", correlated = Document.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.SELECT)
+    public Long getThisCorrelatedId();
+
+    @MappingCorrelatedSimple(correlationBasis = "this", correlated = Document.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.SELECT)
+    public Document getThisCorrelatedEntity();
+
+    @MappingCorrelatedSimple(correlationBasis = "this", correlated = Document.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.SELECT)
+    public SimpleDocumentCorrelatedView getThisCorrelatedView();
+
+    @MappingCorrelatedSimple(correlationBasis = "this", correlationResult = "id", correlated = Document.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.SELECT)
+    public Set<Long> getThisCorrelatedIdList();
+
+    @MappingCorrelatedSimple(correlationBasis = "this", correlated = Document.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.SELECT)
+    public Set<Document> getThisCorrelatedEntityList();
+
+    @MappingCorrelatedSimple(correlationBasis = "this", correlated = Document.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.SELECT)
+    public Set<SimpleDocumentCorrelatedView> getThisCorrelatedViewList();
 
 }

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/simple/model/DocumentSimpleCorrelationViewSubqueryNormal.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/simple/model/DocumentSimpleCorrelationViewSubqueryNormal.java
@@ -19,8 +19,11 @@ package com.blazebit.persistence.view.testsuite.correlation.simple.model;
 import com.blazebit.persistence.view.EntityView;
 import com.blazebit.persistence.view.FetchStrategy;
 import com.blazebit.persistence.view.MappingCorrelatedSimple;
+import com.blazebit.persistence.view.testsuite.correlation.model.DocumentCorrelationView;
+import com.blazebit.persistence.view.testsuite.correlation.model.SimpleDocumentCorrelatedView;
+import com.blazebit.persistence.view.testsuite.correlation.model.SimplePersonCorrelatedSubView;
 import com.blazebit.persistence.view.testsuite.entity.Document;
-import com.blazebit.persistence.view.testsuite.subview.model.DocumentRelatedView;
+import com.blazebit.persistence.view.testsuite.entity.Person;
 
 import java.util.Set;
 
@@ -32,18 +35,60 @@ import java.util.Set;
  * @since 1.2.0
  */
 @EntityView(Document.class)
-public interface DocumentSimpleCorrelationViewSubqueryNormal extends DocumentSimpleCorrelationView {
+public interface DocumentSimpleCorrelationViewSubqueryNormal extends DocumentCorrelationView {
+
+    @MappingCorrelatedSimple(correlationBasis = "owner", correlationResult = "id", correlated = Person.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.SELECT)
+    public Long getCorrelatedOwnerId();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner", correlated = Person.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.SELECT)
+    public Person getCorrelatedOwner();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner", correlated = Person.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.SELECT)
+    public SimplePersonCorrelatedSubView getCorrelatedOwnerView();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner", correlationResult = "id", correlated = Person.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.SELECT)
+    public Set<Long> getCorrelatedOwnerIdList();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner", correlated = Person.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.SELECT)
+    public Set<Person> getCorrelatedOwnerList();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner", correlated = Person.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.SELECT)
+    public Set<SimplePersonCorrelatedSubView> getCorrelatedOwnerViewList();
 
     @MappingCorrelatedSimple(correlationBasis = "owner", correlationResult = "id", correlated = Document.class, correlationExpression = "owner IN correlationKey AND id NOT IN VIEW_ROOT(id)", fetch = FetchStrategy.SELECT)
     public Set<Long> getOwnerRelatedDocumentIds();
 
     @MappingCorrelatedSimple(correlationBasis = "owner", correlated = Document.class, correlationExpression = "owner IN correlationKey AND id NOT IN VIEW_ROOT(id)", fetch = FetchStrategy.SELECT)
-    public Set<DocumentRelatedView> getOwnerRelatedDocuments();
+    public Set<Document> getOwnerRelatedDocuments();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner", correlated = Document.class, correlationExpression = "owner IN correlationKey AND id NOT IN VIEW_ROOT(id)", fetch = FetchStrategy.SELECT)
+    public Set<SimpleDocumentCorrelatedView> getOwnerRelatedDocumentViews();
 
     @MappingCorrelatedSimple(correlationBasis = "owner", correlationResult = "id", correlated = Document.class, correlationExpression = "owner IN correlationKey", fetch = FetchStrategy.SELECT)
     public Set<Long> getOwnerOnlyRelatedDocumentIds();
 
     @MappingCorrelatedSimple(correlationBasis = "owner", correlated = Document.class, correlationExpression = "owner IN correlationKey", fetch = FetchStrategy.SELECT)
-    public Set<DocumentRelatedView> getOwnerOnlyRelatedDocuments();
+    public Set<Document> getOwnerOnlyRelatedDocuments();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner", correlated = Document.class, correlationExpression = "owner IN correlationKey", fetch = FetchStrategy.SELECT)
+    public Set<SimpleDocumentCorrelatedView> getOwnerOnlyRelatedDocumentViews();
+
+    @MappingCorrelatedSimple(correlationBasis = "this", correlated = Document.class, correlationExpression = "this IN correlationKey", correlationResult = "id", fetch = FetchStrategy.SELECT)
+    public Long getThisCorrelatedId();
+
+    @MappingCorrelatedSimple(correlationBasis = "this", correlated = Document.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.SELECT)
+    public Document getThisCorrelatedEntity();
+
+    @MappingCorrelatedSimple(correlationBasis = "this", correlated = Document.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.SELECT)
+    public SimpleDocumentCorrelatedView getThisCorrelatedView();
+
+    @MappingCorrelatedSimple(correlationBasis = "this", correlated = Document.class, correlationExpression = "this IN correlationKey", correlationResult = "id", fetch = FetchStrategy.SELECT)
+    public Set<Long> getThisCorrelatedIdList();
+
+    @MappingCorrelatedSimple(correlationBasis = "this", correlated = Document.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.SELECT)
+    public Set<Document> getThisCorrelatedEntityList();
+
+    @MappingCorrelatedSimple(correlationBasis = "this", correlated = Document.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.SELECT)
+    public Set<SimpleDocumentCorrelatedView> getThisCorrelatedViewList();
 
 }

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/simple/model/DocumentSimpleCorrelationViewSubselectId.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/simple/model/DocumentSimpleCorrelationViewSubselectId.java
@@ -19,8 +19,11 @@ package com.blazebit.persistence.view.testsuite.correlation.simple.model;
 import com.blazebit.persistence.view.EntityView;
 import com.blazebit.persistence.view.FetchStrategy;
 import com.blazebit.persistence.view.MappingCorrelatedSimple;
+import com.blazebit.persistence.view.testsuite.correlation.model.DocumentCorrelationView;
+import com.blazebit.persistence.view.testsuite.correlation.model.SimpleDocumentCorrelatedView;
+import com.blazebit.persistence.view.testsuite.correlation.model.SimplePersonCorrelatedSubView;
 import com.blazebit.persistence.view.testsuite.entity.Document;
-import com.blazebit.persistence.view.testsuite.subview.model.DocumentRelatedView;
+import com.blazebit.persistence.view.testsuite.entity.Person;
 
 import java.util.Set;
 
@@ -33,18 +36,60 @@ import java.util.Set;
  * @since 1.2.0
  */
 @EntityView(Document.class)
-public interface DocumentSimpleCorrelationViewSubselectId extends DocumentSimpleCorrelationView {
+public interface DocumentSimpleCorrelationViewSubselectId extends DocumentCorrelationView {
+
+    @MappingCorrelatedSimple(correlationBasis = "owner.id", correlationResult = "id", correlated = Person.class, correlationExpression = "id IN correlationKey", fetch = FetchStrategy.SUBSELECT)
+    public Long getCorrelatedOwnerId();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner.id", correlated = Person.class, correlationExpression = "id IN correlationKey", fetch = FetchStrategy.SUBSELECT)
+    public Person getCorrelatedOwner();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner.id", correlated = Person.class, correlationExpression = "id IN correlationKey", fetch = FetchStrategy.SUBSELECT)
+    public SimplePersonCorrelatedSubView getCorrelatedOwnerView();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner.id", correlationResult = "id", correlated = Person.class, correlationExpression = "id IN correlationKey", fetch = FetchStrategy.SUBSELECT)
+    public Set<Long> getCorrelatedOwnerIdList();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner.id", correlated = Person.class, correlationExpression = "id IN correlationKey", fetch = FetchStrategy.SUBSELECT)
+    public Set<Person> getCorrelatedOwnerList();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner.id", correlated = Person.class, correlationExpression = "id IN correlationKey", fetch = FetchStrategy.SUBSELECT)
+    public Set<SimplePersonCorrelatedSubView> getCorrelatedOwnerViewList();
 
     @MappingCorrelatedSimple(correlationBasis = "owner.id", correlationResult = "id", correlated = Document.class, correlationExpression = "owner.id IN correlationKey AND id NOT IN VIEW_ROOT(id)", fetch = FetchStrategy.SUBSELECT)
     public Set<Long> getOwnerRelatedDocumentIds();
 
     @MappingCorrelatedSimple(correlationBasis = "owner.id", correlated = Document.class, correlationExpression = "owner.id IN correlationKey AND id NOT IN VIEW_ROOT(id)", fetch = FetchStrategy.SUBSELECT)
-    public Set<DocumentRelatedView> getOwnerRelatedDocuments();
+    public Set<Document> getOwnerRelatedDocuments();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner.id", correlated = Document.class, correlationExpression = "owner.id IN correlationKey AND id NOT IN VIEW_ROOT(id)", fetch = FetchStrategy.SUBSELECT)
+    public Set<SimpleDocumentCorrelatedView> getOwnerRelatedDocumentViews();
 
     @MappingCorrelatedSimple(correlationBasis = "owner.id", correlationResult = "id", correlated = Document.class, correlationExpression = "owner.id IN correlationKey", fetch = FetchStrategy.SUBSELECT)
     public Set<Long> getOwnerOnlyRelatedDocumentIds();
 
     @MappingCorrelatedSimple(correlationBasis = "owner.id", correlated = Document.class, correlationExpression = "owner.id IN correlationKey", fetch = FetchStrategy.SUBSELECT)
-    public Set<DocumentRelatedView> getOwnerOnlyRelatedDocuments();
+    public Set<Document> getOwnerOnlyRelatedDocuments();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner.id", correlated = Document.class, correlationExpression = "owner.id IN correlationKey", fetch = FetchStrategy.SUBSELECT)
+    public Set<SimpleDocumentCorrelatedView> getOwnerOnlyRelatedDocumentViews();
+
+    @MappingCorrelatedSimple(correlationBasis = "this", correlationResult = "id", correlated = Document.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.SUBSELECT)
+    public Long getThisCorrelatedId();
+
+    @MappingCorrelatedSimple(correlationBasis = "this", correlated = Document.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.SUBSELECT)
+    public Document getThisCorrelatedEntity();
+
+    @MappingCorrelatedSimple(correlationBasis = "this", correlated = Document.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.SUBSELECT)
+    public SimpleDocumentCorrelatedView getThisCorrelatedView();
+
+    @MappingCorrelatedSimple(correlationBasis = "this", correlationResult = "id", correlated = Document.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.SUBSELECT)
+    public Set<Long> getThisCorrelatedIdList();
+
+    @MappingCorrelatedSimple(correlationBasis = "this", correlated = Document.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.SUBSELECT)
+    public Set<Document> getThisCorrelatedEntityList();
+
+    @MappingCorrelatedSimple(correlationBasis = "this", correlated = Document.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.SUBSELECT)
+    public Set<SimpleDocumentCorrelatedView> getThisCorrelatedViewList();
 
 }

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/simple/model/DocumentSimpleCorrelationViewSubselectNormal.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/correlation/simple/model/DocumentSimpleCorrelationViewSubselectNormal.java
@@ -19,8 +19,11 @@ package com.blazebit.persistence.view.testsuite.correlation.simple.model;
 import com.blazebit.persistence.view.EntityView;
 import com.blazebit.persistence.view.FetchStrategy;
 import com.blazebit.persistence.view.MappingCorrelatedSimple;
+import com.blazebit.persistence.view.testsuite.correlation.model.DocumentCorrelationView;
+import com.blazebit.persistence.view.testsuite.correlation.model.SimpleDocumentCorrelatedView;
+import com.blazebit.persistence.view.testsuite.correlation.model.SimplePersonCorrelatedSubView;
 import com.blazebit.persistence.view.testsuite.entity.Document;
-import com.blazebit.persistence.view.testsuite.subview.model.DocumentRelatedView;
+import com.blazebit.persistence.view.testsuite.entity.Person;
 
 import java.util.Set;
 
@@ -32,18 +35,60 @@ import java.util.Set;
  * @since 1.2.0
  */
 @EntityView(Document.class)
-public interface DocumentSimpleCorrelationViewSubselectNormal extends DocumentSimpleCorrelationView {
+public interface DocumentSimpleCorrelationViewSubselectNormal extends DocumentCorrelationView {
+
+    @MappingCorrelatedSimple(correlationBasis = "owner", correlationResult = "id", correlated = Person.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.SUBSELECT)
+    public Long getCorrelatedOwnerId();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner", correlated = Person.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.SUBSELECT)
+    public Person getCorrelatedOwner();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner", correlated = Person.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.SUBSELECT)
+    public SimplePersonCorrelatedSubView getCorrelatedOwnerView();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner", correlationResult = "id", correlated = Person.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.SUBSELECT)
+    public Set<Long> getCorrelatedOwnerIdList();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner", correlated = Person.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.SUBSELECT)
+    public Set<Person> getCorrelatedOwnerList();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner", correlated = Person.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.SUBSELECT)
+    public Set<SimplePersonCorrelatedSubView> getCorrelatedOwnerViewList();
 
     @MappingCorrelatedSimple(correlationBasis = "owner", correlationResult = "id", correlated = Document.class, correlationExpression = "owner IN correlationKey AND id NOT IN VIEW_ROOT(id)", fetch = FetchStrategy.SUBSELECT)
     public Set<Long> getOwnerRelatedDocumentIds();
 
     @MappingCorrelatedSimple(correlationBasis = "owner", correlated = Document.class, correlationExpression = "owner IN correlationKey AND id NOT IN VIEW_ROOT(id)", fetch = FetchStrategy.SUBSELECT)
-    public Set<DocumentRelatedView> getOwnerRelatedDocuments();
+    public Set<Document> getOwnerRelatedDocuments();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner", correlated = Document.class, correlationExpression = "owner IN correlationKey AND id NOT IN VIEW_ROOT(id)", fetch = FetchStrategy.SUBSELECT)
+    public Set<SimpleDocumentCorrelatedView> getOwnerRelatedDocumentViews();
 
     @MappingCorrelatedSimple(correlationBasis = "owner", correlationResult = "id", correlated = Document.class, correlationExpression = "owner IN correlationKey", fetch = FetchStrategy.SUBSELECT)
     public Set<Long> getOwnerOnlyRelatedDocumentIds();
 
     @MappingCorrelatedSimple(correlationBasis = "owner", correlated = Document.class, correlationExpression = "owner IN correlationKey", fetch = FetchStrategy.SUBSELECT)
-    public Set<DocumentRelatedView> getOwnerOnlyRelatedDocuments();
+    public Set<Document> getOwnerOnlyRelatedDocuments();
+
+    @MappingCorrelatedSimple(correlationBasis = "owner", correlated = Document.class, correlationExpression = "owner IN correlationKey", fetch = FetchStrategy.SUBSELECT)
+    public Set<SimpleDocumentCorrelatedView> getOwnerOnlyRelatedDocumentViews();
+
+    @MappingCorrelatedSimple(correlationBasis = "this", correlated = Document.class, correlationExpression = "this IN correlationKey", correlationResult = "id", fetch = FetchStrategy.SUBSELECT)
+    public Long getThisCorrelatedId();
+
+    @MappingCorrelatedSimple(correlationBasis = "this", correlated = Document.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.SUBSELECT)
+    public Document getThisCorrelatedEntity();
+
+    @MappingCorrelatedSimple(correlationBasis = "this", correlated = Document.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.SUBSELECT)
+    public SimpleDocumentCorrelatedView getThisCorrelatedView();
+
+    @MappingCorrelatedSimple(correlationBasis = "this", correlated = Document.class, correlationExpression = "this IN correlationKey", correlationResult = "id", fetch = FetchStrategy.SUBSELECT)
+    public Set<Long> getThisCorrelatedIdList();
+
+    @MappingCorrelatedSimple(correlationBasis = "this", correlated = Document.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.SUBSELECT)
+    public Set<Document> getThisCorrelatedEntityList();
+
+    @MappingCorrelatedSimple(correlationBasis = "this", correlated = Document.class, correlationExpression = "this IN correlationKey", fetch = FetchStrategy.SUBSELECT)
+    public Set<SimpleDocumentCorrelatedView> getThisCorrelatedViewList();
 
 }

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/embedded/AbstractEmbeddedMappingTest.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/embedded/AbstractEmbeddedMappingTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2014 - 2017 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.view.testsuite.embedded;
+
+import com.blazebit.persistence.testsuite.tx.TxVoidWork;
+import com.blazebit.persistence.view.testsuite.AbstractEntityViewTest;
+import com.blazebit.persistence.view.testsuite.entity.Document;
+import com.blazebit.persistence.view.testsuite.entity.Person;
+import org.junit.Before;
+
+import javax.persistence.EntityManager;
+
+/**
+ * @author Christian Beikov
+ * @since 1.2.0
+ */
+public class AbstractEmbeddedMappingTest extends AbstractEntityViewTest {
+
+    protected Document doc1;
+    protected Document doc2;
+
+    @Before
+    public void setUp() {
+        cleanDatabase();
+        transactional(new TxVoidWork() {
+            @Override
+            public void work(EntityManager em) {
+                Person p = new Person("pers");
+                doc1 = new Document("doc1", p);
+                doc2 = new Document("doc2", p);
+
+                em.persist(p);
+                em.persist(doc1);
+                em.persist(doc2);
+            }
+        });
+    }
+}

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/embedded/basic/EmbeddedMappingBasicTest.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/embedded/basic/EmbeddedMappingBasicTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2014 - 2017 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.view.testsuite.embedded.basic;
+
+import com.blazebit.persistence.CriteriaBuilder;
+import com.blazebit.persistence.view.EntityViewManager;
+import com.blazebit.persistence.view.EntityViewSetting;
+import com.blazebit.persistence.view.EntityViews;
+import com.blazebit.persistence.view.spi.EntityViewConfiguration;
+import com.blazebit.persistence.view.testsuite.embedded.AbstractEmbeddedMappingTest;
+import com.blazebit.persistence.view.testsuite.embedded.basic.model.DocumentDetailEmbeddableView;
+import com.blazebit.persistence.view.testsuite.embedded.basic.model.DocumentDetailView;
+import com.blazebit.persistence.view.testsuite.embedded.basic.model.DocumentViewWithEmbedded;
+import com.blazebit.persistence.view.testsuite.entity.Document;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ *
+ * @author Christian Beikov
+ * @since 1.2.0
+ */
+public class EmbeddedMappingBasicTest extends AbstractEmbeddedMappingTest {
+
+    EntityViewManager evm;
+
+    @Before
+    public void prepare() {
+        EntityViewConfiguration cfg = EntityViews.createDefaultConfiguration();
+        cfg.addEntityView(DocumentDetailView.class);
+        cfg.addEntityView(DocumentDetailEmbeddableView.class);
+        cfg.addEntityView(DocumentViewWithEmbedded.class);
+        this.evm = cfg.createEntityViewManager(cbf);
+    }
+
+    @Test
+    public void multipleEmbeddingsProduceCorrectResults() {
+        CriteriaBuilder<Document> criteria = cbf.create(em, Document.class, "e")
+            .orderByAsc("id");
+        EntityViewSetting<DocumentViewWithEmbedded, CriteriaBuilder<DocumentViewWithEmbedded>> setting = EntityViewSetting.create(DocumentViewWithEmbedded.class);
+        CriteriaBuilder<DocumentViewWithEmbedded> cb = evm.applySetting(setting, criteria);
+        List<DocumentViewWithEmbedded> results = cb.getResultList();
+
+        assertEquals(2, results.size());
+
+        assertEquals(doc1.getId(), results.get(0).getId());
+        assertEquals(doc1.getId(), results.get(0).getDetails().getId());
+        assertEquals("doc1", results.get(0).getDetails().getName());
+        assertEquals("doc1", results.get(0).getEmbeddedDetails().getName());
+
+        assertEquals(doc2.getId(), results.get(1).getId());
+        assertEquals(doc2.getId(), results.get(1).getDetails().getId());
+        assertEquals("doc2", results.get(1).getDetails().getName());
+        assertEquals("doc2", results.get(1).getEmbeddedDetails().getName());
+    }
+
+    @Test
+    public void filteringOnEmbeddedAttributeWorks() {
+        CriteriaBuilder<Document> criteria = cbf.create(em, Document.class, "e")
+                .orderByAsc("id");
+        EntityViewSetting<DocumentViewWithEmbedded, CriteriaBuilder<DocumentViewWithEmbedded>> setting = EntityViewSetting.create(DocumentViewWithEmbedded.class);
+        setting.addAttributeFilter("details.name", "doc1");
+        setting.addAttributeFilter("embeddedDetails.name", "doc1");
+        CriteriaBuilder<DocumentViewWithEmbedded> cb = evm.applySetting(setting, criteria);
+        List<DocumentViewWithEmbedded> results = cb.getResultList();
+        assertEquals(1, results.size());
+
+        assertEquals(doc1.getId(), results.get(0).getId());
+        assertEquals(doc1.getId(), results.get(0).getDetails().getId());
+        assertEquals("doc1", results.get(0).getDetails().getName());
+        assertEquals("doc1", results.get(0).getEmbeddedDetails().getName());
+    }
+}

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/embedded/basic/model/DocumentDetailEmbeddableView.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/embedded/basic/model/DocumentDetailEmbeddableView.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014 - 2017 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.view.testsuite.embedded.basic.model;
+
+import com.blazebit.persistence.view.AttributeFilter;
+import com.blazebit.persistence.view.EmbeddableEntityView;
+import com.blazebit.persistence.view.EntityView;
+import com.blazebit.persistence.view.filter.EqualFilter;
+import com.blazebit.persistence.view.testsuite.basic.model.IdHolderView;
+import com.blazebit.persistence.view.testsuite.entity.Document;
+
+/**
+ * @author Christian Beikov
+ * @since 1.2.0
+ */
+@EmbeddableEntityView(Document.class)
+public interface DocumentDetailEmbeddableView {
+
+    @AttributeFilter(EqualFilter.class)
+    public String getName();
+}

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/embedded/basic/model/DocumentDetailView.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/embedded/basic/model/DocumentDetailView.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014 - 2017 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.view.testsuite.embedded.basic.model;
+
+import com.blazebit.persistence.view.AttributeFilter;
+import com.blazebit.persistence.view.EntityView;
+import com.blazebit.persistence.view.Mapping;
+import com.blazebit.persistence.view.filter.EqualFilter;
+import com.blazebit.persistence.view.testsuite.basic.model.IdHolderView;
+import com.blazebit.persistence.view.testsuite.entity.Document;
+import com.blazebit.persistence.view.testsuite.entity.Person;
+
+import java.util.List;
+
+/**
+ * @author Christian Beikov
+ * @since 1.2.0
+ */
+@EntityView(Document.class)
+public interface DocumentDetailView extends IdHolderView<Long> {
+
+    @AttributeFilter(EqualFilter.class)
+    public String getName();
+}

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/embedded/basic/model/DocumentViewWithEmbedded.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/embedded/basic/model/DocumentViewWithEmbedded.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2014 - 2017 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.view.testsuite.embedded.basic.model;
+
+import com.blazebit.persistence.view.EntityView;
+import com.blazebit.persistence.view.Mapping;
+import com.blazebit.persistence.view.testsuite.basic.model.IdHolderView;
+import com.blazebit.persistence.view.testsuite.entity.Document;
+
+/**
+ * @author Christian Beikov
+ * @since 1.2.0
+ */
+@EntityView(Document.class)
+public interface DocumentViewWithEmbedded extends IdHolderView<Long> {
+
+    @Mapping("this")
+    DocumentDetailView getDetails();
+
+    @Mapping("this")
+    DocumentDetailEmbeddableView getEmbeddedDetails();
+
+}

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/embedded/collection/EmbeddedMappingCollectionTest.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/embedded/collection/EmbeddedMappingCollectionTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2014 - 2017 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.view.testsuite.embedded.collection;
+
+import com.blazebit.persistence.CriteriaBuilder;
+import com.blazebit.persistence.view.EntityViewManager;
+import com.blazebit.persistence.view.EntityViewSetting;
+import com.blazebit.persistence.view.EntityViews;
+import com.blazebit.persistence.view.spi.EntityViewConfiguration;
+import com.blazebit.persistence.view.testsuite.embedded.AbstractEmbeddedMappingTest;
+import com.blazebit.persistence.view.testsuite.embedded.collection.model.DocumentDetailEmbeddableCollectionView;
+import com.blazebit.persistence.view.testsuite.embedded.collection.model.DocumentDetailCollectionView;
+import com.blazebit.persistence.view.testsuite.embedded.collection.model.DocumentViewWithEmbeddedCollection;
+import com.blazebit.persistence.view.testsuite.entity.Document;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ *
+ * @author Christian Beikov
+ * @since 1.2.0
+ */
+public class EmbeddedMappingCollectionTest extends AbstractEmbeddedMappingTest {
+
+    EntityViewManager evm;
+
+    @Before
+    public void prepare() {
+        EntityViewConfiguration cfg = EntityViews.createDefaultConfiguration();
+        cfg.addEntityView(DocumentDetailCollectionView.class);
+        cfg.addEntityView(DocumentDetailEmbeddableCollectionView.class);
+        cfg.addEntityView(DocumentViewWithEmbeddedCollection.class);
+        this.evm = cfg.createEntityViewManager(cbf);
+    }
+
+    @Test
+    public void multipleEmbeddingsProduceCorrectResults() {
+        CriteriaBuilder<Document> criteria = cbf.create(em, Document.class, "e")
+            .orderByAsc("id");
+        EntityViewSetting<DocumentViewWithEmbeddedCollection, CriteriaBuilder<DocumentViewWithEmbeddedCollection>> setting = EntityViewSetting.create(DocumentViewWithEmbeddedCollection.class);
+        CriteriaBuilder<DocumentViewWithEmbeddedCollection> cb = evm.applySetting(setting, criteria);
+        List<DocumentViewWithEmbeddedCollection> results = cb.getResultList();
+
+        assertEquals(2, results.size());
+
+        assertEquals(doc1.getId(), results.get(0).getId());
+        assertEquals(1, results.get(0).getDetails().size());
+        assertEquals(1, results.get(0).getEmbeddedDetails().size());
+        assertEquals(doc1.getId(), results.get(0).getDetails().get(0).getId());
+        assertEquals("doc1", results.get(0).getDetails().get(0).getName());
+        assertEquals("doc1", results.get(0).getEmbeddedDetails().get(0).getName());
+
+        assertEquals(doc2.getId(), results.get(1).getId());
+        assertEquals(1, results.get(1).getDetails().size());
+        assertEquals(1, results.get(1).getEmbeddedDetails().size());
+        assertEquals(doc2.getId(), results.get(1).getDetails().get(0).getId());
+        assertEquals("doc2", results.get(1).getDetails().get(0).getName());
+        assertEquals("doc2", results.get(1).getEmbeddedDetails().get(0).getName());
+    }
+
+    @Test
+    public void filteringOnEmbeddedAttributeWorks() {
+        CriteriaBuilder<Document> criteria = cbf.create(em, Document.class, "e")
+                .orderByAsc("id");
+        EntityViewSetting<DocumentViewWithEmbeddedCollection, CriteriaBuilder<DocumentViewWithEmbeddedCollection>> setting = EntityViewSetting.create(DocumentViewWithEmbeddedCollection.class);
+        setting.addAttributeFilter("details.name", "doc1");
+        setting.addAttributeFilter("embeddedDetails.name", "doc1");
+        CriteriaBuilder<DocumentViewWithEmbeddedCollection> cb = evm.applySetting(setting, criteria);
+        List<DocumentViewWithEmbeddedCollection> results = cb.getResultList();
+
+        assertEquals(1, results.size());
+
+        assertEquals(doc1.getId(), results.get(0).getId());
+        assertEquals(1, results.get(0).getDetails().size());
+        assertEquals(1, results.get(0).getEmbeddedDetails().size());
+        assertEquals(doc1.getId(), results.get(0).getDetails().get(0).getId());
+        assertEquals("doc1", results.get(0).getDetails().get(0).getName());
+        assertEquals("doc1", results.get(0).getEmbeddedDetails().get(0).getName());
+    }
+}

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/embedded/collection/model/DocumentDetailCollectionView.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/embedded/collection/model/DocumentDetailCollectionView.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014 - 2017 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.view.testsuite.embedded.collection.model;
+
+import com.blazebit.persistence.view.AttributeFilter;
+import com.blazebit.persistence.view.EntityView;
+import com.blazebit.persistence.view.filter.EqualFilter;
+import com.blazebit.persistence.view.testsuite.basic.model.IdHolderView;
+import com.blazebit.persistence.view.testsuite.entity.Document;
+
+/**
+ * @author Christian Beikov
+ * @since 1.2.0
+ */
+@EntityView(Document.class)
+public interface DocumentDetailCollectionView extends IdHolderView<Long> {
+
+    @AttributeFilter(EqualFilter.class)
+    public String getName();
+}

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/embedded/collection/model/DocumentDetailEmbeddableCollectionView.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/embedded/collection/model/DocumentDetailEmbeddableCollectionView.java
@@ -14,24 +14,20 @@
  * limitations under the License.
  */
 
-package com.blazebit.persistence.view.testsuite.correlation.general.model;
+package com.blazebit.persistence.view.testsuite.embedded.collection.model;
 
-import com.blazebit.persistence.view.CorrelationBuilder;
-import com.blazebit.persistence.view.CorrelationProvider;
+import com.blazebit.persistence.view.AttributeFilter;
+import com.blazebit.persistence.view.EmbeddableEntityView;
+import com.blazebit.persistence.view.filter.EqualFilter;
 import com.blazebit.persistence.view.testsuite.entity.Document;
 
 /**
- *
  * @author Christian Beikov
  * @since 1.2.0
  */
-public class OwnerOnlyRelatedCorrelationIdProviderNormal implements CorrelationProvider {
+@EmbeddableEntityView(Document.class)
+public interface DocumentDetailEmbeddableCollectionView {
 
-    @Override
-    public void applyCorrelation(CorrelationBuilder correlationBuilder, String correlationExpression) {
-        String correlatedDocument = correlationBuilder.getCorrelationAlias();
-        correlationBuilder.correlate(Document.class)
-            .on(correlatedDocument + ".owner").inExpressions(correlationExpression)
-        .end();
-    }
+    @AttributeFilter(EqualFilter.class)
+    public String getName();
 }

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/embedded/collection/model/DocumentViewWithEmbeddedCollection.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/embedded/collection/model/DocumentViewWithEmbeddedCollection.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014 - 2017 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.view.testsuite.embedded.collection.model;
+
+import com.blazebit.persistence.view.EntityView;
+import com.blazebit.persistence.view.Mapping;
+import com.blazebit.persistence.view.testsuite.basic.model.IdHolderView;
+import com.blazebit.persistence.view.testsuite.entity.Document;
+
+import java.util.List;
+
+/**
+ * @author Christian Beikov
+ * @since 1.2.0
+ */
+@EntityView(Document.class)
+public interface DocumentViewWithEmbeddedCollection extends IdHolderView<Long> {
+
+    @Mapping("this")
+    List<DocumentDetailCollectionView> getDetails();
+
+    @Mapping("this")
+    List<DocumentDetailEmbeddableCollectionView> getEmbeddedDetails();
+
+}

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/embedded/entity/EmbeddedMappingEntityTest.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/embedded/entity/EmbeddedMappingEntityTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2014 - 2017 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.view.testsuite.embedded.entity;
+
+import com.blazebit.persistence.CriteriaBuilder;
+import com.blazebit.persistence.view.EntityViewManager;
+import com.blazebit.persistence.view.EntityViewSetting;
+import com.blazebit.persistence.view.EntityViews;
+import com.blazebit.persistence.view.spi.EntityViewConfiguration;
+import com.blazebit.persistence.view.testsuite.embedded.AbstractEmbeddedMappingTest;
+import com.blazebit.persistence.view.testsuite.embedded.entity.model.DocumentDetailEmbeddableEntityMappingView;
+import com.blazebit.persistence.view.testsuite.embedded.entity.model.DocumentDetailEntityMappingView;
+import com.blazebit.persistence.view.testsuite.embedded.entity.model.DocumentViewWithEmbeddedEntityMapping;
+import com.blazebit.persistence.view.testsuite.entity.Document;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ *
+ * @author Christian Beikov
+ * @since 1.2.0
+ */
+public class EmbeddedMappingEntityTest extends AbstractEmbeddedMappingTest {
+
+    EntityViewManager evm;
+
+    @Before
+    public void prepare() {
+        EntityViewConfiguration cfg = EntityViews.createDefaultConfiguration();
+        cfg.addEntityView(DocumentDetailEntityMappingView.class);
+        cfg.addEntityView(DocumentDetailEmbeddableEntityMappingView.class);
+        cfg.addEntityView(DocumentViewWithEmbeddedEntityMapping.class);
+        this.evm = cfg.createEntityViewManager(cbf);
+    }
+
+    @Test
+    public void multipleEmbeddingsProduceCorrectResults() {
+        CriteriaBuilder<Document> criteria = cbf.create(em, Document.class, "e")
+            .orderByAsc("id");
+        EntityViewSetting<DocumentViewWithEmbeddedEntityMapping, CriteriaBuilder<DocumentViewWithEmbeddedEntityMapping>> setting = EntityViewSetting.create(DocumentViewWithEmbeddedEntityMapping.class);
+        CriteriaBuilder<DocumentViewWithEmbeddedEntityMapping> cb = evm.applySetting(setting, criteria);
+        List<DocumentViewWithEmbeddedEntityMapping> results = cb.getResultList();
+
+        assertEquals(2, results.size());
+
+        assertEquals(doc1.getId(), results.get(0).getId());
+        assertEquals(doc1.getId(), results.get(0).getDetails().getId());
+        assertEquals(doc1, results.get(0).getDocument());
+        assertEquals(doc1, results.get(0).getDetails().getDocument());
+        assertEquals(doc1, results.get(0).getEmbeddedDetails().getDocument());
+        assertEquals("doc1", results.get(0).getDetails().getName());
+        assertEquals("doc1", results.get(0).getEmbeddedDetails().getName());
+
+        assertEquals(doc2.getId(), results.get(1).getId());
+        assertEquals(doc2.getId(), results.get(1).getDetails().getId());
+        assertEquals(doc2, results.get(1).getDocument());
+        assertEquals(doc2, results.get(1).getDetails().getDocument());
+        assertEquals(doc2, results.get(1).getEmbeddedDetails().getDocument());
+        assertEquals("doc2", results.get(1).getDetails().getName());
+        assertEquals("doc2", results.get(1).getEmbeddedDetails().getName());
+    }
+
+    @Test
+    public void filteringOnEmbeddedAttributeWorks() {
+        CriteriaBuilder<Document> criteria = cbf.create(em, Document.class, "e")
+                .orderByAsc("id");
+        EntityViewSetting<DocumentViewWithEmbeddedEntityMapping, CriteriaBuilder<DocumentViewWithEmbeddedEntityMapping>> setting = EntityViewSetting.create(DocumentViewWithEmbeddedEntityMapping.class);
+        setting.addAttributeFilter("details.document", em.getReference(Document.class, doc1.getId()));
+        setting.addAttributeFilter("embeddedDetails.document", em.getReference(Document.class, doc1.getId()));
+        setting.addAttributeFilter("document", em.getReference(Document.class, doc1.getId()));
+        CriteriaBuilder<DocumentViewWithEmbeddedEntityMapping> cb = evm.applySetting(setting, criteria);
+        List<DocumentViewWithEmbeddedEntityMapping> results = cb.getResultList();
+
+        assertEquals(1, results.size());
+
+        assertEquals(doc1.getId(), results.get(0).getId());
+        assertEquals(doc1.getId(), results.get(0).getDetails().getId());
+        assertEquals(doc1, results.get(0).getDocument());
+        assertEquals(doc1, results.get(0).getDetails().getDocument());
+        assertEquals(doc1, results.get(0).getEmbeddedDetails().getDocument());
+        assertEquals("doc1", results.get(0).getDetails().getName());
+        assertEquals("doc1", results.get(0).getEmbeddedDetails().getName());
+    }
+}

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/embedded/entity/model/DocumentDetailEmbeddableEntityMappingView.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/embedded/entity/model/DocumentDetailEmbeddableEntityMappingView.java
@@ -14,31 +14,24 @@
  * limitations under the License.
  */
 
-package com.blazebit.persistence.view.testsuite.correlation.simple.model;
+package com.blazebit.persistence.view.testsuite.embedded.entity.model;
 
-import com.blazebit.persistence.view.IdMapping;
-import com.blazebit.persistence.view.testsuite.subview.model.DocumentRelatedView;
-
-import java.util.Set;
+import com.blazebit.persistence.view.AttributeFilter;
+import com.blazebit.persistence.view.EmbeddableEntityView;
+import com.blazebit.persistence.view.Mapping;
+import com.blazebit.persistence.view.filter.EqualFilter;
+import com.blazebit.persistence.view.testsuite.entity.Document;
 
 /**
- *
  * @author Christian Beikov
  * @since 1.2.0
  */
-public interface DocumentSimpleCorrelationView {
-
-    @IdMapping("id")
-    public Long getId();
+@EmbeddableEntityView(Document.class)
+public interface DocumentDetailEmbeddableEntityMappingView {
 
     public String getName();
 
-    public Set<Long> getOwnerRelatedDocumentIds();
-
-    public Set<DocumentRelatedView> getOwnerRelatedDocuments();
-
-    public Set<Long> getOwnerOnlyRelatedDocumentIds();
-
-    public Set<DocumentRelatedView> getOwnerOnlyRelatedDocuments();
-
+    @Mapping("this")
+    @AttributeFilter(EqualFilter.class)
+    public Document getDocument();
 }

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/embedded/entity/model/DocumentDetailEntityMappingView.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/embedded/entity/model/DocumentDetailEntityMappingView.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014 - 2017 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.view.testsuite.embedded.entity.model;
+
+import com.blazebit.persistence.view.AttributeFilter;
+import com.blazebit.persistence.view.EntityView;
+import com.blazebit.persistence.view.Mapping;
+import com.blazebit.persistence.view.filter.EqualFilter;
+import com.blazebit.persistence.view.testsuite.basic.model.IdHolderView;
+import com.blazebit.persistence.view.testsuite.entity.Document;
+
+/**
+ * @author Christian Beikov
+ * @since 1.2.0
+ */
+@EntityView(Document.class)
+public interface DocumentDetailEntityMappingView extends IdHolderView<Long> {
+
+    public String getName();
+
+    @Mapping("this")
+    @AttributeFilter(EqualFilter.class)
+    public Document getDocument();
+}

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/embedded/entity/model/DocumentViewWithEmbeddedEntityMapping.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/embedded/entity/model/DocumentViewWithEmbeddedEntityMapping.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2014 - 2017 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.view.testsuite.embedded.entity.model;
+
+import com.blazebit.persistence.view.AttributeFilter;
+import com.blazebit.persistence.view.EntityView;
+import com.blazebit.persistence.view.Mapping;
+import com.blazebit.persistence.view.filter.EqualFilter;
+import com.blazebit.persistence.view.testsuite.basic.model.IdHolderView;
+import com.blazebit.persistence.view.testsuite.entity.Document;
+
+/**
+ * @author Christian Beikov
+ * @since 1.2.0
+ */
+@EntityView(Document.class)
+public interface DocumentViewWithEmbeddedEntityMapping extends IdHolderView<Long> {
+
+    @Mapping("this")
+    @AttributeFilter(EqualFilter.class)
+    public Document getDocument();
+
+    @Mapping("this")
+    DocumentDetailEntityMappingView getDetails();
+
+    @Mapping("this")
+    DocumentDetailEmbeddableEntityMappingView getEmbeddedDetails();
+
+}

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/embedded/nested/EmbeddedMappingNestedTest.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/embedded/nested/EmbeddedMappingNestedTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2014 - 2017 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.view.testsuite.embedded.nested;
+
+import com.blazebit.persistence.CriteriaBuilder;
+import com.blazebit.persistence.view.EntityViewManager;
+import com.blazebit.persistence.view.EntityViewSetting;
+import com.blazebit.persistence.view.EntityViews;
+import com.blazebit.persistence.view.spi.EntityViewConfiguration;
+import com.blazebit.persistence.view.testsuite.embedded.AbstractEmbeddedMappingTest;
+import com.blazebit.persistence.view.testsuite.embedded.nested.model.DocumentDetailEmbeddableNestedView;
+import com.blazebit.persistence.view.testsuite.embedded.nested.model.DocumentDetailNestedView;
+import com.blazebit.persistence.view.testsuite.embedded.nested.model.DocumentViewNestedEmbedded;
+import com.blazebit.persistence.view.testsuite.embedded.nested.model.DocumentViewNestedEmbeddedEmbeddable;
+import com.blazebit.persistence.view.testsuite.embedded.nested.model.DocumentViewWithNestedEmbedded;
+import com.blazebit.persistence.view.testsuite.entity.Document;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ *
+ * @author Christian Beikov
+ * @since 1.2.0
+ */
+public class EmbeddedMappingNestedTest extends AbstractEmbeddedMappingTest {
+
+    EntityViewManager evm;
+
+    @Before
+    public void prepare() {
+        EntityViewConfiguration cfg = EntityViews.createDefaultConfiguration();
+        cfg.addEntityView(DocumentDetailNestedView.class);
+        cfg.addEntityView(DocumentDetailEmbeddableNestedView.class);
+        cfg.addEntityView(DocumentViewNestedEmbedded.class);
+        cfg.addEntityView(DocumentViewNestedEmbeddedEmbeddable.class);
+        cfg.addEntityView(DocumentViewWithNestedEmbedded.class);
+        this.evm = cfg.createEntityViewManager(cbf);
+    }
+
+    @Test
+    public void multipleEmbeddingsProduceCorrectResults() {
+        CriteriaBuilder<Document> criteria = cbf.create(em, Document.class, "e")
+            .orderByAsc("id");
+        EntityViewSetting<DocumentViewWithNestedEmbedded, CriteriaBuilder<DocumentViewWithNestedEmbedded>> setting = EntityViewSetting.create(DocumentViewWithNestedEmbedded.class);
+        CriteriaBuilder<DocumentViewWithNestedEmbedded> cb = evm.applySetting(setting, criteria);
+        List<DocumentViewWithNestedEmbedded> results = cb.getResultList();
+
+        assertEquals(2, results.size());
+
+        assertEquals(doc1.getId(), results.get(0).getId());
+        assertEquals(doc1.getId(), results.get(0).getNested().getId());
+        assertEquals(doc1.getId(), results.get(0).getNested().getDetails().getId());
+        assertEquals(doc1.getId(), results.get(0).getNestedEmbedded().getDetails().getId());
+        assertEquals("doc1", results.get(0).getNested().getDetails().getName());
+        assertEquals("doc1", results.get(0).getNested().getEmbeddedDetails().getName());
+        assertEquals("doc1", results.get(0).getNestedEmbedded().getDetails().getName());
+        assertEquals("doc1", results.get(0).getNestedEmbedded().getEmbeddedDetails().getName());
+
+        assertEquals(doc2.getId(), results.get(1).getId());
+        assertEquals(doc2.getId(), results.get(1).getNested().getId());
+        assertEquals(doc2.getId(), results.get(1).getNested().getDetails().getId());
+        assertEquals(doc2.getId(), results.get(1).getNestedEmbedded().getDetails().getId());
+        assertEquals("doc2", results.get(1).getNested().getDetails().getName());
+        assertEquals("doc2", results.get(1).getNested().getEmbeddedDetails().getName());
+        assertEquals("doc2", results.get(1).getNestedEmbedded().getDetails().getName());
+        assertEquals("doc2", results.get(1).getNestedEmbedded().getEmbeddedDetails().getName());
+    }
+
+    @Test
+    public void filteringOnEmbeddedAttributeWorks() {
+        CriteriaBuilder<Document> criteria = cbf.create(em, Document.class, "e")
+                .orderByAsc("id");
+        EntityViewSetting<DocumentViewWithNestedEmbedded, CriteriaBuilder<DocumentViewWithNestedEmbedded>> setting = EntityViewSetting.create(DocumentViewWithNestedEmbedded.class);
+        setting.addAttributeFilter("nested.details.name", "doc1");
+        setting.addAttributeFilter("nested.embeddedDetails.name", "doc1");
+        setting.addAttributeFilter("nestedEmbedded.details.name", "doc1");
+        setting.addAttributeFilter("nestedEmbedded.embeddedDetails.name", "doc1");
+        CriteriaBuilder<DocumentViewWithNestedEmbedded> cb = evm.applySetting(setting, criteria);
+        List<DocumentViewWithNestedEmbedded> results = cb.getResultList();
+
+        assertEquals(1, results.size());
+
+        assertEquals(doc1.getId(), results.get(0).getId());
+        assertEquals(doc1.getId(), results.get(0).getNested().getId());
+        assertEquals(doc1.getId(), results.get(0).getNested().getDetails().getId());
+        assertEquals(doc1.getId(), results.get(0).getNestedEmbedded().getDetails().getId());
+        assertEquals("doc1", results.get(0).getNested().getDetails().getName());
+        assertEquals("doc1", results.get(0).getNested().getEmbeddedDetails().getName());
+        assertEquals("doc1", results.get(0).getNestedEmbedded().getDetails().getName());
+        assertEquals("doc1", results.get(0).getNestedEmbedded().getEmbeddedDetails().getName());
+    }
+}

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/embedded/nested/model/DocumentDetailEmbeddableNestedView.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/embedded/nested/model/DocumentDetailEmbeddableNestedView.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014 - 2017 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.view.testsuite.embedded.nested.model;
+
+import com.blazebit.persistence.view.AttributeFilter;
+import com.blazebit.persistence.view.EmbeddableEntityView;
+import com.blazebit.persistence.view.filter.EqualFilter;
+import com.blazebit.persistence.view.testsuite.entity.Document;
+
+/**
+ * @author Christian Beikov
+ * @since 1.2.0
+ */
+@EmbeddableEntityView(Document.class)
+public interface DocumentDetailEmbeddableNestedView {
+
+    @AttributeFilter(EqualFilter.class)
+    public String getName();
+}

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/embedded/nested/model/DocumentDetailNestedView.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/embedded/nested/model/DocumentDetailNestedView.java
@@ -14,25 +14,21 @@
  * limitations under the License.
  */
 
-package com.blazebit.persistence.view.testsuite.correlation.general.model;
+package com.blazebit.persistence.view.testsuite.embedded.nested.model;
 
-import com.blazebit.persistence.view.CorrelationBuilder;
-import com.blazebit.persistence.view.CorrelationProvider;
+import com.blazebit.persistence.view.AttributeFilter;
+import com.blazebit.persistence.view.EntityView;
+import com.blazebit.persistence.view.filter.EqualFilter;
+import com.blazebit.persistence.view.testsuite.basic.model.IdHolderView;
 import com.blazebit.persistence.view.testsuite.entity.Document;
 
 /**
- *
  * @author Christian Beikov
  * @since 1.2.0
  */
-public class OwnerRelatedCorrelationIdProviderId implements CorrelationProvider {
+@EntityView(Document.class)
+public interface DocumentDetailNestedView extends IdHolderView<Long> {
 
-    @Override
-    public void applyCorrelation(CorrelationBuilder correlationBuilder, String correlationExpression) {
-        String correlatedDocument = correlationBuilder.getCorrelationAlias();
-        correlationBuilder.correlate(Document.class)
-            .on(correlatedDocument + ".owner.id").inExpressions(correlationExpression)
-            .on(correlatedDocument + ".id").notInExpressions("VIEW_ROOT(id)")
-        .end();
-    }
+    @AttributeFilter(EqualFilter.class)
+    public String getName();
 }

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/embedded/nested/model/DocumentViewNestedEmbedded.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/embedded/nested/model/DocumentViewNestedEmbedded.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2014 - 2017 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.view.testsuite.embedded.nested.model;
+
+import com.blazebit.persistence.view.EntityView;
+import com.blazebit.persistence.view.Mapping;
+import com.blazebit.persistence.view.testsuite.basic.model.IdHolderView;
+import com.blazebit.persistence.view.testsuite.entity.Document;
+
+/**
+ * @author Christian Beikov
+ * @since 1.2.0
+ */
+@EntityView(Document.class)
+public interface DocumentViewNestedEmbedded extends IdHolderView<Long> {
+
+    @Mapping("this")
+    DocumentDetailNestedView getDetails();
+
+    @Mapping("this")
+    DocumentDetailEmbeddableNestedView getEmbeddedDetails();
+
+}

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/embedded/nested/model/DocumentViewNestedEmbeddedEmbeddable.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/embedded/nested/model/DocumentViewNestedEmbeddedEmbeddable.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014 - 2017 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.view.testsuite.embedded.nested.model;
+
+import com.blazebit.persistence.view.EmbeddableEntityView;
+import com.blazebit.persistence.view.Mapping;
+import com.blazebit.persistence.view.testsuite.entity.Document;
+
+/**
+ * @author Christian Beikov
+ * @since 1.2.0
+ */
+@EmbeddableEntityView(Document.class)
+public interface DocumentViewNestedEmbeddedEmbeddable {
+
+    @Mapping("this")
+    DocumentDetailNestedView getDetails();
+
+    @Mapping("this")
+    DocumentDetailEmbeddableNestedView getEmbeddedDetails();
+
+}

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/embedded/nested/model/DocumentViewWithNestedEmbedded.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/embedded/nested/model/DocumentViewWithNestedEmbedded.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2014 - 2017 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.view.testsuite.embedded.nested.model;
+
+import com.blazebit.persistence.view.EntityView;
+import com.blazebit.persistence.view.Mapping;
+import com.blazebit.persistence.view.testsuite.basic.model.IdHolderView;
+import com.blazebit.persistence.view.testsuite.entity.Document;
+
+/**
+ * @author Christian Beikov
+ * @since 1.2.0
+ */
+@EntityView(Document.class)
+public interface DocumentViewWithNestedEmbedded extends IdHolderView<Long> {
+
+    @Mapping("this")
+    DocumentViewNestedEmbedded getNested();
+
+    @Mapping("this")
+    DocumentViewNestedEmbeddedEmbeddable getNestedEmbedded();
+
+}

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/entity/Document.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/entity/Document.java
@@ -210,24 +210,29 @@ public class Document implements Serializable {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        result = prime * result + ((getId() == null) ? 0 : getId().hashCode());
         return result;
     }
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (obj == null)
+        }
+        if (obj == null) {
             return false;
-        if (getClass() != obj.getClass())
+        }
+        if (!(obj instanceof Document)) {
             return false;
+        }
         Document other = (Document) obj;
-        if (id == null) {
-            if (other.id != null)
+        if (getId() == null) {
+            if (other.getId() != null) {
                 return false;
-        } else if (!id.equals(other.id))
+            }
+        } else if (!getId().equals(other.getId())) {
             return false;
+        }
         return true;
     }
 

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/entity/Person.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/entity/Person.java
@@ -126,24 +126,29 @@ public class Person implements Serializable {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        result = prime * result + ((getId() == null) ? 0 : getId().hashCode());
         return result;
     }
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (obj == null)
+        }
+        if (obj == null) {
             return false;
-        if (getClass() != obj.getClass())
+        }
+        if (!(obj instanceof Person)) {
             return false;
+        }
         Person other = (Person) obj;
-        if (id == null) {
-            if (other.id != null)
+        if (getId() == null) {
+            if (other.getId() != null) {
                 return false;
-        } else if (!id.equals(other.id))
+            }
+        } else if (!getId().equals(other.getId())) {
             return false;
+        }
         return true;
     }
 }


### PR DESCRIPTION
<!--- This template is for code related PRs. Remove it for e.g. documentation PRs. -->

<!--- Prefix the title with the issue number like "[#123] Some title" and try to summarize the changes in the title -->

<!--- Before submitting the PR, please make sure it satisfies the following guidelines -->
<!---  * Tests for issues should have one commit that has the form "Test for #123" where "#123" is the issue number -->
<!---  * Fixes for issues should have one commit that has the form "Fix for #123" where "#123" is the issue number -->
<!---  * Commits for the test and the fix should be separate -->

## Description
<!--- Give an overview of what you changed -->
Most of the changes are tests. Basically I adapted the mapping validation checks to allow `this` and replaced the `this` in the expressions with the view root.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue(s) here: -->
#357

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is the foundation for treat support.
