### PR TITLE
Use getSubclassTableSpan instead of getTableSpan, fixes #521

### DIFF
--- a/integration/hibernate-base/src/main/java/com/blazebit/persistence/impl/hibernate/HibernateJpaProvider.java
+++ b/integration/hibernate-base/src/main/java/com/blazebit/persistence/impl/hibernate/HibernateJpaProvider.java
@@ -483,17 +483,17 @@ public class HibernateJpaProvider implements JpaProvider {
         Table[] tables;
 
         if (entityPersister instanceof JoinedSubclassEntityPersister) {
-            tables = new Table[((JoinedSubclassEntityPersister) entityPersister).getTableSpan()];
+            tables = new Table[((JoinedSubclassEntityPersister) entityPersister).getSubclassTableSpan()];
             for (int i = 0; i < tables.length; i++) {
                 tables[i] = database.getTable(entityPersister.getSubclassTableName(i));
             }
         } else if (entityPersister instanceof UnionSubclassEntityPersister) {
-            tables = new Table[((UnionSubclassEntityPersister) entityPersister).getTableSpan()];
+            tables = new Table[((UnionSubclassEntityPersister) entityPersister).getSubclassTableSpan()];
             for (int i = 0; i < tables.length; i++) {
                 tables[i] = database.getTable(entityPersister.getSubclassTableName(i));
             }
         } else if (entityPersister instanceof SingleTableEntityPersister) {
-            tables = new Table[((SingleTableEntityPersister) entityPersister).getTableSpan()];
+            tables = new Table[((SingleTableEntityPersister) entityPersister).getSubclassTableSpan()];
             for (int i = 0; i < tables.length; i++) {
                 tables[i] = database.getTable(entityPersister.getSubclassTableName(i));
             }


### PR DESCRIPTION
The trivial fix for #521. Surprisingly the reproducer #522 failed to address this issue. I am still working on a true reproducer.

<!--- This template is for code related PRs. Remove it for e.g. documentation PRs. -->

<!--- Prefix the title with the issue number like "[#123] Some title" and try to summarize the changes in the title -->

<!--- Before submitting the PR, please make sure it satisfies the following guidelines -->
<!---  * Tests for issues should have one commit that has the form "Test for #123" where "#123" is the issue number -->
<!---  * Fixes for issues should have one commit that has the form "Fix for #123" where "#123" is the issue number -->
<!---  * Commits for the test and the fix should be separate -->

## Description
<!--- Give an overview of what you changed -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue(s) here: -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
