### PR TITLE
[#624] Fix NPE in query method specification

### DIFF
--- a/integration/spring-data/base/src/main/java/com/blazebit/persistence/spring/data/base/query/AbstractPartTreeBlazePersistenceQuery.java
+++ b/integration/spring-data/base/src/main/java/com/blazebit/persistence/spring/data/base/query/AbstractPartTreeBlazePersistenceQuery.java
@@ -324,7 +324,9 @@ public abstract class AbstractPartTreeBlazePersistenceQuery extends AbstractJpaQ
                 Root root = criteriaQuery.getRoots().iterator().next();
                 BlazeCriteriaBuilder criteriaBuilder = blazeCriteriaQuery.getCriteriaBuilder();
                 Predicate predicate = specification.toPredicate(root, criteriaQuery, criteriaBuilder);
-                criteriaQuery.where(predicate);
+                if (predicate != null) {
+                    criteriaQuery.where(predicate);
+                }
             }
         }
 


### PR DESCRIPTION
## Description
Checks if the `Specification` returns a null predicate.

## Related Issue
Fixes #624.