### PR TITLE
[#1638] Use empty escape character for like predicates when noEscape is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ None yet
 
 ### Bug fixes
 
-None yet
+* Use empty escape character for like predicates when noEscape is used
 
 ### Backwards-incompatible changes
 

--- a/core/parser/src/main/java/com/blazebit/persistence/parser/SimpleQueryGenerator.java
+++ b/core/parser/src/main/java/com/blazebit/persistence/parser/SimpleQueryGenerator.java
@@ -163,10 +163,6 @@ public class SimpleQueryGenerator implements Expression.Visitor {
         return Character.toString(character);
     }
 
-    protected void renderLikePattern(LikePredicate predicate) {
-        predicate.getRight().accept(this);
-    }
-
     @Override
     public void visit(final CompoundPredicate predicate) {
         BooleanLiteralRenderingContext oldConditionalContext = setBooleanLiteralRenderingContext(BooleanLiteralRenderingContext.PREDICATE);
@@ -285,7 +281,7 @@ public class SimpleQueryGenerator implements Expression.Visitor {
         if (!predicate.isCaseSensitive()) {
             sb.append("UPPER(");
         }
-        renderLikePattern(predicate);
+        predicate.getRight().accept(this);
         if (!predicate.isCaseSensitive()) {
             sb.append(")");
         }

--- a/core/testsuite/src/main/java/com/blazebit/persistence/testsuite/AbstractCoreTest.java
+++ b/core/testsuite/src/main/java/com/blazebit/persistence/testsuite/AbstractCoreTest.java
@@ -140,18 +140,11 @@ public abstract class AbstractCoreTest extends AbstractPersistenceTest {
         return jpaProvider.escapeCharacter(character);
     }
 
-    protected String likePattern(String expression) {
-        Character defaultEscapeCharacter = dbmsDialect.getDefaultEscapeCharacter();
-        if (jpaProvider.supportsLikePatternEscape() || defaultEscapeCharacter == null) {
-            return expression;
+    protected String noEscape() {
+        if (!jpaProvider.supportsLikePatternEscape() && dbmsDialect.getDefaultEscapeCharacter() != null) {
+            return " ESCAPE ''";
         }
-        if (expression.charAt(0) == '\'') {
-            return expression.replace(defaultEscapeCharacter.toString(), defaultEscapeCharacter.toString() + defaultEscapeCharacter);
-        } else {
-            return jpaProvider.getCustomFunctionInvocation("REPLACE", 1)
-                    + expression + ", '" + defaultEscapeCharacter + defaultEscapeCharacter + "', '"
-                    + defaultEscapeCharacter + defaultEscapeCharacter + defaultEscapeCharacter + defaultEscapeCharacter + "')";
-        }
+        return "";
     }
 
     protected String renderNullPrecedence(String expression, String resolvedExpression, String order, String nulls) {

--- a/core/testsuite/src/test/java/com/blazebit/persistence/testsuite/PaginationTest.java
+++ b/core/testsuite/src/test/java/com/blazebit/persistence/testsuite/PaginationTest.java
@@ -207,16 +207,16 @@ public class PaginationTest extends AbstractCoreTest {
         // do not include joins that are only needed for the select clause
         String expectedCountQuery = "SELECT " + countPaginated("d.id", false) + " FROM Document d JOIN d.owner owner_1 LEFT JOIN owner_1.localized localized_1_1"
                 + onClause("KEY(localized_1_1) = 1")
-                + " WHERE UPPER(d.name) LIKE UPPER(" + likePattern(":param_0") + ") AND owner_1.name LIKE " + likePattern(":param_1") + " AND UPPER(" + joinAliasValue("localized_1_1")
-                + ") LIKE UPPER(" + likePattern(":param_2") + ")";
+                + " WHERE UPPER(d.name) LIKE UPPER(:param_0)" + noEscape() + " AND owner_1.name LIKE :param_1" + noEscape() + " AND UPPER(" + joinAliasValue("localized_1_1")
+                + ") LIKE UPPER(:param_2)" + noEscape();
 
         String expectedObjectQuery = "SELECT d.name, CONCAT(owner_1.name,' user'), COALESCE(" + joinAliasValue("localized_1_1")
                 + ",'no item'), partnerDocument_1.name FROM Document d "
                 + "JOIN d.owner owner_1 LEFT JOIN owner_1.localized localized_1_1"
                 + onClause("KEY(localized_1_1) = 1")
                 + " LEFT JOIN owner_1.partnerDocument partnerDocument_1 "
-                + "WHERE UPPER(d.name) LIKE UPPER(" + likePattern(":param_0") + ") AND owner_1.name LIKE " + likePattern(":param_1") + " AND UPPER(" + joinAliasValue("localized_1_1")
-                + ") LIKE UPPER(" + likePattern(":param_2") + ") "
+                + "WHERE UPPER(d.name) LIKE UPPER(:param_0)" + noEscape() + " AND owner_1.name LIKE :param_1" + noEscape() + " AND UPPER(" + joinAliasValue("localized_1_1")
+                + ") LIKE UPPER(:param_2)" + noEscape() + " "
                 + "ORDER BY d.id ASC";
 
         PaginatedCriteriaBuilder<DocumentViewModel> pcb = crit.page(0, 2);


### PR DESCRIPTION

<!--- This template is for code related PRs. Remove it for e.g. documentation PRs. -->

<!--- Prefix the title with the issue number like "[#123] Some title" and try to summarize the changes in the title -->

<!--- Before submitting the PR, please make sure it satisfies the following guidelines -->
<!---  * Tests for issues should have one commit that has the form "Test for #123" where "#123" is the issue number -->
<!---  * Fixes for issues should have one commit that has the form "Fix for #123" where "#123" is the issue number -->
<!---  * Commits for the test and the fix should be separate -->

## Description
<!--- Give an overview of what you changed -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue(s) here: -->
Fixes #1638

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

