### PR TITLE
[#622] Add support for EntityViewSetting in Spring

### DIFF
--- a/integration/spring-data/base/src/main/java/com/blazebit/persistence/spring/data/base/query/JpaParameters.java
+++ b/integration/spring-data/base/src/main/java/com/blazebit/persistence/spring/data/base/query/JpaParameters.java
@@ -21,6 +21,11 @@ import com.blazebit.persistence.spring.data.repository.KeysetPageable;
 import org.springframework.core.MethodParameter;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.Temporal;
+
+import com.blazebit.persistence.spring.data.annotation.OptionalParam;
+import com.blazebit.persistence.spring.data.base.query.JpaParameters.JpaParameter;
+import com.blazebit.persistence.spring.data.repository.EntityViewSettingProcessor;
+
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.repository.query.Parameter;
 import org.springframework.data.repository.query.Parameters;
@@ -144,6 +149,35 @@ public class JpaParameters extends Parameters<JpaParameters, JpaParameter> {
         return getSpecificationIndex() >= 0;
     }
 
+    /**
+     * Returns the index of the {@link EntityViewSettingProcessor} {@link Method} parameter if available. Will return
+     * {@literal -1} if there is no {@link EntityViewSettingProcessor} parameter in the {@link Method}'s parameter list.
+     *
+     * @return the index of the processor parameter, or -1 if not present
+     */
+    public int getEntityViewSettingProcessorIndex() {
+        int index = 0;
+
+        for (JpaParameter candidate : this) {
+            if (candidate.isEntityViewSettingProcessorParameter()) {
+                return index;
+            }
+            ++index;
+        }
+
+        return -1;
+    }
+
+    /**
+     * Returns whether the method the {@link Parameters} was created for contains a {@link EntityViewSettingProcessor}
+     * parameter.
+     *
+     * @return true if the methods has a processor parameter
+     */
+    public boolean hasEntityViewSettingProcessorParameter() {
+        return getEntityViewSettingProcessorIndex() >= 0;
+    }
+
     /*
      * (non-Javadoc)
      * @see org.springframework.data.repository.query.Parameters#createParameter(org.springframework.core.MethodParameter)
@@ -214,7 +248,8 @@ public class JpaParameters extends Parameters<JpaParameters, JpaParameter> {
 
         @Override
         public boolean isSpecialParameter() {
-            return super.isSpecialParameter() || isOptionalParameter() || isSpecificationParameter();
+            return super.isSpecialParameter() || isOptionalParameter() || isSpecificationParameter()
+                || isEntityViewSettingProcessorParameter();
         }
 
         boolean isOptionalParameter() {
@@ -223,6 +258,10 @@ public class JpaParameters extends Parameters<JpaParameters, JpaParameter> {
 
         boolean isSpecificationParameter() {
             return Specification.class.isAssignableFrom(parameter.getParameterType());
+        }
+
+        boolean isEntityViewSettingProcessorParameter() {
+            return EntityViewSettingProcessor.class.isAssignableFrom(parameter.getParameterType());
         }
 
         /**

--- a/integration/spring-data/base/src/main/java/com/blazebit/persistence/spring/data/repository/EntityViewSettingProcessor.java
+++ b/integration/spring-data/base/src/main/java/com/blazebit/persistence/spring/data/repository/EntityViewSettingProcessor.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014 - 2018 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.spring.data.repository;
+
+import com.blazebit.persistence.view.EntityViewSetting;
+
+/**
+ * @author Giovanni Lovato
+ * @since 1.3.0
+ */
+public interface EntityViewSettingProcessor<T> {
+
+    /**
+     * Processes the {@link EntityViewSetting} to allow additional Entity View customization during query creation.
+     *
+     * @param setting the {@link EntityViewSetting} to be processed
+     * @return the final {@link EntityViewSetting} to allow further processing
+     */
+    EntityViewSetting<T, ?> acceptEntityViewSetting(EntityViewSetting<T, ?> setting);
+}

--- a/integration/spring-data/testsuite/src/test/java/com/blazebit/persistence/spring/data/testsuite/DocumentRepositoryTest.java
+++ b/integration/spring-data/testsuite/src/test/java/com/blazebit/persistence/spring/data/testsuite/DocumentRepositoryTest.java
@@ -29,11 +29,14 @@ import com.blazebit.persistence.spring.data.testsuite.repository.DocumentViewRep
 import com.blazebit.persistence.spring.data.testsuite.tx.TransactionalWorkService;
 import com.blazebit.persistence.spring.data.testsuite.tx.TxWork;
 import com.blazebit.persistence.spring.data.testsuite.view.DocumentView;
+import com.blazebit.persistence.spring.data.repository.EntityViewSettingProcessor;
 import com.blazebit.persistence.spring.data.repository.KeysetAwarePage;
 import com.blazebit.persistence.spring.data.repository.KeysetPageRequest;
 import com.blazebit.persistence.testsuite.base.jpa.category.NoDatanucleus;
 import com.blazebit.persistence.testsuite.base.jpa.category.NoEclipselink;
 import com.blazebit.persistence.testsuite.base.jpa.category.NoHibernate42;
+import com.blazebit.persistence.view.EntityViewSetting;
+
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
@@ -561,6 +564,28 @@ public class DocumentRepositoryTest extends AbstractSpringTest {
 
         // Then
         assertEquals(2, actual.size());
+        assertEquals(actual.get(0).getOptionalParameter(), param);
+    }
+
+    @Test
+    public void testEntityViewSettingProcessorParameter() {
+        // Given
+        String name = "D1";
+        String param = "Foo";
+        createDocument(name);
+
+        // When
+        List<DocumentView> actual = documentRepository.findAll(new EntityViewSettingProcessor<DocumentView>() {
+
+            @Override
+            public EntityViewSetting<DocumentView, ?> acceptEntityViewSetting(EntityViewSetting<DocumentView, ?> setting) {
+                setting.addOptionalParameter("optionalParameter", "Foo");
+                return setting;
+            }
+        });
+
+        // Then
+        assertEquals(1, actual.size());
         assertEquals(actual.get(0).getOptionalParameter(), param);
     }
 

--- a/integration/spring-data/testsuite/src/test/java/com/blazebit/persistence/spring/data/testsuite/repository/DocumentRepository.java
+++ b/integration/spring-data/testsuite/src/test/java/com/blazebit/persistence/spring/data/testsuite/repository/DocumentRepository.java
@@ -18,6 +18,7 @@ package com.blazebit.persistence.spring.data.testsuite.repository;
 
 import com.blazebit.persistence.spring.data.annotation.OptionalParam;
 import com.blazebit.persistence.spring.data.repository.EntityViewRepository;
+import com.blazebit.persistence.spring.data.repository.EntityViewSettingProcessor;
 import com.blazebit.persistence.spring.data.repository.EntityViewSpecificationExecutor;
 import com.blazebit.persistence.spring.data.repository.KeysetAwarePage;
 import com.blazebit.persistence.spring.data.testsuite.entity.Document;
@@ -78,4 +79,6 @@ public interface DocumentRepository<T> extends EntityViewRepository<T, Long>, En
     Page<DocumentView> findByNameOrderById(String name, Pageable pageable, @OptionalParam("optionalParameter") String optionalParameter);
 
     List<DocumentView> findAll(Specification<Document> specification, @OptionalParam("optionalParameter") String optionalParameter);
+
+    List<DocumentView> findAll(EntityViewSettingProcessor<DocumentView> processor);
 }


### PR DESCRIPTION
## Description
Adds `EntityViewSettingProcessor` interface which can be used as a parameter of Spring Data repository to customize the `EntityViewSetting` during the query creation.

## Related Issue
Fixes #622