### PR TITLE
Add support for spring boot 2.4.3 - fix objectMapper field access - fixes #1266

### DIFF
--- a/integration/spring-data/webmvc/src/main/java/com/blazebit/persistence/spring/data/webmvc/impl/json/EntityViewAwareMappingJackson2HttpMessageConverter.java
+++ b/integration/spring-data/webmvc/src/main/java/com/blazebit/persistence/spring/data/webmvc/impl/json/EntityViewAwareMappingJackson2HttpMessageConverter.java
@@ -38,7 +38,7 @@ public class EntityViewAwareMappingJackson2HttpMessageConverter extends MappingJ
     private final EntityViewAwareObjectMapper entityViewAwareObjectMapper;
 
     public EntityViewAwareMappingJackson2HttpMessageConverter(final EntityViewManager entityViewManager, EntityViewIdValueAccessor entityViewIdValueAccessor) {
-        this.entityViewAwareObjectMapper = new EntityViewAwareObjectMapper(entityViewManager, objectMapper, entityViewIdValueAccessor);
+        this.entityViewAwareObjectMapper = new EntityViewAwareObjectMapper(entityViewManager, getObjectMapper(), entityViewIdValueAccessor);
     }
 
     @Override
@@ -79,7 +79,7 @@ public class EntityViewAwareMappingJackson2HttpMessageConverter extends MappingJ
             if (inputMessage instanceof MappingJacksonInputMessage) {
                 Class<?> deserializationView = ((MappingJacksonInputMessage) inputMessage).getDeserializationView();
                 if (deserializationView != null) {
-                    return this.objectMapper.readerWithView(deserializationView).forType(javaType).
+                    return this.getObjectMapper().readerWithView(deserializationView).forType(javaType).
                             readValue(inputMessage.getBody());
                 }
             }


### PR DESCRIPTION
## Description
Use the `Getter` instead of direct field access - the field has been renamed to `defaultObjectMapper` in `2.4.3`


## Related Issue
Relates to #1266


## Motivation and Context
Add support for Spring Boot 2.4.3

