### PR TITLE
[#626] Avoid using JPQL keywords as root aliases

### DIFF
--- a/core/impl/src/main/java/com/blazebit/persistence/impl/JoinManager.java
+++ b/core/impl/src/main/java/com/blazebit/persistence/impl/JoinManager.java
@@ -55,6 +55,7 @@ import com.blazebit.persistence.parser.predicate.EqPredicate;
 import com.blazebit.persistence.parser.predicate.Predicate;
 import com.blazebit.persistence.parser.predicate.PredicateBuilder;
 import com.blazebit.persistence.impl.transform.ExpressionModifierVisitor;
+import com.blazebit.persistence.impl.util.Keywords;
 import com.blazebit.persistence.parser.util.ExpressionUtils;
 import com.blazebit.persistence.parser.util.JpaMetamodelUtils;
 import com.blazebit.persistence.spi.DbmsModificationState;
@@ -371,7 +372,7 @@ public class JoinManager extends AbstractManager<ExpressionModifier> {
             sb.setCharAt(0, Character.toLowerCase(sb.charAt(0)));
             String alias = sb.toString();
 
-            if (aliasManager.getAliasInfo(alias) == null) {
+            if (aliasManager.getAliasInfo(alias) == null && !Keywords.JPQL.contains(alias.toUpperCase())) {
                 rootAlias = alias;
             } else {
                 rootAlias = aliasManager.generateRootAlias(alias);

--- a/core/impl/src/main/java/com/blazebit/persistence/impl/util/Keywords.java
+++ b/core/impl/src/main/java/com/blazebit/persistence/impl/util/Keywords.java
@@ -17,7 +17,8 @@
 package com.blazebit.persistence.impl.util;
 
 import java.util.Arrays;
-import java.util.List;
+import java.util.Set;
+import java.util.HashSet;
 
 /**
  * @author Giovanni Lovato
@@ -28,13 +29,13 @@ public final class Keywords {
     /**
      * JPQL keywords from JPA BNF.
      */
-    public static final List<String> JPQL = Arrays
+    public static final Set<String> JPQL = new HashSet<>(Arrays
         .asList("ABS", "ALL", "AND", "ANY", "AS", "ASC", "AVG", "BETWEEN", "BOTH", "BY", "CASE",
             "COALESCE", "CONCAT", "COUNT", "CURRENT_DATE", "CURRENT_TIME", "CURRENT_TIMESTAMP", "DELETE", "DESC", "DISTINCT",
             "ELSE", "EMPTY", "END", "ENTRY", "ESCAPE", "EXISTS", "FETCH", "FROM", "FUNCTION", "GROUP", "HAVING", "IN", "INDEX",
             "INNER", "IS", "JOIN", "KEY", "LEADING", "LEFT", "LENGTH", "LIKE", "LOCATE", "LOWER", "MAX", "MEMBER", "MIN", "MOD",
             "NEW", "NOT", "NULL", "NULLIF", "OBJECT", "OF", "ON", "OR", "ORDER", "OUTER", "SELECT", "SET", "SIZE", "SOME",
-                "SQRT", "SUBSTRING", "SUM", "TRAILING", "TREAT", "TRIM", "TYPE", "UPDATE", "UPPER", "VALUE", "WHEN", "WHERE");
+                "SQRT", "SUBSTRING", "SUM", "TRAILING", "TREAT", "TRIM", "TYPE", "UPDATE", "UPPER", "VALUE", "WHEN", "WHERE"));
 
     private Keywords() {
     }

--- a/core/impl/src/main/java/com/blazebit/persistence/impl/util/Keywords.java
+++ b/core/impl/src/main/java/com/blazebit/persistence/impl/util/Keywords.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014 - 2018 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.impl.util;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author Giovanni Lovato
+ * @since 1.3.0
+ */
+public final class Keywords {
+
+    /**
+     * JPQL keywords from JPA BNF.
+     */
+    public static final List<String> JPQL = Arrays
+        .asList("ABS", "ALL", "AND", "ANY", "AS", "ASC", "AVG", "BETWEEN", "BOTH", "BY", "CASE",
+            "COALESCE", "CONCAT", "COUNT", "CURRENT_DATE", "CURRENT_TIME", "CURRENT_TIMESTAMP", "DELETE", "DESC", "DISTINCT",
+            "ELSE", "EMPTY", "END", "ENTRY", "ESCAPE", "EXISTS", "FETCH", "FROM", "FUNCTION", "GROUP", "HAVING", "IN", "INDEX",
+            "INNER", "IS", "JOIN", "KEY", "LEADING", "LEFT", "LENGTH", "LIKE", "LOCATE", "LOWER", "MAX", "MEMBER", "MIN", "MOD",
+            "NEW", "NOT", "NULL", "NULLIF", "OBJECT", "OF", "ON", "OR", "ORDER", "OUTER", "SELECT", "SET", "SIZE", "SOME",
+                "SQRT", "SUBSTRING", "SUM", "TRAILING", "TREAT", "TRIM", "TYPE", "UPDATE", "UPPER", "VALUE", "WHEN", "WHERE");
+
+    private Keywords() {
+    }
+
+}


### PR DESCRIPTION
## Description
Adds a `Keywords` util class with a list of JPQL keywords from the JPA BNF and checks root aliases for inclusion in the list, in which case the alias generation is delegated to the alias manager.

## Related Issue
Fixes #626