### PR TITLE
[#617] Omit the sort param during count query creation

### DIFF
--- a/integration/spring-data/base/src/main/java/com/blazebit/persistence/spring/data/base/query/AbstractPartTreeBlazePersistenceQuery.java
+++ b/integration/spring-data/base/src/main/java/com/blazebit/persistence/spring/data/base/query/AbstractPartTreeBlazePersistenceQuery.java
@@ -93,7 +93,6 @@ public abstract class AbstractPartTreeBlazePersistenceQuery extends AbstractJpaQ
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public TypedQuery<Long> doCreateCountQuery(Object[] values) {
         throw new UnsupportedOperationException();
     }
@@ -432,7 +431,7 @@ public abstract class AbstractPartTreeBlazePersistenceQuery extends AbstractJpaQ
 
         @Override
         protected CriteriaQuery<?> invokeQueryCreator(FixedJpaQueryCreator creator, Sort sort) {
-            return creator.createQuery(sort);
+            return creator.createQuery();
         }
     }
 }

--- a/integration/spring-data/base/src/main/java/com/blazebit/persistence/spring/data/base/query/JpaParameters.java
+++ b/integration/spring-data/base/src/main/java/com/blazebit/persistence/spring/data/base/query/JpaParameters.java
@@ -53,7 +53,7 @@ public class JpaParameters extends Parameters<JpaParameters, JpaParameter> {
         super(parameters);
     }
 
-	/* *
+    /**
      * Gets the parameters annotated with {@link OptionalParam}.
      *
      * @return the optional parameters
@@ -72,13 +72,13 @@ public class JpaParameters extends Parameters<JpaParameters, JpaParameter> {
     }
 
     /*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.repository.query.Parameters#createParameter(org.springframework.core.MethodParameter)
-	 */
-	@Override
-	protected JpaParameter createParameter(MethodParameter parameter) {
-		return new JpaParameter(parameter);
-	}
+     * (non-Javadoc)
+     * @see org.springframework.data.repository.query.Parameters#createParameter(org.springframework.core.MethodParameter)
+     */
+    @Override
+    protected JpaParameter createParameter(MethodParameter parameter) {
+        return new JpaParameter(parameter);
+    }
 
     /*
      * (non-Javadoc)
@@ -111,22 +111,24 @@ public class JpaParameters extends Parameters<JpaParameters, JpaParameter> {
 
             super(parameter);
 
-			this.parameter = parameter;
-			this.optional = parameter.getParameterAnnotation(OptionalParam.class);this.annotation = parameter.getParameterAnnotation(Temporal.class);
-			this.temporalType = null;
+            this.parameter = parameter;
+            this.optional = parameter.getParameterAnnotation(OptionalParam.class);
+            this.annotation = parameter.getParameterAnnotation(Temporal.class);
+            this.temporalType = null;
 
-			if (!isDateParameter() && hasTemporalParamAnnotation()) {
-				throw new IllegalArgumentException(
-						Temporal.class.getSimpleName() + " annotation is only allowed on Date parameter!");
-			}
-		}
+            if (!isDateParameter() && hasTemporalParamAnnotation()) {
+                throw new IllegalArgumentException(
+                    Temporal.class.getSimpleName() + " annotation is only allowed on Date parameter!");
+            }
+        }
 
-		public String getParameterName() {
-			Param annotation = parameter.getParameterAnnotation(Param.class);
-			if (annotation != null) {return annotation.value();
+        public String getParameterName() {
+            Param annotation = parameter.getParameterAnnotation(Param.class);
+            if (annotation != null) {
+                return annotation.value();
             }
             return optional == null ? parameter.getParameterName() : optional.value();
-		}
+        }
 
         /*
          * (non-Javadoc)
@@ -137,19 +139,21 @@ public class JpaParameters extends Parameters<JpaParameters, JpaParameter> {
             return super.isBindable() || isTemporalParameter();
         }
 
-		@Override
+        @Override
         public boolean isSpecialParameter() {
             return super.isSpecialParameter() || isOptionalParameter();
         }
 
         boolean isOptionalParameter() {
             return optional != null;
-        }/**
-		 * @return {@literal true} if this parameter is of type {@link Date} and has an {@link Temporal} annotation.
-		 */
-		boolean isTemporalParameter() {
-			return isDateParameter() && hasTemporalParamAnnotation();
-		}
+        }
+
+        /**
+         * @return {@literal true} if this parameter is of type {@link Date} and has an {@link Temporal} annotation.
+         */
+        boolean isTemporalParameter() {
+            return isDateParameter() && hasTemporalParamAnnotation();
+        }
 
         /**
          * @return the {@link TemporalType} on the {@link Temporal} annotation of the given {@link Parameter}.


### PR DESCRIPTION
## Description
Omit the `sort` param on count query creation, which is irrelevant and might cause exceptions.

## Related Issue
Fixes #617 
