### PR TITLE
Add support for view property sorting with Spring Sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,9 +681,9 @@ DataNucleus requires bytecode enhancement to work properly which requires an ext
 Usually when switching the JPA provider profile, it is recommended to trigger a _Rebuild Project_ action in IntelliJ to avoid strange errors causes by previous bytecode enhancement runs.
 After that, the entities in the project *core/testsuite* have to be enhanced. This is done through a Maven command.
 
-* DataNucleus 4: `mvn -P "datanucleus-4" -pl core/testsuite datanucleus:enhance`
-* DataNucleus 5: `mvn -P "datanucleus-5" -pl core/testsuite datanucleus:enhance`
-* DataNucleus 5.1: `mvn -P "datanucleus-5.1" -pl core/testsuite datanucleus:enhance`
+* DataNucleus 4: `mvn -P "datanucleus-4,h2,deltaspike-1.8,spring-data-2.0.x,eclipselink" -pl core/testsuite,integration/spring-data/testsuite datanucleus:enhance`
+* DataNucleus 5: `mvn -P "datanucleus-5,h2,deltaspike-1.8,spring-data-2.0.x,eclipselink" -pl core/testsuite,integration/spring-data/testsuite datanucleus:enhance`
+* DataNucleus 5.1: `mvn -P "datanucleus-5.1,h2,deltaspike-1.8,spring-data-2.0.x,eclipselink" -pl core/testsuite,integration/spring-data/testsuite datanucleus:enhance`
 
 After doing that, you should be able to execute any test in IntelliJ.
 

--- a/integration/spring-data/base/src/main/java/com/blazebit/persistence/spring/data/base/EntityViewSortUtil.java
+++ b/integration/spring-data/base/src/main/java/com/blazebit/persistence/spring/data/base/EntityViewSortUtil.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2014 - 2018 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.spring.data.base;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.NullHandling;
+import org.springframework.data.domain.Sort.Order;
+
+import com.blazebit.persistence.view.EntityViewManager;
+import com.blazebit.persistence.view.EntityViewSetting;
+import com.blazebit.persistence.view.Sorter;
+import com.blazebit.persistence.view.Sorters;
+import com.blazebit.persistence.view.metamodel.ManagedViewType;
+import com.blazebit.persistence.view.metamodel.MethodAttribute;
+import com.blazebit.persistence.view.metamodel.PluralAttribute;
+import com.blazebit.persistence.view.metamodel.SingularAttribute;
+import com.blazebit.persistence.view.metamodel.Type;
+
+/**
+ * Utility methods to handle entity view sorting.
+ * 
+ * @author Giovanni Lovato
+ * @since 1.3.0
+ */
+
+public final class EntityViewSortUtil {
+
+    private EntityViewSortUtil() {
+    }
+
+    /**
+     * Checks if the given {@link Order} refers to a property of {@code entityViewClass}.
+     * 
+     * @param evm the entity view manager
+     * @param entityViewClass the entity view class
+     * @param order the order
+     * @return true, if the given order refers to a view property
+     */
+    public static boolean isEntityViewSorting(EntityViewManager evm, Class<?> entityViewClass, Order order) {
+        String property = order.getProperty();
+        ManagedViewType<?> viewType = evm.getMetamodel().view(entityViewClass);
+        for (String path : property.split("\\.")) {
+            MethodAttribute<?, ?> attribute = viewType.getAttribute(path);
+            if (attribute == null) {
+                return false;
+            } else {
+                Type<?> type;
+                if (attribute instanceof SingularAttribute) {
+                    type = ((SingularAttribute<?, ?>) attribute).getType();
+                } else {
+                    type = ((PluralAttribute<?, ?, ?>) attribute).getElementType();
+                }
+                if (type instanceof ManagedViewType) {
+                    // It's a view type, continue descending
+                    viewType = (ManagedViewType<?>) type;
+                } else {
+                    // It's a basic type, sort by that
+                    return true;
+                }
+            }
+        }
+        return viewType != null;
+    }
+
+    /**
+     * Process a {@link Sort} instance applying entity-view related sort orders to {@code setting} and
+     * returning a new {@link Sort} instance with only entity related sort orders.
+     * 
+     * @param evm the entity view manager
+     * @param setting the entity view setting
+     * @param sort the sort instance
+     * @return a new {@link Sort} with only entity related sort orders
+     */
+    public static <T> Sort processEntityViewSortOrders(EntityViewManager evm, EntityViewSetting<T, ?> setting, Sort sort) {
+        Class<T> entityViewClass = setting.getEntityViewClass();
+        List<Order> orders = new ArrayList<>();
+        Map<String, Sorter> sorters = new HashMap<>();
+        for (Order order : sort) {
+            if (isEntityViewSorting(evm, entityViewClass, order)) {
+                boolean nullsFirst = order.getNullHandling().equals(NullHandling.NULLS_FIRST);
+                Sorter sorter = order.isAscending() ? Sorters.ascending(nullsFirst) : Sorters.descending(nullsFirst);
+                String property = order.getProperty();
+                sorters.putIfAbsent(property, sorter);
+            } else {
+                orders.add(order);
+            }
+        }
+        setting.addAttributeSorters(sorters);
+        return orders.isEmpty() ? null : new Sort(orders);
+    }
+
+    /**
+     * Returns a new {@link Sort} instance with only entity related sort orders.
+     *
+     * @param evm the entity view manager
+     * @param entityViewClass the entity view class
+     * @param sort the sort instance
+     * @return a new {@link Sort} with only entity related sort orders
+     */
+    public static Sort removeEntityViewSortOrders(EntityViewManager evm, Class<?> entityViewClass, Sort sort) {
+        List<Order> orders = new ArrayList<>();
+        for (Order order : sort) {
+            if (!isEntityViewSorting(evm, entityViewClass, order)) {
+                orders.add(order);
+            }
+        }
+        return orders.isEmpty() ? null : new Sort(orders);
+    }
+
+}

--- a/integration/spring-data/base/src/main/java/com/blazebit/persistence/spring/data/base/query/AbstractPartTreeBlazePersistenceQuery.java
+++ b/integration/spring-data/base/src/main/java/com/blazebit/persistence/spring/data/base/query/AbstractPartTreeBlazePersistenceQuery.java
@@ -347,11 +347,15 @@ public abstract class AbstractPartTreeBlazePersistenceQuery extends AbstractJpaQ
             Sort sort;
             int sortIndex = parameters.getSortIndex();
             if (sortIndex >= 0 && (sort = (Sort) values[sortIndex]) != null) {
-                EntityViewSortUtil.processEntityViewSortOrders(evm, setting, sort);
+                setting.addAttributeSorters(
+                        EntityViewSortUtil.createEntityViewSortersFromSort(evm, setting.getEntityViewClass(), sort)
+                );
             }
             int pageableIndex = parameters.getPageableIndex();
             if (pageableIndex >= 0 && (sort = ((Pageable) values[pageableIndex]).getSort()) != null) {
-                EntityViewSortUtil.processEntityViewSortOrders(evm, setting, sort);
+                setting.addAttributeSorters(
+                    EntityViewSortUtil.createEntityViewSortersFromSort(evm, setting.getEntityViewClass(), sort)
+                );
             }
             int entityViewSettingProcessorIndex = parameters.getEntityViewSettingProcessorIndex();
             if (entityViewSettingProcessorIndex >= 0) {

--- a/integration/spring-data/base/src/main/java/com/blazebit/persistence/spring/data/base/repository/AbstractEntityViewAwareRepository.java
+++ b/integration/spring-data/base/src/main/java/com/blazebit/persistence/spring/data/base/repository/AbstractEntityViewAwareRepository.java
@@ -492,15 +492,22 @@ public abstract class AbstractEntityViewAwareRepository<V, E, ID extends Seriali
             if (pageable == null) {
                 EntityViewSetting<V, CriteriaBuilder<V>> setting = EntityViewSetting.create(entityViewClass);
                 if (sort != null) {
-                    EntityViewSortUtil.processEntityViewSortOrders(evm, setting, sort);
+                    setting.addAttributeSorters(
+                            EntityViewSortUtil.createEntityViewSortersFromSort(evm, setting.getEntityViewClass(), sort)
+                    );
                 }
                 query = evm.applySetting(setting, cb).getQuery();
             } else {
                 EntityViewSetting<V, PaginatedCriteriaBuilder<V>> setting = EntityViewSetting.create(entityViewClass, getOffset(pageable), pageable.getPageSize());
                 if (sort != null) {
-                    EntityViewSortUtil.processEntityViewSortOrders(evm, setting, sort);
+                    setting.addAttributeSorters(
+                            EntityViewSortUtil.createEntityViewSortersFromSort(evm, setting.getEntityViewClass(), sort)
+                    );
+
                 } else if (pageable.getSort() != null) {
-                    EntityViewSortUtil.processEntityViewSortOrders(evm, setting, pageable.getSort());
+                    setting.addAttributeSorters(
+                            EntityViewSortUtil.createEntityViewSortersFromSort(evm, setting.getEntityViewClass(), pageable.getSort())
+                    );
                 }
                 if (pageable instanceof KeysetPageable) {
                     KeysetPageable keysetPageable = (KeysetPageable) pageable;

--- a/integration/spring-data/base/src/main/java/org/springframework/data/jpa/repository/query/FixedJpaQueryCreator.java
+++ b/integration/spring-data/base/src/main/java/org/springframework/data/jpa/repository/query/FixedJpaQueryCreator.java
@@ -132,7 +132,7 @@ public class FixedJpaQueryCreator extends AbstractQueryCreator<CriteriaQuery<Obj
      * Moritz Becker: Rewrote NOT and NOT_IN cases to explicitely cast criteria IN argument to Expression&lt;Collection&lt;?&gt;&gt; which is needed
      * to work around an EclipseLink bug.
      *
-     * @author Phil Webb
+     * @author Phil Webbare not assignable to the given expression type
      * @author Oliver Gierke
      * @author Moritz Becker
      */

--- a/integration/spring-data/base/src/main/java/org/springframework/data/jpa/repository/query/FixedJpaQueryCreator.java
+++ b/integration/spring-data/base/src/main/java/org/springframework/data/jpa/repository/query/FixedJpaQueryCreator.java
@@ -132,7 +132,7 @@ public class FixedJpaQueryCreator extends AbstractQueryCreator<CriteriaQuery<Obj
      * Moritz Becker: Rewrote NOT and NOT_IN cases to explicitely cast criteria IN argument to Expression&lt;Collection&lt;?&gt;&gt; which is needed
      * to work around an EclipseLink bug.
      *
-     * @author Phil Webbare not assignable to the given expression type
+     * @author Phil Webb
      * @author Oliver Gierke
      * @author Moritz Becker
      */

--- a/integration/spring-data/testsuite/pom.xml
+++ b/integration/spring-data/testsuite/pom.xml
@@ -1830,7 +1830,7 @@
                         <version>4.0.0-release</version>
                         <configuration>
                             <api>JPA</api>
-                            <persistenceUnitName>TestsuiteBase</persistenceUnitName>
+                            <persistenceUnitName>TEST-PU</persistenceUnitName>
                             <verbose>false</verbose>
                             <fork>true</fork>
                             <log4jConfiguration>${basedir}/log4j.properties</log4jConfiguration>

--- a/integration/spring-data/testsuite/src/main/java/com/blazebit/persistence/spring/data/testsuite/entity/Person.java
+++ b/integration/spring-data/testsuite/src/main/java/com/blazebit/persistence/spring/data/testsuite/entity/Person.java
@@ -20,7 +20,10 @@ import javax.persistence.Basic;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.OneToMany;
+
 import java.io.Serializable;
+import java.util.Set;
 
 /**
  * @author Christian Beikov
@@ -34,6 +37,7 @@ public class Person implements Serializable {
     private Long id;
     private String name;
     private long age;
+    private Set<Document> documents;
 
     public Person() {
     }
@@ -72,5 +76,14 @@ public class Person implements Serializable {
 
     public void setAge(long age) {
         this.age = age;
+    }
+
+    @OneToMany(mappedBy = "owner")
+    public Set<Document> getDocuments() {
+        return documents;
+    }
+
+    public void setDocuments(Set<Document> documents) {
+        this.documents = documents;
     }
 }

--- a/integration/spring-data/testsuite/src/main/java/com/blazebit/persistence/spring/data/testsuite/entity/Person.java
+++ b/integration/spring-data/testsuite/src/main/java/com/blazebit/persistence/spring/data/testsuite/entity/Person.java
@@ -23,6 +23,7 @@ import javax.persistence.Id;
 import javax.persistence.OneToMany;
 
 import java.io.Serializable;
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -37,7 +38,7 @@ public class Person implements Serializable {
     private Long id;
     private String name;
     private long age;
-    private Set<Document> documents;
+    private Set<Document> documents = new HashSet<>(0);
 
     public Person() {
     }

--- a/integration/spring-data/testsuite/src/test/java/com/blazebit/persistence/spring/data/testsuite/DocumentRepositoryTest.java
+++ b/integration/spring-data/testsuite/src/test/java/com/blazebit/persistence/spring/data/testsuite/DocumentRepositoryTest.java
@@ -639,7 +639,7 @@ public class DocumentRepositoryTest extends AbstractSpringTest {
         // Given
         String doc1 = "D1";
         String doc2 = "D2";
-        String doc3 = "D2";
+        String doc3 = "D3";
         Person person = createPerson("Foo");
         createDocument(doc1, person);
         createDocument(doc2, person);
@@ -701,8 +701,12 @@ public class DocumentRepositoryTest extends AbstractSpringTest {
                 Document d = new Document(name);
                 d.setDescription(description);
                 d.setAge(age);
-                d.setOwner(owner);
                 em.persist(d);
+                if (owner != null) {
+                    d.setOwner(owner);
+                    owner.getDocuments().add(d);
+                    em.merge(owner);
+                }
                 return d;
             }
         });

--- a/integration/spring-data/testsuite/src/test/java/com/blazebit/persistence/spring/data/testsuite/DocumentRepositoryTest.java
+++ b/integration/spring-data/testsuite/src/test/java/com/blazebit/persistence/spring/data/testsuite/DocumentRepositoryTest.java
@@ -663,15 +663,15 @@ public class DocumentRepositoryTest extends AbstractSpringTest {
         String doc2 = "D2";
         String doc3 = "D2";
         Person person = createPerson("Foo");
-        createDocument(doc1, "A", 0l, person);
-        createDocument(doc2, "B", 0l, person);
+        createDocument(doc1, "A", 0L, person);
+        createDocument(doc2, "B", 0L, person);
         createDocument(doc3, createPerson("Bar"));
 
         String entityViewSortProperty = "ownerDocumentCount";
         String entitySortProperty = "description";
 
         List<DocumentView> list = documentRepository.findAll(
-                Sort.by(
+                new Sort(
                     new Sort.Order(Direction.ASC, entityViewSortProperty),
                     new Sort.Order(Direction.DESC, entitySortProperty)
                 ),
@@ -682,15 +682,15 @@ public class DocumentRepositoryTest extends AbstractSpringTest {
         assertEquals(doc1, list.get(2).getName());
 
         list = documentRepository.findAll(
-                Sort.by(
-                    new Sort.Order(Direction.DESC, entityViewSortProperty),
-                    new Sort.Order(Direction.ASC, entitySortProperty)
+                new Sort(
+                    new Sort.Order(Direction.ASC, entitySortProperty),
+                    new Sort.Order(Direction.ASC, entityViewSortProperty)
                 ),
                 "foo");
 
         assertEquals(doc1, list.get(0).getName());
-        assertEquals(doc2, list.get(1).getName());
-        assertEquals(doc3, list.get(2).getName());
+        assertEquals(doc3, list.get(1).getName());
+        assertEquals(doc2, list.get(2).getName());
     }
 
     private List<Long> getIdsFromViews(Iterable<DocumentAccessor> views) {
@@ -706,7 +706,7 @@ public class DocumentRepositoryTest extends AbstractSpringTest {
     }
 
     private Document createDocument(final String name, final Person owner) {
-        return createDocument(name, null, 0l, owner);
+        return createDocument(name, null, 0L, owner);
     }
 
     private Document createDocument(final String name, final String description, final long age, final Person owner) {

--- a/integration/spring-data/testsuite/src/test/java/com/blazebit/persistence/spring/data/testsuite/DocumentRepositoryTest.java
+++ b/integration/spring-data/testsuite/src/test/java/com/blazebit/persistence/spring/data/testsuite/DocumentRepositoryTest.java
@@ -635,7 +635,7 @@ public class DocumentRepositoryTest extends AbstractSpringTest {
     }
 
     @Test
-    public void testEntityViewPropertySorting() {
+    public void testEntityViewAttributeSorting() {
         // Given
         String doc1 = "D1";
         String doc2 = "D2";
@@ -657,24 +657,39 @@ public class DocumentRepositoryTest extends AbstractSpringTest {
     }
 
     @Test
-    public void testEntityViewPropertySortingPartTree() {
+    public void testMixedEntityViewAndEntityAttributeSortingPartTree() {
         // Given
         String doc1 = "D1";
         String doc2 = "D2";
         String doc3 = "D2";
         Person person = createPerson("Foo");
-        createDocument(doc1, person);
-        createDocument(doc2, person);
+        createDocument(doc1, "A", 0l, person);
+        createDocument(doc2, "B", 0l, person);
         createDocument(doc3, createPerson("Bar"));
 
-        String sortProperty = "ownerDocumentCount";
+        String entityViewSortProperty = "ownerDocumentCount";
+        String entitySortProperty = "description";
 
-        List<DocumentView> list = documentRepository.findAll(new Sort(Direction.ASC, sortProperty), "foo");
+        List<DocumentView> list = documentRepository.findAll(
+                Sort.by(
+                    new Sort.Order(Direction.ASC, entityViewSortProperty),
+                    new Sort.Order(Direction.DESC, entitySortProperty)
+                ),
+                "foo");
 
         assertEquals(doc3, list.get(0).getName());
+        assertEquals(doc2, list.get(1).getName());
+        assertEquals(doc1, list.get(2).getName());
 
-        list = documentRepository.findAll(new Sort(Direction.DESC, sortProperty), "foo");
+        list = documentRepository.findAll(
+                Sort.by(
+                    new Sort.Order(Direction.DESC, entityViewSortProperty),
+                    new Sort.Order(Direction.ASC, entitySortProperty)
+                ),
+                "foo");
 
+        assertEquals(doc1, list.get(0).getName());
+        assertEquals(doc2, list.get(1).getName());
         assertEquals(doc3, list.get(2).getName());
     }
 

--- a/integration/spring-data/testsuite/src/test/java/com/blazebit/persistence/spring/data/testsuite/DocumentRepositoryTest.java
+++ b/integration/spring-data/testsuite/src/test/java/com/blazebit/persistence/spring/data/testsuite/DocumentRepositoryTest.java
@@ -55,6 +55,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.test.annotation.DirtiesContext;
@@ -580,7 +581,7 @@ public class DocumentRepositoryTest extends AbstractSpringTest {
 
             @Override
             public EntityViewSetting<DocumentView, ?> acceptEntityViewSetting(EntityViewSetting<DocumentView, ?> setting) {
-                setting.addOptionalParameter("optionalParameter", "Foo");
+                setting.addOptionalParameter("optionalParameter", param);
                 return setting;
             }
         });
@@ -631,6 +632,50 @@ public class DocumentRepositoryTest extends AbstractSpringTest {
 
         // Then
         assertEquals(3, keysetAwarePage.getKeysetPage().getKeysets().size());
+    }
+
+    @Test
+    public void testEntityViewPropertySorting() {
+        // Given
+        String doc1 = "D1";
+        String doc2 = "D2";
+        String doc3 = "D2";
+        Person person = createPerson("Foo");
+        createDocument(doc1, person);
+        createDocument(doc2, person);
+        createDocument(doc3, createPerson("Bar"));
+
+        String sortProperty = "ownerDocumentCount";
+
+        List<DocumentView> list = documentRepository.findAll(new Sort(Direction.ASC, sortProperty));
+
+        assertEquals(doc3, list.get(0).getName());
+
+        list = documentRepository.findAll(new Sort(Direction.DESC, sortProperty));
+
+        assertEquals(doc3, list.get(2).getName());
+    }
+
+    @Test
+    public void testEntityViewPropertySortingPartTree() {
+        // Given
+        String doc1 = "D1";
+        String doc2 = "D2";
+        String doc3 = "D2";
+        Person person = createPerson("Foo");
+        createDocument(doc1, person);
+        createDocument(doc2, person);
+        createDocument(doc3, createPerson("Bar"));
+
+        String sortProperty = "ownerDocumentCount";
+
+        List<DocumentView> list = documentRepository.findAll(new Sort(Direction.ASC, sortProperty), "foo");
+
+        assertEquals(doc3, list.get(0).getName());
+
+        list = documentRepository.findAll(new Sort(Direction.DESC, sortProperty), "foo");
+
+        assertEquals(doc3, list.get(2).getName());
     }
 
     private List<Long> getIdsFromViews(Iterable<DocumentAccessor> views) {

--- a/integration/spring-data/testsuite/src/test/java/com/blazebit/persistence/spring/data/testsuite/repository/DocumentRepository.java
+++ b/integration/spring-data/testsuite/src/test/java/com/blazebit/persistence/spring/data/testsuite/repository/DocumentRepository.java
@@ -24,6 +24,7 @@ import com.blazebit.persistence.spring.data.testsuite.view.DocumentView;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.Query;
@@ -80,4 +81,8 @@ public interface DocumentRepository<T> extends EntityViewRepository<T, Long>, En
     List<DocumentView> findAll(EntityViewSettingProcessor<DocumentView> processor);
 
     List<DocumentView> findAll(BlazeSpecification processor);
+
+    List<DocumentView> findAll(Sort sort);
+
+    List<DocumentView> findAll(Sort sort, @OptionalParam("optionalParameter") String optionalParameter);
 }

--- a/integration/spring-data/testsuite/src/test/java/com/blazebit/persistence/spring/data/testsuite/view/DocumentView.java
+++ b/integration/spring-data/testsuite/src/test/java/com/blazebit/persistence/spring/data/testsuite/view/DocumentView.java
@@ -19,6 +19,7 @@ package com.blazebit.persistence.spring.data.testsuite.view;
 import com.blazebit.persistence.spring.data.testsuite.entity.Document;
 import com.blazebit.persistence.view.EntityView;
 import com.blazebit.persistence.view.IdMapping;
+import com.blazebit.persistence.view.Mapping;
 import com.blazebit.persistence.view.MappingParameter;
 
 /**
@@ -34,6 +35,9 @@ public interface DocumentView {
     String getName();
 
     PersonView getOwner();
+
+    @Mapping("size(owner.documents)")
+    long getOwnerDocumentCount();
 
     @MappingParameter("optionalParameter")
     String getOptionalParameter();


### PR DESCRIPTION
## Description
This adds support for entity-view property sorting via Spring `Sort`: it checks if `Sort` contains properties which are sortable via entity-view sorters, if so it creates a `Sorter` and apply it to the view setting; it also replace the original `Sort` with a new one without the sorting which has been delegated to the view setting.

This is applied both to `AbstractEntityViewAwareRepository` and `AbstractPartTreeBlazePersistenceQuery` to support both concrete and derived methods.

## Motivation and Context
This allows sorting by entity-view properties without the need of explicitly create and add `Sorter`s to the entity-view setting.
