### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -207,25 +207,25 @@ matrix:
     - env: JPAPROVIDER=hibernate-5.4 RDBMS=h2 NATIVE=true
       jdk: oraclejdk8
       script:
-        - travis_wait 70 ./build.sh
+        - ./build.sh
     - env: JPAPROVIDER=hibernate-5.4 RDBMS=mysql8 NATIVE=true
       jdk: oraclejdk8
       sudo: required
       script:
-        - travis_wait 70 ./build.sh
+        - ./build.sh
     - env: JPAPROVIDER=hibernate-5.4 RDBMS=postgresql NATIVE=true
       jdk: oraclejdk8
       addons:
         postgresql: "9.5"
       script:
-        - travis_wait 70 ./build.sh
+        - ./build.sh
     - env: JPAPROVIDER=hibernate-5.4 RDBMS=mssql NATIVE=true
       jdk: oraclejdk8
       sudo: true
       services:
         - docker
       script:
-        - travis_wait 70 ./build.sh
+        - ./build.sh
     - env: JPAPROVIDER=hibernate-5.4 RDBMS=db2
       jdk: oraclejdk8
       sudo: true


### PR DESCRIPTION

According to [Build times out because no output was received](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received), we should carefully use travis_wait, as it may make the build unstable and extend the build time.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
