### PR TITLE
[#1285] Fix aliasing issues with joinOnSubquery variants on databases that don't support column aliasing at the table alias site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ None yet
 * Retain entity view kind when converting entity view if possible
 * Improve dialect detection for MariaDB dialects
 * Workaround Hibernate proxy field access bug for non-pk relations
+* Fix aliasing issues with `joinOnSubquery` variants on databases that don't support column aliasing at the table alias site
 
 ### Backwards-incompatible changes
 

--- a/core/testsuite/src/test/java/com/blazebit/persistence/testsuite/InlineCTETest.java
+++ b/core/testsuite/src/test/java/com/blazebit/persistence/testsuite/InlineCTETest.java
@@ -467,6 +467,31 @@ public class InlineCTETest extends AbstractCoreTest {
         assertEquals(1, resultList.size());
     }
 
+    // Test for #1285
+    @Test
+    @Category({ NoDatanucleus.class, NoEclipselink.class, NoOpenJPA.class })
+    public void testJoinOnSubquery() {
+        CriteriaBuilder<RecursiveEntity> cb = cbf.create(em, RecursiveEntity.class)
+                .from(RecursiveEntity.class, "t")
+                .innerJoinOnSubquery(TestCTE.class, "cte")
+                    .from(RecursiveEntity.class, "sub")
+                    .bind("id").select("MAX(sub.id)")
+                    .bind("name").select("'abc'")
+                    .bind("level").select("1")
+                    .where("sub.id").gtLiteral(0)
+                .end().setOnExpression("t.id = cte.id")
+                .where("t.id").gtLiteral(0);
+        String expected = ""
+                + "SELECT t FROM RecursiveEntity t JOIN TestCTE(" +
+                "SELECT MAX(sub.id), 'abc', 1 FROM RecursiveEntity sub WHERE sub.id > 0" +
+                ") cte(id, name, level)" + onClause("t.id = cte.id") +
+                " WHERE t.id > 0";
+
+        assertEquals(expected, cb.getQueryString());
+        List<RecursiveEntity> resultList = cb.getResultList();
+        assertEquals(1, resultList.size());
+    }
+
     // NOTE: Entity joins are only supported on Hibernate 5.1+
     // NOTE: Hibernate 5.1 renders t.id = tSub.id rather than t = tSub
     @Test


### PR DESCRIPTION
<!--- This template is for code related PRs. Remove it for e.g. documentation PRs. -->

<!--- Prefix the title with the issue number like "[#123] Some title" and try to summarize the changes in the title -->

<!--- Before submitting the PR, please make sure it satisfies the following guidelines -->
<!---  * Tests for issues should have one commit that has the form "Test for #123" where "#123" is the issue number -->
<!---  * Fixes for issues should have one commit that has the form "Fix for #123" where "#123" is the issue number -->
<!---  * Commits for the test and the fix should be separate -->

## Description
<!--- Give an overview of what you changed -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue(s) here: -->
Fixes #1285

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

