### PR TITLE
Support spring-data-jpa 2.1.6

### DIFF
--- a/integration/spring-data/2.1/src/main/java/com/blazebit/persistence/spring/data/impl/repository/BlazePersistenceRepositoryFactoryBean.java
+++ b/integration/spring-data/2.1/src/main/java/com/blazebit/persistence/spring/data/impl/repository/BlazePersistenceRepositoryFactoryBean.java
@@ -140,4 +140,8 @@ public class BlazePersistenceRepositoryFactoryBean<T extends Repository<S, ID>, 
         super.afterPropertiesSet();
     }
 
+    public void setEscapeCharacter(char escapeCharacter) {
+        // Needed to work with Spring Boot 2.1.4
+    }
+
 }


### PR DESCRIPTION
Spring Boot 2.1.4 brings `spring-data-jpa` version 2.1.6 which fails at startup if the repository-factory bean lacks a setter for the property `escapeCharacter`.

This PR simply adds a no-op setter, since a real setter would require the updated dependency for the missing type `EscapeCharacter` to be set on the repository-factory, e.g.

```java
public void setEscapeCharacter(char escapeCharacter) {
    EscapeCharacter ec = EscapeCharacter.of(escapeCharacter);
    respositoryFactory.setEscapeCharacter(ec);
}
```

The no-op setter fixes Spring Boot 2.1.4+ apps from throwing on startup.