### PR TITLE
[#1414] Fix Quarkus extension metadata take 2

### DIFF
--- a/integration/quarkus/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/integration/quarkus/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,3 +1,4 @@
+---
 name: "Blaze-Persistence"
 metadata:
   short-name: "BP"
@@ -13,3 +14,21 @@ metadata:
   categories:
   - "data"
   status: "stable"
+  built-with-quarkus-core: "1.11.7.Final"
+  capabilities:
+    provides:
+    - "com.blazebit.persistence.integration.quarkus"
+  extension-dependencies:
+  - "io.quarkus:quarkus-core"
+  - "io.quarkus:quarkus-hibernate-orm"
+  - "io.quarkus:quarkus-agroal"
+  - "io.quarkus:quarkus-arc"
+  - "io.quarkus:quarkus-datasource"
+  - "io.quarkus:quarkus-narayana-jta"
+  - "io.quarkus:quarkus-mutiny"
+  - "io.quarkus:quarkus-smallrye-context-propagation"
+  - "io.quarkus:quarkus-caffeine"
+artifact: "${project.groupId}:${project.artifactId}::jar:${project.version}"
+group-id: "${project.groupId}"
+artifact-id: "${project.artifactId}"
+description: "Advanced SQL support for JPA and Entity-Views as efficient DTOs"

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -122,7 +122,7 @@
         <version.jakarta-jpa-api>3.0.0</version.jakarta-jpa-api>
 
         <version.weld>3.1.5.Final</version.weld>
-        <version.quarkus>1.11.0.Final</version.quarkus>
+        <version.quarkus>1.11.7.Final</version.quarkus>
         <version.jandex>2.0.4.Final</version.jandex>
         <version.classgraph>4.8.89</version.classgraph>
 


### PR DESCRIPTION
https://github.com/Blazebit/blaze-persistence/pull/1415 is the way to go for the future but Blaze Persistence still supports JDK 8 for now, which makes it a bit impractical.

So for now, we just update the metadata to a format that should work with latest Quarkus.

It should be tested by going to the Dev UI of a 2.6.1.Final project and make sure the BP tile is there.
