### PR TITLE
Move to the new Quarkus datasource configuration

### DIFF
--- a/examples/quarkus/testsuite/base/src/test/resources/application.properties
+++ b/examples/quarkus/testsuite/base/src/test/resources/application.properties
@@ -1,21 +1,21 @@
-%postgresql.quarkus.datasource.url=jdbc:postgresql://localhost:5432/test
-%postgresql.quarkus.datasource.driver=org.postgresql.Driver
+%postgresql.quarkus.datasource.db-kind=postgresql
 %postgresql.quarkus.datasource.username=postgres
 %postgresql.quarkus.datasource.password=postgres
+%postgresql.quarkus.datasource.jdbc.url=jdbc:postgresql://localhost:5432/test
 
-%h2.quarkus.datasource.url=jdbc:h2:tcp://localhost/mem:test
-%h2.quarkus.datasource.driver=org.h2.Driver
+%h2.quarkus.datasource.db-kind=h2
 %h2.quarkus.datasource.username=username-default
+%h2.quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:test
 
-%mysql8.quarkus.datasource.url=jdbc:mysql://localhost:3306/test?useUnicode=true&characterEncoding=utf8
-%mysql8.quarkus.datasource.driver=com.mysql.jdbc.Driver
+%mysql8.quarkus.datasource.db-kind=mysql
 %mysql8.quarkus.datasource.username=root
+%mysql8.quarkus.datasource.jdbc.url=jdbc:mysql://localhost:3306/test?useUnicode=true&characterEncoding=utf8
 %mysql8.quarkus.hibernate-orm.dialect=org.hibernate.dialect.MySQL8Dialect
 
-%mssql.quarkus.datasource.url=jdbc:sqlserver://localhost:1433
-%mssql.quarkus.datasource.driver=com.microsoft.sqlserver.jdbc.SQLServerDriver
+%mssql.quarkus.datasource.db-kind=mssql
 %mssql.quarkus.datasource.username=sa
 %mssql.quarkus.datasource.password=Blaze-Persistence
+%mssql.quarkus.datasource.jdbc.url=jdbc:sqlserver://localhost:1433
 
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.log.sql=false

--- a/examples/quarkus/testsuite/native/h2/src/main/resources/application.properties
+++ b/examples/quarkus/testsuite/native/h2/src/main/resources/application.properties
@@ -1,6 +1,6 @@
-quarkus.datasource.url=jdbc:h2:tcp://localhost/mem:test
-quarkus.datasource.driver=org.h2.Driver
+quarkus.datasource.db-kind=h2
 quarkus.datasource.username=username-default
+quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:test
 
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.log.sql=false

--- a/examples/quarkus/testsuite/native/mssql/src/main/resources/application.properties
+++ b/examples/quarkus/testsuite/native/mssql/src/main/resources/application.properties
@@ -1,7 +1,7 @@
-quarkus.datasource.url=jdbc:sqlserver://localhost:1433
-quarkus.datasource.driver=com.microsoft.sqlserver.jdbc.SQLServerDriver
+quarkus.datasource.db-kind=mssql
 quarkus.datasource.username=sa
 quarkus.datasource.password=Blaze-Persistence
+quarkus.datasource.jdbc.url=jdbc:sqlserver://localhost:1433
 
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.log.sql=false

--- a/examples/quarkus/testsuite/native/mysql/src/main/resources/application.properties
+++ b/examples/quarkus/testsuite/native/mysql/src/main/resources/application.properties
@@ -1,6 +1,6 @@
-quarkus.datasource.url=jdbc:mysql://localhost:3306/test?useUnicode=true&characterEncoding=utf8
-quarkus.datasource.driver=com.mysql.jdbc.Driver
+quarkus.datasource.db-kind=mysql
 quarkus.datasource.username=root
+quarkus.datasource.jdbc.url=jdbc:mysql://localhost:3306/test?useUnicode=true&characterEncoding=utf8
 quarkus.hibernate-orm.dialect=org.hibernate.dialect.MySQL8Dialect
 
 quarkus.hibernate-orm.database.generation=drop-and-create

--- a/examples/quarkus/testsuite/native/postgresql/src/main/resources/application.properties
+++ b/examples/quarkus/testsuite/native/postgresql/src/main/resources/application.properties
@@ -1,7 +1,7 @@
-quarkus.datasource.url=jdbc:postgresql://localhost:5432/test
-quarkus.datasource.driver=org.postgresql.Driver
+quarkus.datasource.db-kind=postgresql
 quarkus.datasource.username=postgres
 quarkus.datasource.password=postgres
+quarkus.datasource.jdbc.url=jdbc:postgresql://localhost:5432/test
 
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.log.sql=false

--- a/testsuite-base/jpa/src/main/java/com/blazebit/persistence/testsuite/base/jpa/SchemaClearer.java
+++ b/testsuite-base/jpa/src/main/java/com/blazebit/persistence/testsuite/base/jpa/SchemaClearer.java
@@ -61,10 +61,10 @@ public class SchemaClearer extends AbstractJpaPersistenceTest {
                 p.load(stream);
             }
 
-            properties.put("javax.persistence.jdbc.url", p.getProperty("quarkus.datasource.url"));
+            properties.put("javax.persistence.jdbc.url", p.getProperty("quarkus.datasource.jdbc.url"));
             properties.put("javax.persistence.jdbc.user", p.getProperty("quarkus.datasource.username"));
             properties.put("javax.persistence.jdbc.password", p.getProperty("quarkus.datasource.password"));
-            properties.put("javax.persistence.jdbc.driver", p.getProperty("quarkus.datasource.driver"));
+            properties.put("javax.persistence.jdbc.driver", p.getProperty("quarkus.datasource.jdbc.driver"));
         }
         DataSource dataSource = createDataSource(properties);
         try (Connection connection = dataSource.getConnection()) {


### PR DESCRIPTION
The new configuration was introduced in 1.3 and the old one deprecated.
We recently removed the support for the old configuration in master.

