### PR TITLE
[#1072] Introduce CriteriaBuilderConfigurationContributor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Not yet released
 
 ### New features
 
-None yet
+* Introduction of the `CriteriaBuilderConfigurationContributors` SPI which allows third party libraries to extend the default `CriteriaBuilderConfiguration`.
 
 ### Bug fixes
 None yet

--- a/core/api/src/main/java/com/blazebit/persistence/spi/CriteriaBuilderConfigurationContributor.java
+++ b/core/api/src/main/java/com/blazebit/persistence/spi/CriteriaBuilderConfigurationContributor.java
@@ -18,6 +18,10 @@ package com.blazebit.persistence.spi;
 
 /**
  * A bootstrap process hook for contributing settings to the {@link CriteriaBuilderConfiguration}.
+ * {@code CriteriaBuilderConfigurationContributor} instances may be annotated with {@link Priority}
+ * (or {@code javax.annotation.Priority}) to influence the order in which they are registered.
+ * The range 0-500 is reserved for internal uses. 500 - 1000 is reserved for libraries and 1000+
+ * is for user provided contributors.
  *
  * Implementations are instantiated via {@link java.util.ServiceLoader}.
  *

--- a/core/api/src/main/java/com/blazebit/persistence/spi/CriteriaBuilderConfigurationContributor.java
+++ b/core/api/src/main/java/com/blazebit/persistence/spi/CriteriaBuilderConfigurationContributor.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014 - 2021 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.spi;
+
+/**
+ * A bootstrap process hook for contributing settings to the {@link CriteriaBuilderConfiguration}.
+ *
+ * Implementations are instantiated via {@link java.util.ServiceLoader}.
+ *
+ * @author Jan-Willem Gmelig Meyling
+ * @since 1.6.2
+ */
+public interface CriteriaBuilderConfigurationContributor {
+
+    /**
+     * Perform the process of contributing to the {@link CriteriaBuilderConfiguration}.
+     *
+     * @param criteriaBuilderConfiguration the {@link CriteriaBuilderConfiguration} to which to contribute
+     */
+    void contribute(CriteriaBuilderConfiguration criteriaBuilderConfiguration);
+
+}

--- a/core/api/src/main/java/com/blazebit/persistence/spi/Priority.java
+++ b/core/api/src/main/java/com/blazebit/persistence/spi/Priority.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2014 - 2021 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.spi;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * The Priority annotation can be applied to classes to indicate in what order the {@link CriteriaBuilderConfigurationContributor}
+ * should be registered.
+ *
+ * @author Jan-Willem Gmelig Meyling
+ * @since 1.6.2
+ */
+@Target(value = TYPE)
+@Retention(value = RUNTIME)
+@Documented
+public @interface Priority {
+
+    /**
+     * The priority value. The range 0-500 is reserved for internal uses. 500 - 1000 is reserved for libraries and 1000+
+     * is for user provided contributors.
+     * @return The priority value.
+     */
+    int value();
+
+}

--- a/core/impl/src/main/java/com/blazebit/persistence/impl/CriteriaBuilderConfigurationImpl.java
+++ b/core/impl/src/main/java/com/blazebit/persistence/impl/CriteriaBuilderConfigurationImpl.java
@@ -515,6 +515,7 @@ import com.blazebit.persistence.impl.function.window.row.RowNumberFunction;
 import com.blazebit.persistence.impl.function.window.sum.SumFunction;
 import com.blazebit.persistence.parser.expression.ConcurrentHashMapExpressionCache;
 import com.blazebit.persistence.spi.CriteriaBuilderConfiguration;
+import com.blazebit.persistence.spi.CriteriaBuilderConfigurationContributor;
 import com.blazebit.persistence.spi.DbmsDialect;
 import com.blazebit.persistence.spi.EntityManagerFactoryIntegrator;
 import com.blazebit.persistence.spi.ExtendedQuerySupport;
@@ -567,6 +568,7 @@ public class CriteriaBuilderConfigurationImpl implements CriteriaBuilderConfigur
         loadEntityManagerIntegrator();
         loadDbmsDialects();
         loadFunctions();
+        loadExtensions();
     }
 
     // NOTE: When adding a function here, you might want to also add it in AbstractCoreTest so it is recognized
@@ -1870,6 +1872,12 @@ public class CriteriaBuilderConfigurationImpl implements CriteriaBuilderConfigur
         if (iterator.hasNext()) {
             EntityManagerFactoryIntegrator enricher = iterator.next();
             entityManagerIntegrators.add(enricher);
+        }
+    }
+
+    private void loadExtensions() {
+        for (CriteriaBuilderConfigurationContributor contributor : ServiceLoader.load(CriteriaBuilderConfigurationContributor.class)) {
+            contributor.contribute(this);
         }
     }
 

--- a/core/impl/src/main/java/com/blazebit/persistence/impl/CriteriaBuilderConfigurationImpl.java
+++ b/core/impl/src/main/java/com/blazebit/persistence/impl/CriteriaBuilderConfigurationImpl.java
@@ -513,6 +513,7 @@ import com.blazebit.persistence.impl.function.window.percentrank.PercentRankFunc
 import com.blazebit.persistence.impl.function.window.rank.RankFunction;
 import com.blazebit.persistence.impl.function.window.row.RowNumberFunction;
 import com.blazebit.persistence.impl.function.window.sum.SumFunction;
+import com.blazebit.persistence.impl.util.CriteriaBuilderConfigurationContributorComparator;
 import com.blazebit.persistence.parser.expression.ConcurrentHashMapExpressionCache;
 import com.blazebit.persistence.spi.CriteriaBuilderConfiguration;
 import com.blazebit.persistence.spi.CriteriaBuilderConfigurationContributor;
@@ -534,6 +535,7 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -1876,7 +1878,15 @@ public class CriteriaBuilderConfigurationImpl implements CriteriaBuilderConfigur
     }
 
     private void loadExtensions() {
+        List<CriteriaBuilderConfigurationContributor> contributors = new ArrayList<>();
+
         for (CriteriaBuilderConfigurationContributor contributor : ServiceLoader.load(CriteriaBuilderConfigurationContributor.class)) {
+            contributors.add(contributor);
+        }
+
+        Collections.sort(contributors, new CriteriaBuilderConfigurationContributorComparator());
+
+        for (CriteriaBuilderConfigurationContributor contributor : contributors) {
             contributor.contribute(this);
         }
     }
@@ -2007,4 +2017,5 @@ public class CriteriaBuilderConfigurationImpl implements CriteriaBuilderConfigur
         properties.setProperty(propertyName, value);
         return this;
     }
+
 }

--- a/core/impl/src/main/java/com/blazebit/persistence/impl/util/CriteriaBuilderConfigurationContributorComparator.java
+++ b/core/impl/src/main/java/com/blazebit/persistence/impl/util/CriteriaBuilderConfigurationContributorComparator.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2014 - 2021 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.impl.util;
+
+import com.blazebit.persistence.spi.CriteriaBuilderConfigurationContributor;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Comparator;
+
+/**
+ * A comparator for comparing CriteriaBuilderConfigurationContributor implementations.
+ *
+ * @author Jan-Willem Gmelig Meyling
+ * @since 1.6.2
+ */
+public class CriteriaBuilderConfigurationContributorComparator implements Comparator<CriteriaBuilderConfigurationContributor> {
+
+    @Override
+    public int compare(CriteriaBuilderConfigurationContributor o1, CriteriaBuilderConfigurationContributor o2) {
+        Integer o1Priority = getPriority(o1.getClass());
+        Integer o2Priority = getPriority(o2.getClass());
+
+        int result = o1Priority == null ?
+                o2Priority == null ? 0 : 1 :
+                o2Priority == null ? -1 : Integer.compare(o1Priority, o2Priority);
+
+        if (result == 0) {
+            result = o1.getClass().getName().compareTo(o2.getClass().getName());
+        }
+
+        return result;
+    }
+
+    private static Integer getPriority(Class<?> clasz) {
+        for (Annotation annotation : clasz.getAnnotations()) {
+            final Class<? extends Annotation> annotationClass = annotation.annotationType();
+            if ("Priority".equals(annotationClass.getSimpleName())) {
+                try {
+                    Method value = annotationClass.getMethod("value");
+                    return (Integer) value.invoke(annotation);
+                } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException | ClassCastException e) {
+                    continue;
+                }
+            }
+        }
+        return null;
+    }
+
+}

--- a/core/impl/src/test/java/com/blazebit/persistence/impl/util/CriteriaBuilderConfigurationContributorComparatorTest.java
+++ b/core/impl/src/test/java/com/blazebit/persistence/impl/util/CriteriaBuilderConfigurationContributorComparatorTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2014 - 2021 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.impl.util;
+
+import com.blazebit.persistence.spi.CriteriaBuilderConfiguration;
+import com.blazebit.persistence.spi.CriteriaBuilderConfigurationContributor;
+import com.blazebit.persistence.spi.Priority;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+import static org.junit.Assert.assertSame;
+
+public class CriteriaBuilderConfigurationContributorComparatorTest {
+
+    @Test
+    public void testSort() {
+        ArrayList<CriteriaBuilderConfigurationContributor> contributions = new ArrayList<>();
+
+        final A a = new A();
+        final B b = new B();
+        final C c = new C();
+        final D d = new D();
+
+        contributions.add(d);
+        contributions.add(c);
+        contributions.add(b);
+        contributions.add(a);
+
+        Collections.sort(contributions, new CriteriaBuilderConfigurationContributorComparator());
+        assertSame(a, contributions.get(0));
+        assertSame(c, contributions.get(1));
+        assertSame(d, contributions.get(2));
+        assertSame(b, contributions.get(3));
+    }
+
+    @Priority(value = 100)
+    public static class A implements CriteriaBuilderConfigurationContributor {
+        @Override
+        public void contribute(CriteriaBuilderConfiguration criteriaBuilderConfiguration) {
+        }
+    }
+
+    public static class B implements CriteriaBuilderConfigurationContributor {
+        @Override
+        public void contribute(CriteriaBuilderConfiguration criteriaBuilderConfiguration) {
+        }
+    }
+
+    @Priority(value = 1000)
+    public static class C implements CriteriaBuilderConfigurationContributor {
+        @Override
+        public void contribute(CriteriaBuilderConfiguration criteriaBuilderConfiguration) {
+        }
+    }
+
+    @Priority(value = 1000)
+    public static class D implements CriteriaBuilderConfigurationContributor {
+        @Override
+        public void contribute(CriteriaBuilderConfiguration criteriaBuilderConfiguration) {
+        }
+    }
+
+}

--- a/core/testsuite/src/test/hibernate/com/blazebit/persistence/testsuite/CustomFunctionTest.java
+++ b/core/testsuite/src/test/hibernate/com/blazebit/persistence/testsuite/CustomFunctionTest.java
@@ -1,0 +1,89 @@
+
+/*
+ * Copyright 2014 - 2021 Blazebit.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blazebit.persistence.testsuite;
+
+import com.blazebit.persistence.spi.CriteriaBuilderConfiguration;
+import com.blazebit.persistence.spi.JpqlFunctionGroup;
+import com.blazebit.persistence.testsuite.base.jpa.category.NoDB2;
+import com.blazebit.persistence.testsuite.base.jpa.category.NoMSSQL;
+import com.blazebit.persistence.testsuite.base.jpa.category.NoMySQL;
+import com.blazebit.persistence.testsuite.base.jpa.category.NoMySQLOld;
+import com.blazebit.persistence.testsuite.base.jpa.category.NoOracle;
+import com.blazebit.persistence.testsuite.base.jpa.category.NoPostgreSQL;
+import org.hibernate.dialect.H2Dialect;
+import org.hibernate.dialect.function.SQLFunctionTemplate;
+import org.hibernate.type.LongType;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import java.util.Properties;
+
+/**
+ * @author Jan-Willem Gmelig Meyling
+ * @since 1.6.2
+ */
+public class CustomFunctionTest extends AbstractCoreTest {
+
+    @Override
+    protected Class<?>[] getEntityClasses() {
+        return new Class<?>[]{ BasicEntity.class };
+    }
+
+    @Entity(name = "BasicEntity")
+    public static class BasicEntity {
+        @Id
+        Long id;
+    }
+
+    @Test
+    @Category({NoMSSQL.class, NoMySQL.class, NoMySQLOld.class, NoPostgreSQL.class, NoOracle.class, NoDB2.class})
+    public void implicitJoinCustomAggregateFunction() {
+        String queryString = cbf.create(em, BasicEntity.class, "b")
+                .select("addone(b.id)")
+                .select("customsum(b.id)")
+                .select("b.id")
+                .getQueryString();
+
+        Assert.assertEquals("SELECT addone(b.id), customsum(b.id), b.id FROM BasicEntity b GROUP BY addone(b.id), b.id", queryString);
+    }
+
+    @Override
+    protected void configure(CriteriaBuilderConfiguration config) {
+        super.configure(config);
+        // Mark CUSTOMSUM as aggregate function, even though an implementation is provided through
+        config.registerFunction(new JpqlFunctionGroup("CUSTOMSUM", true));
+    }
+
+    @Override
+    protected Properties applyProperties(Properties properties) {
+        super.applyProperties(properties);
+        properties.put("hibernate.dialect", ExtendedDialect.class.getName());
+        return properties;
+    }
+
+    public static class ExtendedDialect extends H2Dialect {
+        public ExtendedDialect() {
+            registerFunction("ADDONE", new SQLFunctionTemplate(LongType.INSTANCE, "?1 + 1"));
+            registerFunction("CUSTOMSUM", new SQLFunctionTemplate(LongType.INSTANCE, "SUM(?1)"));
+        }
+    }
+
+}

--- a/documentation/src/main/asciidoc/core/manual/en_US/configuration.adoc
+++ b/documentation/src/main/asciidoc/core/manual/en_US/configuration.adoc
@@ -251,3 +251,8 @@ For more information refer to the <<customize-dbms-dialect,Customize DBMS dialec
 === Entity manager factory integrators
 
 A little integration layer to extract the dbms of an entity manager and register `JpqlFunctionGroup` instances with the entity manager. This is normally provided by an integration module for persistence providers.
+
+[[service-loader-configuration-integrators]]
+=== Extending configuration from integrations
+
+Integrations may provide additional configuration to the bootstrapping `CriteriaBuilderConfiguration` through a `CriteriaBuilderConfigurationContributor` Service Provider.

--- a/documentation/src/main/asciidoc/core/manual/en_US/configuration.adoc
+++ b/documentation/src/main/asciidoc/core/manual/en_US/configuration.adoc
@@ -255,4 +255,5 @@ A little integration layer to extract the dbms of an entity manager and register
 [[service-loader-configuration-integrators]]
 === Extending configuration from integrations
 
-Integrations may provide additional configuration to the bootstrapping `CriteriaBuilderConfiguration` through a `CriteriaBuilderConfigurationContributor` Service Provider.
+Integrations may provide additional configuration to the bootstrapping `CriteriaBuilderConfiguration` through a `CriteriaBuilderConfigurationContributor` Service Provider that would otherwise need to be registered manually with the `CriteriaBuilderConfiguration`.
+Example use cases include extensions providing additional dialects or custom functions for dialect specific types.

--- a/integration/hibernate-base/src/main/java/com/blazebit/persistence/integration/hibernate/base/function/AbstractHibernateEntityManagerFactoryIntegrator.java
+++ b/integration/hibernate-base/src/main/java/com/blazebit/persistence/integration/hibernate/base/function/AbstractHibernateEntityManagerFactoryIntegrator.java
@@ -208,7 +208,11 @@ public abstract class AbstractHibernateEntityManagerFactoryIntegrator implements
                     function = dbmsFunctionMap.get(null);
                 }
                 if (function == null) {
-                    LOG.warning("Could not register the function '" + functionName + "' because there is neither an implementation for the dbms '" + dbms + "' nor a default implementation!");
+                    if (functions.containsKey(functionName)) {
+                        LOG.finest("Using ORM registered function '" + functionName + "' because there is neither an implementation for the dbms '" + dbms + "' nor a default implementation.");
+                    } else {
+                        LOG.warning("Could not register the function '" + functionName + "' because there is neither an implementation for the dbms '" + dbms + "' nor a default implementation!");
+                    }
                 } else {
                     functions.put(functionName, new HibernateJpqlFunctionAdapter(function));
                 }


### PR DESCRIPTION
<!--- This template is for code related PRs. Remove it for e.g. documentation PRs. -->

<!--- Prefix the title with the issue number like "[#123] Some title" and try to summarize the changes in the title -->

<!--- Before submitting the PR, please make sure it satisfies the following guidelines -->
<!---  * Tests for issues should have one commit that has the form "Test for #123" where "#123" is the issue number -->
<!---  * Fixes for issues should have one commit that has the form "Fix for #123" where "#123" is the issue number -->
<!---  * Commits for the test and the fix should be separate -->

## Description
Allow third-party integrations to extend the CriteriaBuilderConfiguration through a Service Provider interface.

<!--- Give an overview of what you changed -->

## Related Issue
Fixes #1072
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue(s) here: -->


## Motivation and Context
The https://github.com/jwgmeligmeyling/hibernate-types-querydsl-apt project provides an extension for working with custom types in special dialects. For this purpose, some additional functions need to be registered with Hibernate, however, Blaze-Persistence needs to be aware which functions are aggregate functions (for implicit group by) and which ones are not. Therefore the functions need to be registered as Blaze-Persistence functions as well. A service provider interface allows third party libraries like mine to provide the required configuration within the library itself.


<!--- Why is this change required? What problem does it solve? -->

