### PR TITLE
Use entityClass in fromEntitySubquery methods as parameter name

### DIFF
--- a/core/api/src/main/java/com/blazebit/persistence/FromBaseBuilder.java
+++ b/core/api/src/main/java/com/blazebit/persistence/FromBaseBuilder.java
@@ -248,33 +248,33 @@ public interface FromBaseBuilder<X extends FromBaseBuilder<X>> {
      * Like {@link FromBaseBuilder#fromEntitySubquery(Class, String)} with the
      * alias equivalent to the camel cased result of what {@link Class#getSimpleName()} of the entity class returns.
      *
-     * @param cteClass The entity type for the subquery in the FROM clause
+     * @param entityClass The entity type for the subquery in the FROM clause
      * @return The CTE builder for the subquery in the FROM clause
      * @since 1.4.1
      */
-    public FullSelectCTECriteriaBuilder<X> fromEntitySubquery(Class<?> cteClass);
+    public FullSelectCTECriteriaBuilder<X> fromEntitySubquery(Class<?> entityClass);
 
     /**
      * Like calling {@link FromBaseBuilder#from(Class, String)} followed by {@link CTEBuilder#with(Class, boolean)} with <code>inline = true</code>.
      * Registers the given entity type as FROM clause node under the given alias and returns a CTE builder that will be inlined with all attributes bound.
      *
-     * @param cteClass The entity type for the subquery in the FROM clause
+     * @param entityClass The entity type for the subquery in the FROM clause
      * @param alias The alias for the FROM clause item
      * @return The CTE builder for the subquery in the FROM clause
      * @since 1.4.1
      */
-    public FullSelectCTECriteriaBuilder<X> fromEntitySubquery(Class<?> cteClass, String alias);
+    public FullSelectCTECriteriaBuilder<X> fromEntitySubquery(Class<?> entityClass, String alias);
 
     /**
      * Like calling {@link FromBaseBuilder#from(Class, String)} followed by {@link CTEBuilder#with(Class, boolean)} with <code>inline = true</code>.
      * Registers the given entity type as FROM clause node under the given alias and returns a CTE builder that will be inlined with all attributes bound.
      *
-     * @param cteClass The entity type for the subquery in the FROM clause
+     * @param entityClass The entity type for the subquery in the FROM clause
      * @param alias The alias for the FROM clause item
      * @param subqueryAlias The alias for the FROM clause item in the subquery
      * @return The CTE builder for the subquery in the FROM clause
      * @since 1.4.1
      */
-    public FullSelectCTECriteriaBuilder<X> fromEntitySubquery(Class<?> cteClass, String alias, String subqueryAlias);
+    public FullSelectCTECriteriaBuilder<X> fromEntitySubquery(Class<?> entityClass, String alias, String subqueryAlias);
 
 }


### PR DESCRIPTION
As I understand the API these methods should use entityClass as parameter name.

<!--- This template is for code related PRs. Remove it for e.g. documentation PRs. -->

<!--- Prefix the title with the issue number like "[#123] Some title" and try to summarize the changes in the title -->

<!--- Before submitting the PR, please make sure it satisfies the following guidelines -->
<!---  * Tests for issues should have one commit that has the form "Test for #123" where "#123" is the issue number -->
<!---  * Fixes for issues should have one commit that has the form "Fix for #123" where "#123" is the issue number -->
<!---  * Commits for the test and the fix should be separate -->

## Description
<!--- Give an overview of what you changed -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue(s) here: -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

