### PR TITLE
Remove unnecessary annotation

### DIFF
--- a/documentation/src/main/asciidoc/entity-view/manual/en_US/04_mappings.adoc
+++ b/documentation/src/main/asciidoc/entity-view/manual/en_US/04_mappings.adoc
@@ -1628,14 +1628,12 @@ public interface AnimalView {
 }
 
 @EntityView(Cat.class)
-@EntityViewInheritanceMapping
 public interface CatView extends AnimalView {
 
     String getKittyName();
 }
 
 @EntityView(Dog.class)
-@EntityViewInheritanceMapping
 public interface DogView extends AnimalView {
 
     String getDoggyName();


### PR DESCRIPTION
Remove unnecessary `@EntityViewInheritanceMapping` annotation from `CatView` and `DogView` in [§3.17.2. Inheritance mapping and JPA inheritance](https://persistence.blazebit.com/documentation/1.3/entity-view/manual/en_US/#inheritance-mapping-and-jpa-inheritance).