### PR TITLE
Revert "[#1179] Fix NPE during flush for views that were converted with CREATE_NEW and contain an updatable inverse mapping"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ Not yet released
 * Fix boot exception when using Hibernate `@Where` on entity level
 * Properly set `fromClassExplicitlySet` flag when using the subquery `from(String correlationPath)` methods
 * Fix concurrency issue during `EntityViewUpdaterImpl` initialization which can lead to a NPE
-* Fix NPE during flush for views that were converted with `ConvertOption.CREATE_NEW` and contain an updatable inverse mapping
 
 ### Backwards-incompatible changes
 

--- a/entity-view/impl/src/main/java/com/blazebit/persistence/view/impl/update/flush/CollectionAttributeFlusher.java
+++ b/entity-view/impl/src/main/java/com/blazebit/persistence/view/impl/update/flush/CollectionAttributeFlusher.java
@@ -1207,10 +1207,8 @@ public class CollectionAttributeFlusher<E, V extends Collection<?>> extends Abst
                         // TODO: should "replace" mean that the initial values we know right now are "removed" or the actual current values?
                         Map<Object, Object> added = Collections.emptyMap();
                         Map<Object, Object> removed = new IdentityHashMap<>();
-                        if (initial != null) {
-                            for (Object o : (Collection<?>) initial) {
-                                removed.put(o, o);
-                            }
+                        for (Object o : (Collection<?>) initial) {
+                            removed.put(o, o);
                         }
 
                         List<CollectionElementAttributeFlusher<E, V>> elementFlushers = getInverseElementFlushersForActions(context, (Collection<?>) current, added, removed);


### PR DESCRIPTION
Reverts Blazebit/blaze-persistence#1180