### PR TITLE
Add One suffix to method name pattern

### DIFF
--- a/integration/spring-data/base/src/main/java/com/blazebit/persistence/spring/data/base/query/AbstractPartTreeBlazePersistenceQuery.java
+++ b/integration/spring-data/base/src/main/java/com/blazebit/persistence/spring/data/base/query/AbstractPartTreeBlazePersistenceQuery.java
@@ -63,7 +63,7 @@ import java.util.regex.Pattern;
  */
 public abstract class AbstractPartTreeBlazePersistenceQuery extends AbstractJpaQuery {
 
-    private static final Pattern QUERY_PATTERN = Pattern.compile("^(find|read|get|query|stream)All$");
+    private static final Pattern QUERY_PATTERN = Pattern.compile("^(((find|read|get|query)(All|One))|streamAll)$");
 
     private final Class<?> domainClass;
     private final Class<?> entityViewClass;


### PR DESCRIPTION
## Description
This let methods like

```
FooView findOne(Specification<Foo> spec, @OptionalParam("foo") String foo);
```

to be handled by `AbstractPartTreeBlazePersistenceQuery`, which otherwise would throw a `No property findOne found for type Foo` exception.