### PR TITLE
Defer instantiation of TupleObjectBuilder to properly initialise tuple element aliases

### DIFF
--- a/core/impl/src/main/java/com/blazebit/persistence/impl/AbstractCommonQueryBuilder.java
+++ b/core/impl/src/main/java/com/blazebit/persistence/impl/AbstractCommonQueryBuilder.java
@@ -28,6 +28,7 @@ import com.blazebit.persistence.Keyset;
 import com.blazebit.persistence.KeysetBuilder;
 import com.blazebit.persistence.LeafOngoingFinalSetOperationCTECriteriaBuilder;
 import com.blazebit.persistence.MultipleSubqueryInitiator;
+import com.blazebit.persistence.ObjectBuilder;
 import com.blazebit.persistence.RestrictionBuilder;
 import com.blazebit.persistence.ReturningModificationCriteriaBuilderFactory;
 import com.blazebit.persistence.SelectRecursiveCTECriteriaBuilder;
@@ -1990,8 +1991,9 @@ public abstract class AbstractCommonQueryBuilder<QueryResultType, BuilderType, S
 
     @SuppressWarnings("unchecked")
     protected final TypedQuery<QueryResultType> applyObjectBuilder(TypedQuery<?> query) {
-        if (selectManager.getSelectObjectBuilder() != null) {
-            return  new ObjectBuilderTypedQuery<>(query, selectManager.getSelectObjectBuilder());
+        ObjectBuilder<QueryResultType> selectObjectBuilder = selectManager.getSelectObjectBuilder();
+        if (selectObjectBuilder != null) {
+            return  new ObjectBuilderTypedQuery<>(query, selectObjectBuilder);
         } else {
             return (TypedQuery<QueryResultType>) query;
         }

--- a/core/impl/src/main/java/com/blazebit/persistence/impl/SelectManager.java
+++ b/core/impl/src/main/java/com/blazebit/persistence/impl/SelectManager.java
@@ -88,6 +88,7 @@ public class SelectManager<T> extends AbstractManager<SelectInfo> {
     private final ExpressionFactory expressionFactory;
     private final JpaProvider jpaProvider;
     private final MainQuery mainQuery;
+    private final Class<?> resultClazz;
 
     @SuppressWarnings("unchecked")
     public SelectManager(ResolvingQueryGenerator queryGenerator, ParameterManager parameterManager, JoinManager joinManager, AliasManager aliasManager, SubqueryInitiatorFactory subqueryInitFactory, ExpressionFactory expressionFactory, JpaProvider jpaProvider,
@@ -99,9 +100,7 @@ public class SelectManager<T> extends AbstractManager<SelectInfo> {
         this.expressionFactory = expressionFactory;
         this.jpaProvider = jpaProvider;
         this.mainQuery = mainQuery;
-        if (resultClazz.equals(Tuple.class)) {
-            objectBuilder = (ObjectBuilder<T>) new TupleObjectBuilder(selectInfos, selectAliasToPositionMap);
-        }
+        this.resultClazz = resultClazz;
     }
 
     @Override
@@ -120,6 +119,9 @@ public class SelectManager<T> extends AbstractManager<SelectInfo> {
     }
 
     ObjectBuilder<T> getSelectObjectBuilder() {
+        if (objectBuilder == null && resultClazz.equals(Tuple.class)) {
+            return (ObjectBuilder<T>) new TupleObjectBuilder(selectInfos, selectAliasToPositionMap);
+        }
         return objectBuilder;
     }
 

--- a/core/testsuite/src/test/java/com/blazebit/persistence/testsuite/TupleTest.java
+++ b/core/testsuite/src/test/java/com/blazebit/persistence/testsuite/TupleTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2014 - 2018 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.testsuite;
+
+import com.blazebit.persistence.CriteriaBuilder;
+import com.blazebit.persistence.testsuite.entity.Document;
+import com.blazebit.persistence.testsuite.entity.Person;
+import com.blazebit.persistence.testsuite.tx.TxVoidWork;
+import org.junit.Test;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Tuple;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ *
+ * @author Jan-Willem Gmelig Meyling
+ * @since 1.2.0
+ */
+public class TupleTest extends AbstractCoreTest {
+
+    // from issue #490
+    @Test
+    public void testGetTupleElementAlias() {
+        cleanDatabase();
+        transactional(new TxVoidWork() {
+            @Override
+            public void work(EntityManager em) {
+                Document d = new Document("D1");
+
+                Person p1 = new Person("Joe");
+                Person p2 = new Person("Fred");
+                d.setOwner(p1);
+                d.getPartners().add(p1);
+                d.getPartners().add(p2);
+
+                em.persist(p1);
+                em.persist(p2);
+                em.persist(d);
+            }
+        });
+
+        CriteriaBuilder<Tuple> criteria = cbf.create(em, Tuple.class).from(Document.class, "d").select("d.id", "theId");
+
+        Tuple result = criteria.getResultList().get(0);
+        String alias = result.getElements().get(0).getAlias();
+        assertEquals("theId", alias);
+        assertEquals(result.get(0), result.get("theId"));
+    }
+
+}


### PR DESCRIPTION
Defer instantiation of TupleObjectBuilder to properly initialise tuple element aliases.

<!--- This template is for code related PRs. Remove it for e.g. documentation PRs. -->

<!--- Prefix the title with the issue number like "[#123] Some title" and try to summarize the changes in the title -->

<!--- Before submitting the PR, please make sure it satisfies the following guidelines -->
<!---  * Tests for issues should have one commit that has the form "Test for #123" where "#123" is the issue number -->
<!---  * Fixes for issues should have one commit that has the form "Fix for #123" where "#123" is the issue number -->
<!---  * Commits for the test and the fix should be separate -->

## Description
<!--- Give an overview of what you changed -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
#490
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue(s) here: -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
