### PR TITLE
docs: fixes a typo in `@UpdatableEntityView` example

### DIFF
--- a/documentation/src/main/asciidoc/entity-view/manual/en_US/updatable_entity_views.adoc
+++ b/documentation/src/main/asciidoc/entity-view/manual/en_US/updatable_entity_views.adoc
@@ -51,7 +51,7 @@ interface CatUpdateView {
     @IdMapping
     Long getId();
 
-    @MappingUpdatable(cascade = CascadeType.PERSIST)
+    @UpdatableMapping(cascade = CascadeType.PERSIST)
     OwnerView getOwner();
     void setOwner(OwnerView owner);
 }


### PR DESCRIPTION
Fixes a documentation typo in `@UpdatableEntityView` code example. `@MappingUpdatable` doesn't exists. The correct name is `@UpdatableMapping`