### PR TITLE
stop ignoring tests in newer versions of spring-boot-starter-test

### DIFF
--- a/examples/it-service-management/pom.xml
+++ b/examples/it-service-management/pom.xml
@@ -154,6 +154,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>${version.junit-vintage}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <version>${h2.version}</version>

--- a/examples/spring-data-dgs/pom.xml
+++ b/examples/spring-data-dgs/pom.xml
@@ -149,6 +149,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>${version.junit-vintage}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <version>${h2.version}</version>
@@ -469,7 +475,7 @@
             <properties>
                 <version.spring>${version.spring-data-2.6-spring}</version.spring>
                 <version.spring.boot>${version.spring-data-2.6-spring-boot}</version.spring.boot>
-                <version.hibernate>${version.hibernate-5.4}</version.hibernate>
+                <version.hibernate>${version.hibernate-5.6}</version.hibernate>
             </properties>
             <dependencies>
                 <dependency>
@@ -498,7 +504,7 @@
                 </dependency>
                 <dependency>
                     <groupId>${project.groupId}</groupId>
-                    <artifactId>blaze-persistence-integration-hibernate-5.4</artifactId>
+                    <artifactId>blaze-persistence-integration-hibernate-5.6</artifactId>
                 </dependency>
             </dependencies>
         </profile>

--- a/examples/spring-data-graphql/pom.xml
+++ b/examples/spring-data-graphql/pom.xml
@@ -148,6 +148,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>${version.junit-vintage}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <version>${h2.version}</version>
@@ -452,7 +458,7 @@
                 <dependency>
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-core</artifactId>
-                    <version>2.12.1</version>
+                    <version>2.13.3</version>
                 </dependency>
                 <dependency>
                     <groupId>${project.groupId}</groupId>
@@ -521,7 +527,7 @@
                 <dependency>
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-core</artifactId>
-                    <version>2.12.1</version>
+                    <version>2.13.3</version>
                 </dependency>
                 <dependency>
                     <groupId>${project.groupId}</groupId>

--- a/examples/spring-data-spqr/pom.xml
+++ b/examples/spring-data-spqr/pom.xml
@@ -148,6 +148,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>${version.junit-vintage}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <version>${h2.version}</version>

--- a/integration/graphql-spqr/pom.xml
+++ b/integration/graphql-spqr/pom.xml
@@ -138,6 +138,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>${version.junit-vintage}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <version>${h2.version}</version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -49,6 +49,7 @@
         <version.blazecbav>0.2.0</version.blazecbav>
         <version.blazeutils>0.1.21</version.blazeutils>
         <version.junit>4.12</version.junit>
+        <version.junit-vintage>5.9.1</version.junit-vintage>
         <version.javassist>3.27.0-GA</version.javassist>
         <querydsl.version>5.0.0</querydsl.version>
         <!-- 1.18 messed up calculation of load index -->


### PR DESCRIPTION
Since 2.4 the starter no longer includes junit-vintage-engine
for junit 4 tests so it has to be included explicitly.