### PR TITLE
[#1453] Fix rendering parameters in subqueries in select clause

### DIFF
--- a/integration/querydsl/expressions/src/main/java/com/blazebit/persistence/querydsl/BlazeCriteriaBuilderRenderer.java
+++ b/integration/querydsl/expressions/src/main/java/com/blazebit/persistence/querydsl/BlazeCriteriaBuilderRenderer.java
@@ -124,7 +124,9 @@ public class BlazeCriteriaBuilderRenderer<T> {
 
     public Queryable<T, ?> render(Expression<?> expression) {
         this.criteriaBuilder = (CriteriaBuilder) criteriaBuilderFactory.create(entityManager, Object.class);
-        return (Queryable<T, ?>) serializeSubQuery(this.criteriaBuilder, expression);
+        Object output = serializeSubQuery(this.criteriaBuilder, expression);
+        renderConstants((ParameterHolder<?>) output);
+        return (Queryable<T, ?>) output;
     }
 
     private Object serializeSubQuery(Object criteriaBuilder, Expression<?> expression) {
@@ -324,7 +326,6 @@ public class BlazeCriteriaBuilderRenderer<T> {
 
                 renderOrderBy(subQueryMetadata, (OrderByBuilder<?>) criteriaBuilder);
                 renderParameters(subQueryMetadata, (ParameterHolder<?>) criteriaBuilder);
-                renderConstants((ParameterHolder<?>) criteriaBuilder);
 
                 // Limit / offset on full query is set outside of the renderer, based on whether we're rendering a full count query or not
                 if (!(criteriaBuilder instanceof Queryable)) {

--- a/integration/querydsl/testsuite/src/test/java/com/blazebit/persistence/querydsl/BasicQueryTest.java
+++ b/integration/querydsl/testsuite/src/test/java/com/blazebit/persistence/querydsl/BasicQueryTest.java
@@ -119,6 +119,20 @@ public class BasicQueryTest extends AbstractCoreTest {
     }
 
     @Test
+    public void testSubqueryInCase() {
+        doInJPA(em -> {
+
+            BlazeJPAQuery<Boolean> select = new BlazeJPAQuery<>(em, cbf)
+                    .from(document)
+                    .select(Expressions.cases().when(
+                            selectFrom(person).where(person.id.eq(1L)).exists()
+                    ).then(true).otherwise(false));
+
+            assertNotNull(select.getQueryString());
+        });
+    }
+
+    @Test
     public void testFetchResults() {
         doInJPA(em -> {
             QueryResults<Person> personQueryResults = new BlazeJPAQuery<>(em, cbf)


### PR DESCRIPTION
<!--- This template is for code related PRs. Remove it for e.g. documentation PRs. -->

<!--- Prefix the title with the issue number like "[#123] Some title" and try to summarize the changes in the title -->

<!--- Before submitting the PR, please make sure it satisfies the following guidelines -->
<!---  * Tests for issues should have one commit that has the form "Test for #123" where "#123" is the issue number -->
<!---  * Fixes for issues should have one commit that has the form "Fix for #123" where "#123" is the issue number -->
<!---  * Commits for the test and the fix should be separate -->

## Description

The `SerializerBase` which the `JPQLNextSerializer` is based on maintains a mapping of constants to unique parameter names. This ensures for each unique object (by identity) only a single parameter name is introduced. Because this mapping is shared between the main query and subqueries, a query with parameters in both a subquery and the outer query, where the subquery is rendered in the select clause, results in a raise condition where the parameters for the outer query are set when serializing the subquery.

There are a few options to fix this:

1. Only bind parameters that are managed in the `ParameterManager` for the active builder.
2. Only render parameters and constants for the main query, after all subqueries have already been rendered
3. Use a stack based constant to parameter mapping. This way we can determine which parameters should be bound at which stage of serialization. This can either be achieved through a separate separate mapping (used parameters for each subquery) or by making `constantToLabel` itself a stack. In case of the latter, we also need to ensure that generated parameter names remain unique between subqueries. I.e. by keep a count.

This PR implements approach (1), but comments are welcome 😄 

<!--- Give an overview of what you changed -->

## Related Issue
Fixes #1453

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

