### PR TITLE
[#1458] Fix rendering of association joins without alias

### DIFF
--- a/core/impl/src/main/java/com/blazebit/persistence/impl/AbstractCommonQueryBuilder.java
+++ b/core/impl/src/main/java/com/blazebit/persistence/impl/AbstractCommonQueryBuilder.java
@@ -1851,7 +1851,7 @@ public abstract class AbstractCommonQueryBuilder<QueryResultType, BuilderType, S
     @SuppressWarnings("unchecked")
     public BuilderType join(String path, String alias, JoinType type) {
         prepareForModification(ClauseType.JOIN);
-        checkJoinPreconditions(path, alias, type);
+        checkJoinPreconditions(path, alias, type, false);
         joinManager.join(path, alias, type, false, false, null);
         return (BuilderType) this;
     }
@@ -1859,28 +1859,28 @@ public abstract class AbstractCommonQueryBuilder<QueryResultType, BuilderType, S
     @SuppressWarnings("unchecked")
     public BuilderType joinDefault(String path, String alias, JoinType type) {
         prepareForModification(ClauseType.JOIN);
-        checkJoinPreconditions(path, alias, type);
+        checkJoinPreconditions(path, alias, type, true);
         joinManager.join(path, alias, type, false, true, null);
         return (BuilderType) this;
     }
 
     public JoinOnBuilder<BuilderType> joinOn(String path, String alias, JoinType type) {
         prepareForModification(ClauseType.JOIN);
-        checkJoinPreconditions(path, alias, type);
+        checkJoinPreconditions(path, alias, type, false);
         return joinManager.joinOn((BuilderType) this, path, alias, type, false);
     }
 
     @SuppressWarnings("unchecked")
     public JoinOnBuilder<BuilderType> joinOn(Expression expr, String alias, JoinType type) {
         prepareForModification(ClauseType.JOIN);
-        checkJoinPreconditions(expr, alias, type);
+        checkJoinPreconditions(expr, alias, type, false);
         return joinManager.joinOn((BuilderType) this, expr, alias, type, false);
     }
 
     @SuppressWarnings("unchecked")
     public JoinOnBuilder<BuilderType> joinDefaultOn(String path, String alias, JoinType type) {
         prepareForModification(ClauseType.JOIN);
-        checkJoinPreconditions(path, alias, type);
+        checkJoinPreconditions(path, alias, type, true);
         return joinManager.joinOn((BuilderType) this, path, alias, type, true);
     }
 
@@ -1892,7 +1892,7 @@ public abstract class AbstractCommonQueryBuilder<QueryResultType, BuilderType, S
     @SuppressWarnings("unchecked")
     public JoinOnBuilder<BuilderType> joinOn(String base, Class<?> entityClass, String alias, JoinType type) {
         prepareForModification(ClauseType.JOIN);
-        checkJoinPreconditions(base, alias, type);
+        checkJoinPreconditions(base, alias, type, false);
         if (entityClass == null) {
             throw new NullPointerException("entityClass");
         }
@@ -1907,7 +1907,7 @@ public abstract class AbstractCommonQueryBuilder<QueryResultType, BuilderType, S
     @SuppressWarnings("unchecked")
     public JoinOnBuilder<BuilderType> joinOn(String base, EntityType<?> entityType, String alias, JoinType type) {
         prepareForModification(ClauseType.JOIN);
-        checkJoinPreconditions(base, alias, type);
+        checkJoinPreconditions(base, alias, type, false);
         if (entityType == null) {
             throw new NullPointerException("entityType");
         }
@@ -1922,7 +1922,7 @@ public abstract class AbstractCommonQueryBuilder<QueryResultType, BuilderType, S
     @SuppressWarnings("unchecked")
     public FullSelectCTECriteriaBuilder<JoinOnBuilder<BuilderType>> joinOnSubquery(String base, Class<?> entityClass, String alias, JoinType type) {
         prepareForModification(ClauseType.JOIN);
-        checkJoinPreconditions(base, alias, type);
+        checkJoinPreconditions(base, alias, type, false);
         if (entityClass == null) {
             throw new NullPointerException("entityClass");
         }
@@ -1963,7 +1963,7 @@ public abstract class AbstractCommonQueryBuilder<QueryResultType, BuilderType, S
             throw new IllegalStateException("The dbms dialect does not support lateral joins!");
         }
         prepareForModification(ClauseType.JOIN);
-        checkJoinPreconditions(base, alias, type);
+        checkJoinPreconditions(base, alias, type, false);
         if (entityClass == null) {
             throw new NullPointerException("entityClass");
         }
@@ -1978,7 +1978,7 @@ public abstract class AbstractCommonQueryBuilder<QueryResultType, BuilderType, S
     @SuppressWarnings("unchecked")
     public FullSelectCTECriteriaBuilder<JoinOnBuilder<BuilderType>> joinOnSubquery(String base, EntityType<?> entityClass, String alias, JoinType type) {
         prepareForModification(ClauseType.JOIN);
-        checkJoinPreconditions(base, alias, type);
+        checkJoinPreconditions(base, alias, type, false);
         if (entityClass == null) {
             throw new NullPointerException("entityClass");
         }
@@ -2019,7 +2019,7 @@ public abstract class AbstractCommonQueryBuilder<QueryResultType, BuilderType, S
             throw new IllegalStateException("The dbms dialect does not support lateral joins!");
         }
         prepareForModification(ClauseType.JOIN);
-        checkJoinPreconditions(base, alias, type);
+        checkJoinPreconditions(base, alias, type, false);
         if (entityClass == null) {
             throw new NullPointerException("entityClass");
         }
@@ -2035,7 +2035,7 @@ public abstract class AbstractCommonQueryBuilder<QueryResultType, BuilderType, S
             throw new IllegalStateException("The dbms dialect does not support lateral joins!");
         }
         prepareForModification(ClauseType.JOIN);
-        checkJoinPreconditions(correlationPath, alias, type);
+        checkJoinPreconditions(correlationPath, alias, type, false);
         return joinManager.joinOn((BuilderType) this, correlationPath, alias, subqueryAlias, type);
     }
 
@@ -2076,7 +2076,7 @@ public abstract class AbstractCommonQueryBuilder<QueryResultType, BuilderType, S
             throw new IllegalStateException("The dbms dialect does not support lateral joins!");
         }
         prepareForModification(ClauseType.JOIN);
-        checkJoinPreconditions(base, alias, type);
+        checkJoinPreconditions(base, alias, type, false);
         if (entityClass == null) {
             throw new NullPointerException("entityClass");
         }
@@ -2111,7 +2111,7 @@ public abstract class AbstractCommonQueryBuilder<QueryResultType, BuilderType, S
             throw new IllegalStateException("The dbms dialect does not support lateral joins!");
         }
         prepareForModification(ClauseType.JOIN);
-        checkJoinPreconditions(base, alias, type);
+        checkJoinPreconditions(base, alias, type, false);
         if (entityClass == null) {
             throw new NullPointerException("entityClass");
         }
@@ -2127,7 +2127,7 @@ public abstract class AbstractCommonQueryBuilder<QueryResultType, BuilderType, S
             throw new IllegalStateException("The dbms dialect does not support lateral joins!");
         }
         prepareForModification(ClauseType.JOIN);
-        checkJoinPreconditions(correlationPath, alias, type);
+        checkJoinPreconditions(correlationPath, alias, type, false);
         return joinManager.join((BuilderType) this, correlationPath, alias, subqueryAlias, type);
     }
 
@@ -2582,17 +2582,17 @@ public abstract class AbstractCommonQueryBuilder<QueryResultType, BuilderType, S
         return (Z) joinOnEntitySubquery(base, clazz, alias, subqueryAlias, JoinType.RIGHT);
     }
 
-    private void checkJoinPreconditions(Object path, String alias, JoinType type) {
+    protected void checkJoinPreconditions(Object path, String alias, JoinType type, boolean defaultJoin) {
         if (path == null) {
             throw new NullPointerException("path");
         }
-        if (alias == null) {
+        if (alias == null && !defaultJoin) {
             throw new NullPointerException("alias");
         }
         if (type == null) {
             throw new NullPointerException("type");
         }
-        if (alias.isEmpty()) {
+        if ((alias == null || alias.isEmpty()) && !defaultJoin) {
             throw new IllegalArgumentException("Empty alias");
         }
         verifyBuilderEnded();

--- a/core/impl/src/main/java/com/blazebit/persistence/impl/AbstractFullQueryBuilder.java
+++ b/core/impl/src/main/java/com/blazebit/persistence/impl/AbstractFullQueryBuilder.java
@@ -1079,19 +1079,7 @@ public abstract class AbstractFullQueryBuilder<T, X extends FullQueryBuilder<T, 
     @SuppressWarnings("unchecked")
     private X join(String path, String alias, JoinType type, boolean fetch, boolean defaultJoin) {
         prepareForModification(ClauseType.JOIN);
-        if (path == null) {
-            throw new NullPointerException("path");
-        }
-        if (alias == null) {
-            throw new NullPointerException("alias");
-        }
-        if (type == null) {
-            throw new NullPointerException("type");
-        }
-        if (alias.isEmpty()) {
-            throw new IllegalArgumentException("Empty alias");
-        }
-
+        checkJoinPreconditions(path, alias, type, defaultJoin);
         verifyBuilderEnded();
         joinManager.join(path, alias, type, fetch, defaultJoin, null);
         return (X) this;

--- a/core/impl/src/main/java/com/blazebit/persistence/impl/JoinManager.java
+++ b/core/impl/src/main/java/com/blazebit/persistence/impl/JoinManager.java
@@ -3645,7 +3645,7 @@ public class JoinManager extends AbstractManager<ExpressionModifier> {
             throw new ImplicitJoinNotAllowedException(baseNode, joinRelationAttributes, treatType);
         }
 
-        if (implicit) {
+        if (implicit || (defaultJoin && alias == null)) {
             String aliasToUse = alias == null ? attr.getName() : alias;
             alias = baseNode.getAliasInfo().getAliasOwner().generateJoinAlias(aliasToUse);
         }

--- a/integration/querydsl/expressions/src/main/java/com/blazebit/persistence/querydsl/AbstractBlazeJPAQuery.java
+++ b/integration/querydsl/expressions/src/main/java/com/blazebit/persistence/querydsl/AbstractBlazeJPAQuery.java
@@ -74,6 +74,12 @@ public abstract class AbstractBlazeJPAQuery<T, Q extends AbstractBlazeJPAQuery<T
      */
     public static final JoinFlag LATERAL = new JoinFlag("LATERAL", JoinFlag.Position.BEFORE_TARGET);
 
+    /**
+     * Default join flag.
+     * Can be added using {@link QueryMetadata#addJoinFlag(JoinFlag)}.
+     */
+    public static final JoinFlag DEFAULT = new JoinFlag("DEFAULT");
+
     private static final Logger LOG = Logger.getLogger(AbstractBlazeJPAQuery.class.getName());
 
     private static final long serialVersionUID = 992291611132051622L;
@@ -85,23 +91,19 @@ public abstract class AbstractBlazeJPAQuery<T, Q extends AbstractBlazeJPAQuery<T
     protected final Binds<T> binds = new Binds<>();
 
     public AbstractBlazeJPAQuery(CriteriaBuilderFactory criteriaBuilderFactory) {
-        super(null, JPQLNextTemplates.DEFAULT, new DefaultQueryMetadata());
-        this.criteriaBuilderFactory = criteriaBuilderFactory;
+        this(null, JPQLNextTemplates.DEFAULT, new DefaultQueryMetadata(), criteriaBuilderFactory);
     }
 
     public AbstractBlazeJPAQuery(EntityManager em, CriteriaBuilderFactory criteriaBuilderFactory) {
-        super(em, JPQLNextTemplates.DEFAULT, new DefaultQueryMetadata());
-        this.criteriaBuilderFactory = criteriaBuilderFactory;
+        this(em, JPQLNextTemplates.DEFAULT, new DefaultQueryMetadata(), criteriaBuilderFactory);
     }
 
     public AbstractBlazeJPAQuery(EntityManager em, QueryMetadata metadata, CriteriaBuilderFactory criteriaBuilderFactory) {
-        super(em, JPQLNextTemplates.DEFAULT, metadata);
-        this.criteriaBuilderFactory = criteriaBuilderFactory;
+        this(em, JPQLNextTemplates.DEFAULT, metadata, criteriaBuilderFactory);
     }
 
     public AbstractBlazeJPAQuery(EntityManager em, JPQLTemplates templates, CriteriaBuilderFactory criteriaBuilderFactory) {
-        super(em, templates, new DefaultQueryMetadata());
-        this.criteriaBuilderFactory = criteriaBuilderFactory;
+        this(em, templates, new DefaultQueryMetadata(), criteriaBuilderFactory);
     }
 
     public AbstractBlazeJPAQuery(EntityManager em, JPQLTemplates templates, QueryMetadata metadata, CriteriaBuilderFactory criteriaBuilderFactory) {
@@ -394,6 +396,11 @@ public abstract class AbstractBlazeJPAQuery<T, Q extends AbstractBlazeJPAQuery<T
     @Override
     public Q lateral() {
         return queryMixin.addJoinFlag(LATERAL);
+    }
+
+    @Override
+    public Q defaultJoin() {
+        return queryMixin.addJoinFlag(DEFAULT);
     }
 
     @Override

--- a/integration/querydsl/expressions/src/main/java/com/blazebit/persistence/querydsl/JPQLNextQuery.java
+++ b/integration/querydsl/expressions/src/main/java/com/blazebit/persistence/querydsl/JPQLNextQuery.java
@@ -396,6 +396,13 @@ public interface JPQLNextQuery<T, Q extends JPQLNextQuery<T, Q>> extends JPQLQue
      */
     Q lateral();
 
+    /**
+     * Mark the last join as a default join.
+     *
+     * @return this query
+     */
+    Q defaultJoin();
+
     // Covariant Overrides
 
     @Override


### PR DESCRIPTION
Render default joins with no alias (Blaze-Persistence will generate it under the hood). Previously the default alias was used which may result into alias conflicts.

Fixes #1458

<!--- This template is for code related PRs. Remove it for e.g. documentation PRs. -->

<!--- Prefix the title with the issue number like "[#123] Some title" and try to summarize the changes in the title -->

<!--- Before submitting the PR, please make sure it satisfies the following guidelines -->
<!---  * Tests for issues should have one commit that has the form "Test for #123" where "#123" is the issue number -->
<!---  * Fixes for issues should have one commit that has the form "Fix for #123" where "#123" is the issue number -->
<!---  * Commits for the test and the fix should be separate -->

## Description
<!--- Give an overview of what you changed -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue(s) here: -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

