### PR TITLE
Changed MacroConfiguration comparator

### DIFF
--- a/core/parser/src/main/java/com/blazebit/persistence/parser/expression/MacroConfiguration.java
+++ b/core/parser/src/main/java/com/blazebit/persistence/parser/expression/MacroConfiguration.java
@@ -16,7 +16,6 @@
 
 package com.blazebit.persistence.parser.expression;
 
-import java.util.Comparator;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.TreeMap;
@@ -36,7 +35,7 @@ public final class MacroConfiguration {
     }
 
     public static MacroConfiguration of(Map<String, MacroFunction> macros) {
-        NavigableMap<String, MacroFunction> map = new TreeMap<String, MacroFunction>(LengthComparator.INSTANCE);
+        NavigableMap<String, MacroFunction> map = new TreeMap<String, MacroFunction>(String.CASE_INSENSITIVE_ORDER);
         for (Map.Entry<String, MacroFunction> entry : macros.entrySet()) {
             map.put(entry.getKey().toUpperCase(), entry.getValue());
         }
@@ -53,20 +52,6 @@ public final class MacroConfiguration {
             map.put(entry.getKey().toUpperCase(), entry.getValue());
         }
         return new MacroConfiguration(map);
-    }
-
-    /**
-     * @author Christian Beikov
-     * @since 1.2.0
-     */
-    static class LengthComparator implements Comparator<String> {
-
-        public static final LengthComparator INSTANCE = new LengthComparator();
-
-        @Override
-        public int compare(String o1, String o2) {
-            return (o1.length() < o2.length()) ? -1 : ((o1.length() == o2.length()) ? 0 : 1);
-        }
     }
 
     @Override


### PR DESCRIPTION
I have a hard time believing that it is intentional for one macro with the same string length to remove another macro from the macro map, so I think a case insensitive comparator is more appropriate.

> a sorted map performs all key comparisons using its compareTo (or compare) method, so two keys that are deemed equal by this method are, from the standpoint of the sorted map, equal.

<!--- This template is for code related PRs. Remove it for e.g. documentation PRs. -->

<!--- Prefix the title with the issue number like "[#123] Some title" and try to summarize the changes in the title -->

<!--- Before submitting the PR, please make sure it satisfies the following guidelines -->
<!---  * Tests for issues should have one commit that has the form "Test for #123" where "#123" is the issue number -->
<!---  * Fixes for issues should have one commit that has the form "Fix for #123" where "#123" is the issue number -->
<!---  * Commits for the test and the fix should be separate -->

## Description
<!--- Give an overview of what you changed -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue(s) here: -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->