### PR TITLE
Update 04_from_clause.adoc

### DIFF
--- a/documentation/src/main/asciidoc/core/manual/en_US/04_from_clause.adoc
+++ b/documentation/src/main/asciidoc/core/manual/en_US/04_from_clause.adoc
@@ -639,7 +639,7 @@ Databases are pretty good at eliminating unnecessary/unused projections in such 
 [source,java]
 ----
 CriteriaBuilder<Long> cb = cbf.create(em, Long.class)
-    .fromSubquery(Cat.class, "r")
+    .fromEntitySubquery(Cat.class, "r")
         .orderByDesc("age")
         .orderByDesc("id")
         .setMaxResults(5)
@@ -647,7 +647,7 @@ CriteriaBuilder<Long> cb = cbf.create(em, Long.class)
     .select("r.id");
 ----
 
-will result in something like the following
+will result in something like the following:
 
 [source,sql]
 ----
@@ -684,6 +684,8 @@ CriteriaBuilder<Tuple> cb = cbf.create(em, Tuple.class)
         .orderByDesc("id")
         .setMaxResults(5)
     .end()
+        .on("1").eqExpression("1")
+    .end()
     .select("c.name")
     .select("COUNT(topKitten.id)");
 ----
@@ -691,7 +693,7 @@ CriteriaBuilder<Tuple> cb = cbf.create(em, Tuple.class)
 The example query shows a special feature of lateral joins, which is the possibility to correlate a collection for a lateral join.
 This could also have been written by correlating an entity type and defining the correlation for the collection in the `WHERE` clause manually.
 
-The resulting JPQL might look like the following
+The resulting JPQL might look like the following:
 
 [source,sql]
 ----
@@ -702,7 +704,7 @@ LEFT JOIN LATERAL Cat(
     FROM Cat kitten
     ORDER BY kitten.age DESC, kitten.id DESC
     LIMIT 5
-) topKitten(age, father.id, id, mother.id, name)
+) topKitten(age, father.id, id, mother.id, name) ON 1=1
 GROUP BY c.name
 ----
 


### PR DESCRIPTION
* Missing on clause for `leftJoinLateralOnEntitySubquery` example (or should have been `leftJoinLateralEntitySubquery`).
* `fromSubquery` in entity subquery should have been `fromEntitySubquery`

<!--- This template is for code related PRs. Remove it for e.g. documentation PRs. -->

<!--- Prefix the title with the issue number like "[#123] Some title" and try to summarize the changes in the title -->

<!--- Before submitting the PR, please make sure it satisfies the following guidelines -->
<!---  * Tests for issues should have one commit that has the form "Test for #123" where "#123" is the issue number -->
<!---  * Fixes for issues should have one commit that has the form "Fix for #123" where "#123" is the issue number -->
<!---  * Commits for the test and the fix should be separate -->

## Description
<!--- Give an overview of what you changed -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue(s) here: -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

