### PR TITLE
Test nested inheritance mapping (A > B referenced in C)

### DIFF
--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/inheritance/polymorphic/NestedInheritanceMappingTest.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/inheritance/polymorphic/NestedInheritanceMappingTest.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2014 - 2017 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.view.testsuite.inheritance.polymorphic;
+
+import com.blazebit.persistence.testsuite.base.category.NoDatanucleus;
+import com.blazebit.persistence.testsuite.base.category.NoEclipselink;
+import com.blazebit.persistence.testsuite.tx.TxVoidWork;
+import com.blazebit.persistence.view.*;
+import com.blazebit.persistence.view.spi.EntityViewConfiguration;
+import com.blazebit.persistence.view.testsuite.AbstractEntityViewTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import javax.persistence.*;
+
+import static org.junit.Assert.assertTrue;
+
+@Category({ NoEclipselink.class, NoDatanucleus.class })
+public class NestedInheritanceMappingTest extends AbstractEntityViewTest {
+
+    private EntityViewManager evm;
+
+    @Entity
+    @Table(name = "test_a_entity")
+    @Inheritance(strategy = InheritanceType.JOINED)
+    public static abstract class A {
+
+        @Id
+        @GeneratedValue
+        private Long id;
+
+        @Column
+        private String name;
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    @Entity
+    @Table(name = "test_b_entity")
+    public static class B extends A {
+
+        @Column
+        private Short someValue;
+
+        public Short getSomeValue() {
+            return someValue;
+        }
+
+        public void setSomeValue(Short someValue) {
+            this.someValue = someValue;
+        }
+
+    }
+
+    @Entity
+    @Table(name = "test_c_entity")
+    @Inheritance(strategy = InheritanceType.JOINED)
+    public static abstract class C {
+
+        @Id
+        @GeneratedValue
+        private Long id;
+
+        @Column
+        private String name;
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    @Entity
+    @Table(name = "test_d_entity")
+    public static class D extends C {
+
+        @Column
+        private Integer someOtherValue;
+
+        @ManyToOne
+        @JoinColumn
+        private A a;
+
+        public Integer getSomeOtherValue() {
+            return someOtherValue;
+        }
+
+        public void setSomeOtherValue(Integer someOtherValue) {
+            this.someOtherValue = someOtherValue;
+        }
+
+        public A getA() {
+            return a;
+        }
+
+        public void setA(A a) {
+            this.a = a;
+        }
+    }
+
+    @EntityView(A.class)
+    @EntityViewInheritance
+    public interface AView {
+
+        @IdMapping
+        Long getId();
+
+        @Mapping("name")
+        String getName();
+
+    }
+
+    @EntityView(B.class)
+    public interface BView extends AView {
+
+        @Mapping("someValue")
+        Short getSomeValue();
+
+    }
+
+    @EntityView(C.class)
+    @EntityViewInheritance
+    public interface CView {
+
+        @IdMapping
+        Long getId();
+
+        @Mapping("name")
+        String getName();
+
+    }
+
+
+    @EntityView(D.class)
+    public interface DView extends CView {
+
+        @Mapping("someOtherValue")
+        Integer getSomeOtherValue();
+
+        @Mapping("a")
+        AView getAView();
+    }
+
+    @Override
+    protected Class<?>[] getEntityClasses() {
+        return new Class<?>[] {
+            A.class,
+            B.class,
+            C.class,
+            D.class,
+        };
+    }
+
+    @Override
+    public void setUpOnce() {
+        cleanDatabase();
+        transactional(new TxVoidWork() {
+            @Override
+            public void work(EntityManager em) {
+                B b = new B();
+                b.setSomeValue((short) 5);
+                b.setName("test1");
+                em.persist(b);
+
+                D c = new D();
+                c.setSomeOtherValue(1);
+                c.setA(b);
+                c.setName("test");
+                em.persist(c);
+            }
+        });
+    }
+
+    @Before
+    public void setUp() {
+        EntityViewConfiguration cfg = EntityViews.createDefaultConfiguration();
+        cfg.addEntityView(AView.class);
+        cfg.addEntityView(BView.class);
+        cfg.addEntityView(CView.class);
+        cfg.addEntityView(DView.class);
+        this.evm = cfg.createEntityViewManager(cbf);
+    }
+
+    @Test
+    public void testNestedInheritanceMapping() throws Exception {
+        CView singleResult = evm.applySetting(
+                EntityViewSetting.create(CView.class),
+                cbf.create(em, C.class).where("name").eq("test")
+        ).getSingleResult();
+
+        assertTrue(singleResult instanceof DView);
+        assertTrue(((DView) singleResult).getAView() instanceof BView);
+    }
+
+}


### PR DESCRIPTION
While trying to reproduce issue #456, I created the following test case. I don't think it reproduces the same problem, as it seems to fail much earlier in the proces. The error message thrown in the test is as follows:

```
java.lang.RuntimeException: Probably we did something wrong, please contact us if you see this message.

	at com.blazebit.persistence.view.impl.proxy.ProxyFactory.createProxyClass(ProxyFactory.java:362)
	at com.blazebit.persistence.view.impl.proxy.ProxyFactory.getProxy(ProxyFactory.java:193)
	at com.blazebit.persistence.view.impl.proxy.ProxyFactory.getProxy(ProxyFactory.java:110)
	at com.blazebit.persistence.view.impl.proxy.ReflectionInstantiator.getProxyClass(ReflectionInstantiator.java:74)
	at com.blazebit.persistence.view.impl.proxy.ReflectionInstantiator.<init>(ReflectionInstantiator.java:36)
	at com.blazebit.persistence.view.impl.objectbuilder.ViewTypeObjectBuilderTemplate.createInstantiator(ViewTypeObjectBuilderTemplate.java:322)
	at com.blazebit.persistence.view.impl.objectbuilder.ViewTypeObjectBuilderTemplate.<init>(ViewTypeObjectBuilderTemplate.java:289)
	at com.blazebit.persistence.view.impl.objectbuilder.ViewTypeObjectBuilderTemplate.applySubviewMapping(ViewTypeObjectBuilderTemplate.java:576)
	at com.blazebit.persistence.view.impl.objectbuilder.ViewTypeObjectBuilderTemplate.applyMapping(ViewTypeObjectBuilderTemplate.java:521)
	at com.blazebit.persistence.view.impl.objectbuilder.ViewTypeObjectBuilderTemplate.<init>(ViewTypeObjectBuilderTemplate.java:243)
	at com.blazebit.persistence.view.impl.objectbuilder.ViewTypeObjectBuilderTemplate.<init>(ViewTypeObjectBuilderTemplate.java:118)
	at com.blazebit.persistence.view.impl.objectbuilder.ViewTypeObjectBuilderTemplate$Key.createValue(ViewTypeObjectBuilderTemplate.java:1105)
	at com.blazebit.persistence.view.impl.EntityViewManagerImpl.getTemplate(EntityViewManagerImpl.java:344)
	at com.blazebit.persistence.view.impl.EntityViewManagerImpl.createObjectBuilder(EntityViewManagerImpl.java:317)
	at com.blazebit.persistence.view.impl.EntityViewManagerImpl.applyObjectBuilder(EntityViewManagerImpl.java:292)
	at com.blazebit.persistence.view.impl.EntityViewManagerImpl.applyObjectBuilder(EntityViewManagerImpl.java:287)
	at com.blazebit.persistence.view.impl.EntityViewSettingHelper.apply(EntityViewSettingHelper.java:71)
	at com.blazebit.persistence.view.impl.EntityViewManagerImpl.applySetting(EntityViewManagerImpl.java:180)
	at com.blazebit.persistence.view.testsuite.inheritance.polymorphic.NestedInheritanceMapping.testNestedInheritanceMapping(NestedInheritanceMapping.java:210)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
Caused by: javassist.bytecode.DuplicateMemberException: duplicate method: <init> in com.blazebit.persistence.view.testsuite.inheritance.polymorphic.NestedInheritanceMapping$AView_1_BView_$$_javassist_entityview_
	at javassist.bytecode.ClassFile.testExistingMethod(ClassFile.java:680)
	at javassist.bytecode.ClassFile.addMethod(ClassFile.java:656)
	at javassist.CtClassType.addConstructor(CtClassType.java:1315)
	at javassist.CtNewClass.addConstructor(CtNewClass.java:57)
	at com.blazebit.persistence.view.impl.proxy.ProxyFactory.createInheritanceConstructors(ProxyFactory.java:402)
	at com.blazebit.persistence.view.impl.proxy.ProxyFactory.createProxyClass(ProxyFactory.java:336)
	... 43 more
```

<!--- This template is for code related PRs. Remove it for e.g. documentation PRs. -->

<!--- Prefix the title with the issue number like "[#123] Some title" and try to summarize the changes in the title -->

<!--- Before submitting the PR, please make sure it satisfies the following guidelines -->
<!---  * Tests for issues should have one commit that has the form "Test for #123" where "#123" is the issue number -->
<!---  * Fixes for issues should have one commit that has the form "Fix for #123" where "#123" is the issue number -->
<!---  * Commits for the test and the fix should be separate -->

## Description
<!--- Give an overview of what you changed -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue(s) here: -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

