### PR TITLE
Reproducer issue #519: Hibernate Subselect Entity not supported by EntityMetamodelImpl

### DIFF
--- a/core/testsuite/src/test/hibernate/com/blazebit/persistence/testsuite/Issue519Test.java
+++ b/core/testsuite/src/test/hibernate/com/blazebit/persistence/testsuite/Issue519Test.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2014 - 2018 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.testsuite;
+
+import com.blazebit.persistence.CriteriaBuilder;
+import org.hibernate.annotations.Generated;
+import org.hibernate.annotations.GenerationTime;
+import org.hibernate.annotations.Subselect;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.persistence.Entity;
+import javax.persistence.Table;
+import javax.persistence.Column;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+import javax.persistence.PrimaryKeyJoinColumn;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue519Test extends AbstractCoreTest {
+
+    A instance;
+
+    @Before
+    public void setUp() throws Exception {
+        instance = new A();
+        em.persist(instance);
+        em.refresh(instance);
+    }
+
+    @Test
+    public void subselectEntityTest() {
+        CriteriaBuilder<A> a1 = cbf.create(em, A.class)
+                .from(A.class, "a")
+                .where("a.b.b").eq(5l);
+
+        String queryString = a1.getQueryString();
+        List<A> resultList = a1.getResultList();
+        assertTrue(resultList.contains(instance));
+    }
+
+    @Entity
+    @Table(name = "A")
+    public static class A {
+
+        @Id
+        @GeneratedValue
+        private Long id;
+
+        @Generated(GenerationTime.INSERT)
+        @OneToOne(mappedBy = "a")
+        private B b;
+
+
+    }
+
+    @Entity
+    @Subselect("SELECT 5 as b, a.id AS aId FROM A")
+    public static class B {
+
+        private Long aId;
+
+        private A a;
+
+        private Long b;
+
+        @Id
+        public Long getaId() {
+            return aId;
+        }
+
+        public void setaId(Long aId) {
+            this.aId = aId;
+        }
+
+        @OneToOne
+        @PrimaryKeyJoinColumn(name = "a_id")
+        public A getA() {
+            return a;
+        }
+
+        public void setA(A a) {
+            this.a = a;
+        }
+
+        @Column
+        public Long getB() {
+            return b;
+        }
+
+        public void setB(Long b) {
+            this.b = b;
+        }
+    }
+
+    @Override
+    protected Class<?>[] getEntityClasses() {
+        return new Class<?>[] { A.class, B.class };
+    }
+}


### PR DESCRIPTION
<!--- This template is for code related PRs. Remove it for e.g. documentation PRs. -->

<!--- Prefix the title with the issue number like "[#123] Some title" and try to summarize the changes in the title -->

<!--- Before submitting the PR, please make sure it satisfies the following guidelines -->
<!---  * Tests for issues should have one commit that has the form "Test for #123" where "#123" is the issue number -->
<!---  * Fixes for issues should have one commit that has the form "Fix for #123" where "#123" is the issue number -->
<!---  * Commits for the test and the fix should be separate -->

## Description
<!--- Give an overview of what you changed -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue(s) here: -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

