### PR TITLE
[#325] Add support for EntityViewSetting parameters

### DIFF
--- a/integration/spring-data/base/src/main/java/com/blazebit/persistence/spring/data/annotation/OptionalParam.java
+++ b/integration/spring-data/base/src/main/java/com/blazebit/persistence/spring/data/annotation/OptionalParam.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014 - 2018 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.spring.data.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.blazebit.persistence.view.EntityViewSetting;
+
+/**
+ * Annotation to let method parameters be bound to the {@link EntityViewSetting}.
+ *
+ * @author Giovanni Lovato
+ * @since 1.3.0
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface OptionalParam {
+
+    /**
+     * The name of the parameter.
+     */
+    String value();
+}

--- a/integration/spring-data/testsuite/src/test/java/com/blazebit/persistence/spring/data/testsuite/DocumentRepositoryTest.java
+++ b/integration/spring-data/testsuite/src/test/java/com/blazebit/persistence/spring/data/testsuite/DocumentRepositoryTest.java
@@ -509,6 +509,38 @@ public class DocumentRepositoryTest extends AbstractSpringTest {
         assertTrue(actual.get(1).getId().equals(d3.getId()));
     }
 
+    @Test
+    public void testFindWithOptionalParameter() {
+        // Given
+        String name = "D1";
+        String param = "Foo";
+        createDocument(name);
+
+        // When
+        List<DocumentView> result = documentRepository.findByName(name, param);
+
+        // Then
+        assertEquals(1, result.size());
+        String optionalParameter = result.get(0).getOptionalParameter();
+        assertEquals(param, optionalParameter);
+    }
+
+    @Test
+    public void testFindWithOptionalParameterAndPageable() {
+        // Given
+        String name = "D1";
+        String param = "Foo";
+        createDocument("D1");
+
+        // When
+        Page<DocumentView> result = documentRepository.findByNameOrderById(name, new PageRequest(0, 1), param);
+
+        // Then
+        assertEquals(1, result.getSize());
+        String optionalParameter = result.getContent().get(0).getOptionalParameter();
+        assertEquals(param, optionalParameter);
+    }
+
     private List<Long> getIdsFromViews(Iterable<DocumentAccessor> views) {
         List<Long> ids = new ArrayList<>();
         for (DocumentAccessor view : views) {

--- a/integration/spring-data/testsuite/src/test/java/com/blazebit/persistence/spring/data/testsuite/repository/DocumentRepository.java
+++ b/integration/spring-data/testsuite/src/test/java/com/blazebit/persistence/spring/data/testsuite/repository/DocumentRepository.java
@@ -16,10 +16,13 @@
 
 package com.blazebit.persistence.spring.data.testsuite.repository;
 
+import com.blazebit.persistence.spring.data.annotation.OptionalParam;
 import com.blazebit.persistence.spring.data.repository.EntityViewRepository;
 import com.blazebit.persistence.spring.data.repository.EntityViewSpecificationExecutor;
 import com.blazebit.persistence.spring.data.repository.KeysetAwarePage;
 import com.blazebit.persistence.spring.data.testsuite.entity.Document;
+import com.blazebit.persistence.spring.data.testsuite.view.DocumentView;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -68,4 +71,8 @@ public interface DocumentRepository<T> extends EntityViewRepository<T, Long>, En
     Slice<T> findSliceByAgeGreaterThanEqual(long age, Pageable pageable);
 
     T findFirstByOrderByNameAsc();
+
+    List<DocumentView> findByName(String name, @OptionalParam("optionalParameter") String optionalParameter);
+
+    Page<DocumentView> findByNameOrderById(String name, Pageable pageable, @OptionalParam("optionalParameter") String optionalParameter);
 }

--- a/integration/spring-data/testsuite/src/test/java/com/blazebit/persistence/spring/data/testsuite/view/DocumentView.java
+++ b/integration/spring-data/testsuite/src/test/java/com/blazebit/persistence/spring/data/testsuite/view/DocumentView.java
@@ -19,6 +19,7 @@ package com.blazebit.persistence.spring.data.testsuite.view;
 import com.blazebit.persistence.spring.data.testsuite.entity.Document;
 import com.blazebit.persistence.view.EntityView;
 import com.blazebit.persistence.view.IdMapping;
+import com.blazebit.persistence.view.MappingParameter;
 
 /**
  * @author Moritz Becker
@@ -33,4 +34,7 @@ public interface DocumentView {
     String getName();
 
     PersonView getOwner();
+
+    @MappingParameter("optionalParameter")
+    String getOptionalParameter();
 }


### PR DESCRIPTION
## Description

- Add `OptionalParam` annotation to denote parameters to be bound via `EntityViewSetting::addOptionalParameter`
- ~~Add also support for `Specification` parameters~~

## Related Issue
Partly fixes #325.

## Motivation and Context
Provides ability to customize `EntityViewSetting` via Spring repository interfaces.