### PR TITLE
Use basic view as Node type for as an connection.edge.node type by default fixes #1707 #1719

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Changes that happened in releases
 * Fix issue with unions in GraphQL selection set
 * Fix issue with `EMBEDDING_VIEW` macro when used in subquery within batch loaded mapping
 * Fix issue with resolving function return types in Hibernate 6 integration
+* Fix fetch determination for relay node types
 
 ### Backwards-incompatible changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Changes that happened in releases
 ### Backwards-incompatible changes
 
 * The GraphQL integration bumped the graphql-java version to 17.4 and had to do some signature changes to fully support union types
+* Default for `GraphQLEntityViewSupportFactory.setDefineDedicatedRelayNodeTypes` changed to `false` to reuse object types for relay edge
 
 ## 1.6.8
 

--- a/examples/spring-data-dgs/src/main/java/com/blazebit/persistence/examples/spring/data/dgs/fetcher/CatGraphQLApi.java
+++ b/examples/spring-data-dgs/src/main/java/com/blazebit/persistence/examples/spring/data/dgs/fetcher/CatGraphQLApi.java
@@ -78,13 +78,4 @@ public class CatGraphQLApi {
         }
         return null;
     }
-
-    @DgsData(parentType = "CatWithOwnerViewNode", field = "theData")
-    public String getNodeData(DataFetchingEnvironment dataFetchingEnvironment) {
-        Object source = dataFetchingEnvironment.getSource();
-        if (source instanceof CatWithOwnerView) {
-            return ((CatWithOwnerView) source).abc();
-        }
-        return null;
-    }
 }

--- a/integration/graphql-dgs/src/test/java/com/blazebit/persistence/integration/graphql/dgs/SampleTest.java
+++ b/integration/graphql-dgs/src/test/java/com/blazebit/persistence/integration/graphql/dgs/SampleTest.java
@@ -114,7 +114,7 @@ public class SampleTest extends AbstractSampleTest {
           nodes.forEach(node -> {
               assertThat(node.get("id")).isNotNull();
               assertThat(node.get("name").asText()).contains("Cat");
-              assertThat(node.get("__typename").asText()).isEqualTo("CatWithOwnerViewNode");
+              assertThat(node.get("__typename").asText()).isEqualTo("CatWithOwnerView");
           });
     }
 

--- a/integration/graphql-dgs/src/test/java/com/blazebit/persistence/integration/graphql/dgs/fetcher/CatGraphQLApi.java
+++ b/integration/graphql-dgs/src/test/java/com/blazebit/persistence/integration/graphql/dgs/fetcher/CatGraphQLApi.java
@@ -43,7 +43,7 @@ public class CatGraphQLApi {
 
     @DgsQuery
     public CatWithOwnerView catById(@InputArgument("id") Long id, DataFetchingEnvironment dataFetchingEnvironment) {
-        return repository.findById(graphQLEntityViewSupport.createSetting(dataFetchingEnvironment), dataFetchingEnvironment.getArgument("id"));
+        return repository.findById(graphQLEntityViewSupport.createSetting(dataFetchingEnvironment), id);
     }
 
     @DgsQuery
@@ -68,15 +68,6 @@ public class CatGraphQLApi {
 
     @DgsData(parentType = "CatWithOwnerView", field = "theData")
     public String getData(DataFetchingEnvironment dataFetchingEnvironment) {
-        Object source = dataFetchingEnvironment.getSource();
-        if (source instanceof CatWithOwnerView) {
-            return ((CatWithOwnerView) source).abc();
-        }
-        return null;
-    }
-
-    @DgsData(parentType = "CatWithOwnerViewNode", field = "theData")
-    public String getNodeData(DataFetchingEnvironment dataFetchingEnvironment) {
         Object source = dataFetchingEnvironment.getSource();
         if (source instanceof CatWithOwnerView) {
             return ((CatWithOwnerView) source).abc();

--- a/integration/graphql/src/main/java/com/blazebit/persistence/integration/graphql/GraphQLEntityViewSupportFactory.java
+++ b/integration/graphql/src/main/java/com/blazebit/persistence/integration/graphql/GraphQLEntityViewSupportFactory.java
@@ -31,7 +31,6 @@ import com.blazebit.persistence.view.metamodel.MethodAttribute;
 import com.blazebit.persistence.view.metamodel.PluralAttribute;
 import com.blazebit.persistence.view.metamodel.SingularAttribute;
 import com.blazebit.reflection.ReflectionUtils;
-import graphql.language.Definition;
 import graphql.language.Description;
 import graphql.language.EnumTypeDefinition;
 import graphql.language.EnumValueDefinition;
@@ -66,7 +65,6 @@ import graphql.schema.idl.TypeDefinitionRegistry;
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedParameterizedType;
-import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -99,36 +97,6 @@ public class GraphQLEntityViewSupportFactory {
 
     private static final Map<Class<?>, String> TYPES;
     private static final Map<Class<?>, String> MP_TYPES;
-    private static final Method TYPE_REGISTRY_ADD;
-    private static final Constructor<ObjectTypeDefinition> OBJECT_TYPE_DEFINITION_CONSTRUCTOR;
-    private static final Method OBJECT_TYPE_DEFINITION_NEW_BUILDER;
-    private static final Method OBJECT_TYPE_DEFINITION_SET_DESCRIPTION;
-    private static final Method OBJECT_TYPE_DEFINITION_BUILDER_NAME;
-    private static final Method OBJECT_TYPE_DEFINITION_BUILDER_DESCRIPTION;
-    private static final Method OBJECT_TYPE_DEFINITION_BUILDER_IMPLEMENTS;
-    private static final Method OBJECT_TYPE_DEFINITION_BUILDER_FIELD_DEFINITIONS;
-    private static final Method OBJECT_TYPE_DEFINITION_BUILDER_BUILD;
-    private static final Constructor<InputObjectTypeDefinition> INPUT_OBJECT_TYPE_DEFINITION_CONSTRUCTOR;
-    private static final Method INPUT_OBJECT_TYPE_DEFINITION_NEW_BUILDER;
-    private static final Method INPUT_OBJECT_TYPE_DEFINITION_SET_DESCRIPTION;
-    private static final Method INPUT_OBJECT_TYPE_DEFINITION_BUILDER_NAME;
-    private static final Method INPUT_OBJECT_TYPE_DEFINITION_BUILDER_DESCRIPTION;
-    private static final Method INPUT_OBJECT_TYPE_DEFINITION_BUILDER_VALUE_DEFINITIONS;
-    private static final Method INPUT_OBJECT_TYPE_DEFINITION_BUILDER_BUILD;
-    private static final Constructor<InterfaceTypeDefinition> INTERFACE_TYPE_DEFINITION_CONSTRUCTOR;
-    private static final Method INTERFACE_TYPE_DEFINITION_NEW_BUILDER;
-    private static final Method INTERFACE_TYPE_DEFINITION_SET_DESCRIPTION;
-    private static final Method INTERFACE_TYPE_DEFINITION_BUILDER_NAME;
-    private static final Method INTERFACE_TYPE_DEFINITION_BUILDER_DESCRIPTION;
-    private static final Method INTERFACE_TYPE_DEFINITION_BUILDER_FIELD_DEFINITIONS;
-    private static final Method INTERFACE_TYPE_DEFINITION_BUILDER_BUILD;
-    private static final Constructor<EnumTypeDefinition> ENUM_TYPE_DEFINITION_CONSTRUCTOR;
-    private static final Method ENUM_TYPE_DEFINITION_NEW_BUILDER;
-    private static final Method ENUM_TYPE_DEFINITION_SET_DESCRIPTION;
-    private static final Method ENUM_TYPE_DEFINITION_BUILDER_NAME;
-    private static final Method ENUM_TYPE_DEFINITION_BUILDER_DESCRIPTION;
-    private static final Method ENUM_TYPE_DEFINITION_BUILDER_FIELD_DEFINITIONS;
-    private static final Method ENUM_TYPE_DEFINITION_BUILDER_BUILD;
 
     static {
         Map<Class<?>, String> types = new HashMap<>();
@@ -179,119 +147,13 @@ public class GraphQLEntityViewSupportFactory {
         mpTypes.put(OffsetDateTime.class, "DateTime");
         mpTypes.put(ZonedDateTime.class, "DateTime");
         MP_TYPES = mpTypes;
-
-        Method typeRegistryAdd = null;
-        try {
-            typeRegistryAdd = TypeDefinitionRegistry.class.getMethod("add", Class.forName("graphql.language.SDLDefinition"));
-        } catch (Exception ex) {
-            try {
-                typeRegistryAdd = TypeDefinitionRegistry.class.getMethod("add", Class.forName("graphql.language.Definition"));
-            } catch (Exception ex2) {
-                RuntimeException runtimeException = new RuntimeException("Could not initialize accessors for graphql-java", ex2);
-                runtimeException.addSuppressed(ex);
-                throw runtimeException;
-            }
-        }
-        TYPE_REGISTRY_ADD = typeRegistryAdd;
-        OBJECT_TYPE_DEFINITION_CONSTRUCTOR = getConstructor(ObjectTypeDefinition.class, String.class, List.class, List.class, List.class);
-        INPUT_OBJECT_TYPE_DEFINITION_CONSTRUCTOR = getConstructor(InputObjectTypeDefinition.class, String.class, List.class, List.class);
-        INTERFACE_TYPE_DEFINITION_CONSTRUCTOR = getConstructor(InterfaceTypeDefinition.class, String.class, List.class, List.class);
-        ENUM_TYPE_DEFINITION_CONSTRUCTOR = getConstructor(EnumTypeDefinition.class, String.class, List.class, List.class);
-        Method objectTypeDefinitionNewBuilder = null;
-        Method objectTypeDefinitionSetDescription = null;
-        Method objectTypeDefinitionBuilderName = null;
-        Method objectTypeDefinitionBuilderDescription = null;
-        Method objectTypeDefinitionBuilderImplements = null;
-        Method objectTypeDefinitionBuilderFieldDefinitions = null;
-        Method objectTypeDefinitionBuilderBuild = null;
-        Method inputObjectTypeDefinitionNewBuilder = null;
-        Method inputObjectTypeDefinitionSetDescription = null;
-        Method inputObjectTypeDefinitionBuilderName = null;
-        Method inputObjectTypeDefinitionBuilderDescription = null;
-        Method inputObjectTypeDefinitionBuilderValueDefinitions = null;
-        Method inputObjectTypeDefinitionBuilderBuild = null;
-        Method interfaceTypeDefinitionNewBuilder = null;
-        Method interfaceTypeDefinitionSetDescription = null;
-        Method interfaceTypeDefinitionBuilderName = null;
-        Method interfaceTypeDefinitionBuilderDescription = null;
-        Method interfaceTypeDefinitionBuilderFieldDefinitions = null;
-        Method interfaceTypeDefinitionBuilderBuild = null;
-        Method enumTypeDefinitionNewBuilder = null;
-        Method enumTypeDefinitionSetDescription = null;
-        Method enumTypeDefinitionBuilderName = null;
-        Method enumTypeDefinitionBuilderDescription = null;
-        Method enumTypeDefinitionBuilderFieldDefinitions = null;
-        Method enumTypeDefinitionBuilderBuild = null;
-        if (OBJECT_TYPE_DEFINITION_CONSTRUCTOR == null) {
-            try {
-                objectTypeDefinitionNewBuilder = ObjectTypeDefinition.class.getMethod("newObjectTypeDefinition");
-                objectTypeDefinitionBuilderName = Class.forName("graphql.language.ObjectTypeDefinition$Builder").getMethod("name", String.class);
-                objectTypeDefinitionBuilderDescription = Class.forName("graphql.language.ObjectTypeDefinition$Builder").getMethod("description", Description.class);
-                objectTypeDefinitionBuilderImplements = Class.forName("graphql.language.ObjectTypeDefinition$Builder").getMethod("implementz", List.class);
-                objectTypeDefinitionBuilderFieldDefinitions = Class.forName("graphql.language.ObjectTypeDefinition$Builder").getMethod("fieldDefinitions", List.class);
-                objectTypeDefinitionBuilderBuild = Class.forName("graphql.language.ObjectTypeDefinition$Builder").getMethod("build");
-
-                inputObjectTypeDefinitionNewBuilder = InputObjectTypeDefinition.class.getMethod("newInputObjectDefinition");
-                inputObjectTypeDefinitionBuilderName = Class.forName("graphql.language.InputObjectTypeDefinition$Builder").getMethod("name", String.class);
-                inputObjectTypeDefinitionBuilderDescription = Class.forName("graphql.language.InputObjectTypeDefinition$Builder").getMethod("description", Description.class);
-                inputObjectTypeDefinitionBuilderValueDefinitions = Class.forName("graphql.language.InputObjectTypeDefinition$Builder").getMethod("inputValueDefinitions", List.class);
-                inputObjectTypeDefinitionBuilderBuild = Class.forName("graphql.language.InputObjectTypeDefinition$Builder").getMethod("build");
-
-                interfaceTypeDefinitionNewBuilder = InterfaceTypeDefinition.class.getMethod("newInterfaceTypeDefinition");
-                interfaceTypeDefinitionBuilderName = Class.forName("graphql.language.InterfaceTypeDefinition$Builder").getMethod("name", String.class);
-                interfaceTypeDefinitionBuilderDescription = Class.forName("graphql.language.InterfaceTypeDefinition$Builder").getMethod("description", Description.class);
-                interfaceTypeDefinitionBuilderFieldDefinitions = Class.forName("graphql.language.InterfaceTypeDefinition$Builder").getMethod("definitions", List.class);
-                interfaceTypeDefinitionBuilderBuild = Class.forName("graphql.language.InterfaceTypeDefinition$Builder").getMethod("build");
-
-                enumTypeDefinitionNewBuilder = EnumTypeDefinition.class.getMethod("newEnumTypeDefinition");
-                enumTypeDefinitionBuilderName = Class.forName("graphql.language.EnumTypeDefinition$Builder").getMethod("name", String.class);
-                enumTypeDefinitionBuilderDescription = Class.forName("graphql.language.EnumTypeDefinition$Builder").getMethod("description", Description.class);
-                enumTypeDefinitionBuilderFieldDefinitions = Class.forName("graphql.language.EnumTypeDefinition$Builder").getMethod("enumValueDefinitions", List.class);
-                enumTypeDefinitionBuilderBuild = Class.forName("graphql.language.EnumTypeDefinition$Builder").getMethod("build");
-            } catch (Exception ex) {
-                throw new RuntimeException("Could not initialize accessors for graphql-java", ex);
-            }
-        } else {
-            try {
-                objectTypeDefinitionSetDescription = ObjectTypeDefinition.class.getMethod("setDescription", Description.class);
-                inputObjectTypeDefinitionSetDescription = InputObjectTypeDefinition.class.getMethod("setDescription", Description.class);
-                interfaceTypeDefinitionSetDescription = InterfaceTypeDefinition.class.getMethod("setDescription", Description.class);
-                enumTypeDefinitionSetDescription = EnumTypeDefinition.class.getMethod("setDescription", Description.class);
-            } catch (Exception ex) {
-                throw new RuntimeException("Could not initialize accessors for graphql-java", ex);
-            }
-        }
-        OBJECT_TYPE_DEFINITION_NEW_BUILDER = objectTypeDefinitionNewBuilder;
-        OBJECT_TYPE_DEFINITION_SET_DESCRIPTION = objectTypeDefinitionSetDescription;
-        OBJECT_TYPE_DEFINITION_BUILDER_NAME = objectTypeDefinitionBuilderName;
-        OBJECT_TYPE_DEFINITION_BUILDER_DESCRIPTION = objectTypeDefinitionBuilderDescription;
-        OBJECT_TYPE_DEFINITION_BUILDER_IMPLEMENTS = objectTypeDefinitionBuilderImplements;
-        OBJECT_TYPE_DEFINITION_BUILDER_FIELD_DEFINITIONS = objectTypeDefinitionBuilderFieldDefinitions;
-        OBJECT_TYPE_DEFINITION_BUILDER_BUILD = objectTypeDefinitionBuilderBuild;
-        INPUT_OBJECT_TYPE_DEFINITION_NEW_BUILDER = inputObjectTypeDefinitionNewBuilder;
-        INPUT_OBJECT_TYPE_DEFINITION_SET_DESCRIPTION = inputObjectTypeDefinitionSetDescription;
-        INPUT_OBJECT_TYPE_DEFINITION_BUILDER_NAME = inputObjectTypeDefinitionBuilderName;
-        INPUT_OBJECT_TYPE_DEFINITION_BUILDER_DESCRIPTION = inputObjectTypeDefinitionBuilderDescription;
-        INPUT_OBJECT_TYPE_DEFINITION_BUILDER_VALUE_DEFINITIONS = inputObjectTypeDefinitionBuilderValueDefinitions;
-        INPUT_OBJECT_TYPE_DEFINITION_BUILDER_BUILD = inputObjectTypeDefinitionBuilderBuild;
-        INTERFACE_TYPE_DEFINITION_NEW_BUILDER = interfaceTypeDefinitionNewBuilder;
-        INTERFACE_TYPE_DEFINITION_SET_DESCRIPTION = interfaceTypeDefinitionSetDescription;
-        INTERFACE_TYPE_DEFINITION_BUILDER_NAME = interfaceTypeDefinitionBuilderName;
-        INTERFACE_TYPE_DEFINITION_BUILDER_DESCRIPTION = interfaceTypeDefinitionBuilderDescription;
-        INTERFACE_TYPE_DEFINITION_BUILDER_FIELD_DEFINITIONS = interfaceTypeDefinitionBuilderFieldDefinitions;
-        INTERFACE_TYPE_DEFINITION_BUILDER_BUILD = interfaceTypeDefinitionBuilderBuild;
-        ENUM_TYPE_DEFINITION_NEW_BUILDER = enumTypeDefinitionNewBuilder;
-        ENUM_TYPE_DEFINITION_SET_DESCRIPTION = enumTypeDefinitionSetDescription;
-        ENUM_TYPE_DEFINITION_BUILDER_NAME = enumTypeDefinitionBuilderName;
-        ENUM_TYPE_DEFINITION_BUILDER_DESCRIPTION = enumTypeDefinitionBuilderDescription;
-        ENUM_TYPE_DEFINITION_BUILDER_FIELD_DEFINITIONS = enumTypeDefinitionBuilderFieldDefinitions;
-        ENUM_TYPE_DEFINITION_BUILDER_BUILD = enumTypeDefinitionBuilderBuild;
     }
 
     private boolean defineNormalTypes;
     private boolean defineRelayTypes;
     private Boolean implementRelayNode;
     private boolean defineRelayNodeIfNotExist;
+    private boolean defineDedicatedRelayNodes;
     private Pattern typeFilterPattern;
     private Map<String, GraphQLScalarType> scalarTypeMap;
     private Set<String> registeredScalarTypeNames;
@@ -305,14 +167,6 @@ public class GraphQLEntityViewSupportFactory {
     public GraphQLEntityViewSupportFactory(boolean defineNormalTypes, boolean defineRelayTypes) {
         this.defineNormalTypes = defineNormalTypes;
         this.defineRelayTypes = defineRelayTypes;
-    }
-
-    private static <T> Constructor<T> getConstructor(Class<T> clazz, Class<?>... parameterTypes) {
-        try {
-            return clazz.getConstructor(parameterTypes);
-        } catch (NoSuchMethodException e) {
-            return null;
-        }
     }
 
     /**
@@ -385,6 +239,28 @@ public class GraphQLEntityViewSupportFactory {
      */
     public void setDefineRelayNodeIfNotExist(boolean defineRelayNodeIfNotExist) {
         this.defineRelayNodeIfNotExist = defineRelayNodeIfNotExist;
+    }
+
+    /**
+     * Returns <code>true</code> if dedicated types should be created, name-suffixed with {@code Node}, as relay node types,
+     * or <code>false</code> if the object types for entity views should be used directly.
+     *
+     * @return <code>true</code> if dedicated types should be created, name-suffixed with {@code Node}, as relay node types
+     * @since 1.6.9
+     */
+    public boolean isDefineDedicatedRelayNodes() {
+        return defineDedicatedRelayNodes;
+    }
+
+    /**
+     * Sets whether dedicated types should be created, name-suffixed with {@code Node}, as relay node types,
+     * or <code>false</code> if the object types for entity views should be used directly.
+     *
+     * @param defineDedicatedRelayNodes Whether dedicated types should be created, name-suffixed with {@code Node}, as relay node types
+     * @since 1.6.9
+     */
+    public void setDefineDedicatedRelayNodes(boolean defineDedicatedRelayNodes) {
+        this.defineDedicatedRelayNodes = defineDedicatedRelayNodes;
     }
 
     /**
@@ -461,6 +337,12 @@ public class GraphQLEntityViewSupportFactory {
         EntityMetamodel entityMetamodel = entityViewManager.getService(EntityMetamodel.class);
         Map<String, ManagedViewType<?>> typeNameToViewType = new HashMap<>();
         Map<String, Map<String, String>> typeNameToFieldMapping = new HashMap<>();
+        List<Type> implementsTypes;
+        if (isImplementRelayNode()) {
+            implementsTypes = Collections.singletonList(new TypeName("Node"));
+        } else {
+            implementsTypes = Collections.emptyList();
+        }
         for (ManagedViewType<?> managedView : entityViewManager.getMetamodel().getManagedViews()) {
             if (typeFilterPattern != null && !typeFilterPattern.matcher(managedView.getJavaType().getName()).matches()
                 || isIgnored(managedView.getJavaType())) {
@@ -502,7 +384,7 @@ public class GraphQLEntityViewSupportFactory {
                     fieldDefinitions.add(fieldDefinition);
                     fieldNames.add(fieldName);
                     addFieldMapping(typeNameToFieldMapping, typeName, attribute, fieldName);
-                    if ( isDefineRelayTypes() ) {
+                    if (isDefineRelayTypes() && isDefineDedicatedRelayNodes()) {
                         addFieldMapping(typeNameToFieldMapping, typeName + "Node", attribute, fieldName);
                     }
                     valueDefinitions.add(new InputValueDefinition(fieldName, inputType));
@@ -566,7 +448,7 @@ public class GraphQLEntityViewSupportFactory {
                 }
             }
 
-            addObjectTypeDefinition(typeRegistry, typeNameToViewType, managedView, newObjectTypeDefinition(typeName, fieldDefinitions, description), newInputObjectTypeDefinition(inputTypeName, valueDefinitions, description));
+            addObjectTypeDefinition(typeRegistry, typeNameToViewType, managedView, newObjectTypeDefinition(typeName, implementsTypes, fieldDefinitions, description), newInputObjectTypeDefinition(inputTypeName, valueDefinitions, description));
         }
 
         Set<String> serializableBasicTypes = new HashSet<>();
@@ -641,6 +523,7 @@ public class GraphQLEntityViewSupportFactory {
         Map<String, ManagedViewType<?>> typeNameToViewType = new HashMap<>();
         Map<String, Map<String, String>> typeNameToFieldMapping = new HashMap<>();
         Map<Class<?>, String> registeredTypeNames = new HashMap<>();
+
         for (ManagedViewType<?> managedView : entityViewManager.getMetamodel().getManagedViews()) {
             if (typeFilterPattern != null && !typeFilterPattern.matcher(managedView.getJavaType().getName()).matches()
                 || isIgnored(managedView.getJavaType())) {
@@ -651,6 +534,9 @@ public class GraphQLEntityViewSupportFactory {
             String description = getDescription(managedView.getJavaType());
             GraphQLObjectType.Builder builder = GraphQLObjectType.newObject().name(typeName);
             GraphQLInputObjectType.Builder inputBuilder = GraphQLInputObjectType.newInputObject().name(inputTypeName);
+            if (isImplementRelayNode()) {
+                builder.withInterface(new GraphQLTypeReference("Node"));
+            }
             if (description != null) {
                 builder.description(description);
                 inputBuilder.description(description);
@@ -685,7 +571,7 @@ public class GraphQLEntityViewSupportFactory {
                     fieldBuilder.type(type);
                     builder.field(fieldBuilder);
                     addFieldMapping(typeNameToFieldMapping, typeName, attribute, fieldName);
-                    if ( isDefineRelayTypes() ) {
+                    if (isDefineRelayTypes() && isDefineDedicatedRelayNodes()) {
                         addFieldMapping(typeNameToFieldMapping, typeName + "Node", attribute, fieldName);
                     }
                     inputBuilder.field(GraphQLInputObjectField.newInputObjectField().name(fieldName).type(inputType).build());
@@ -833,136 +719,69 @@ public class GraphQLEntityViewSupportFactory {
     }
 
     protected ObjectTypeDefinition newObjectTypeDefinition(String typeName, List<Type> implementsTypes, List<FieldDefinition> fieldDefinitions, String description) {
-        try {
-            if (OBJECT_TYPE_DEFINITION_CONSTRUCTOR != null) {
-//                new ObjectTypeDefinition(typeName, implementsTypes, directives, fieldDefinitions);
-                ObjectTypeDefinition typeDefinition = OBJECT_TYPE_DEFINITION_CONSTRUCTOR.newInstance(typeName, implementsTypes, new ArrayList<>(0), fieldDefinitions);
-                if (description != null) {
-                    OBJECT_TYPE_DEFINITION_SET_DESCRIPTION.invoke(typeDefinition, new Description(description, null, false));
-                }
-                return typeDefinition;
-            } else {
-//                ObjectTypeDefinition.newObjectTypeDefinition()
-//                        .name(typeName)
-//                        .fieldDefinitions(fieldDefinitions)
-//                        .build()
-                Object newObjectTypeDefinitionBuilder = OBJECT_TYPE_DEFINITION_NEW_BUILDER.invoke(null);
-                OBJECT_TYPE_DEFINITION_BUILDER_NAME.invoke(newObjectTypeDefinitionBuilder, typeName);
-                if (description != null) {
-                    OBJECT_TYPE_DEFINITION_BUILDER_DESCRIPTION.invoke(newObjectTypeDefinitionBuilder, new Description(description, null, false));
-                }
-                OBJECT_TYPE_DEFINITION_BUILDER_IMPLEMENTS.invoke(newObjectTypeDefinitionBuilder, implementsTypes);
-                OBJECT_TYPE_DEFINITION_BUILDER_FIELD_DEFINITIONS.invoke(newObjectTypeDefinitionBuilder, fieldDefinitions);
-                return (ObjectTypeDefinition) OBJECT_TYPE_DEFINITION_BUILDER_BUILD.invoke(newObjectTypeDefinitionBuilder);
-            }
-        } catch (Exception e) {
-            throw new RuntimeException("Could not build object type definition", e);
-        }
+        return ObjectTypeDefinition.newObjectTypeDefinition()
+                .name(typeName)
+                .description(new Description(description, null, false))
+                .implementz(implementsTypes)
+                .fieldDefinitions(fieldDefinitions)
+                .build();
     }
 
     protected InputObjectTypeDefinition newInputObjectTypeDefinition(String typeName, List<InputValueDefinition> valueDefinitions, String description) {
-        try {
-            if (INPUT_OBJECT_TYPE_DEFINITION_CONSTRUCTOR != null) {
-//                new InputObjectTypeDefinition(typeName, directives, valueDefinitions);
-                InputObjectTypeDefinition typeDefinition = INPUT_OBJECT_TYPE_DEFINITION_CONSTRUCTOR.newInstance(typeName, new ArrayList<>(0), valueDefinitions);
-                if (description != null) {
-                    INPUT_OBJECT_TYPE_DEFINITION_SET_DESCRIPTION.invoke(typeDefinition, new Description(description, null, false));
-                }
-                return typeDefinition;
-            } else {
-//                InputObjectTypeDefinition.newInputObjectTypeDefinition()
-//                        .name(typeName)
-//                        .valueDefinitions(valueDefinitions)
-//                        .build()
-                Object newInputObjectTypeDefinitionBuilder = INPUT_OBJECT_TYPE_DEFINITION_NEW_BUILDER.invoke(null);
-                INPUT_OBJECT_TYPE_DEFINITION_BUILDER_NAME.invoke(newInputObjectTypeDefinitionBuilder, typeName);
-                if (description != null) {
-                    INPUT_OBJECT_TYPE_DEFINITION_BUILDER_DESCRIPTION.invoke(newInputObjectTypeDefinitionBuilder, new Description(description, null, false));
-                }
-                INPUT_OBJECT_TYPE_DEFINITION_BUILDER_VALUE_DEFINITIONS.invoke(newInputObjectTypeDefinitionBuilder, valueDefinitions);
-                return (InputObjectTypeDefinition) INPUT_OBJECT_TYPE_DEFINITION_BUILDER_BUILD.invoke(newInputObjectTypeDefinitionBuilder);
-            }
-        } catch (Exception e) {
-            throw new RuntimeException("Could not build input object type definition", e);
-        }
+        return InputObjectTypeDefinition.newInputObjectDefinition()
+                .name(typeName)
+                .description(new Description(description, null, false))
+                .inputValueDefinitions(valueDefinitions)
+                .build();
     }
 
     protected InterfaceTypeDefinition newInterfaceTypeDefinition(String name, List<FieldDefinition> fieldDefinitions, String description) {
-        try {
-            if (INTERFACE_TYPE_DEFINITION_CONSTRUCTOR != null) {
-//                return new InterfaceTypeDefinition(name, fieldDefinitions, new ArrayList<>(0));
-                InterfaceTypeDefinition typeDefinition = INTERFACE_TYPE_DEFINITION_CONSTRUCTOR.newInstance(name, fieldDefinitions, new ArrayList<>(0));
-                if (description != null) {
-                    INTERFACE_TYPE_DEFINITION_SET_DESCRIPTION.invoke(typeDefinition, new Description(description, null, false));
-                }
-                return typeDefinition;
-            } else {
-//                InterfaceTypeDefinition.newInterfaceTypeDefinition().name(name).definitions(fieldDefinitions).build()
-                Object newInterfaceTypeDefinitionBuilder = INTERFACE_TYPE_DEFINITION_NEW_BUILDER.invoke(null);
-                INTERFACE_TYPE_DEFINITION_BUILDER_NAME.invoke(newInterfaceTypeDefinitionBuilder, name);
-                if (description != null) {
-                    INTERFACE_TYPE_DEFINITION_BUILDER_DESCRIPTION.invoke(newInterfaceTypeDefinitionBuilder, new Description(description, null, false));
-                }
-                INTERFACE_TYPE_DEFINITION_BUILDER_FIELD_DEFINITIONS.invoke(newInterfaceTypeDefinitionBuilder, fieldDefinitions);
-                return (InterfaceTypeDefinition) INTERFACE_TYPE_DEFINITION_BUILDER_BUILD.invoke(newInterfaceTypeDefinitionBuilder);
-            }
-        } catch (Exception e) {
-            throw new RuntimeException("Could not build object type definition", e);
-        }
+        return InterfaceTypeDefinition.newInterfaceTypeDefinition()
+            .name(name)
+            .description(new Description(description, null, false))
+            .definitions(fieldDefinitions)
+            .build();
     }
 
     protected EnumTypeDefinition newEnumTypeDefinition(String typeName, List<EnumValueDefinition> enumValueDefinitions, String description) {
-        try {
-            if (ENUM_TYPE_DEFINITION_CONSTRUCTOR != null) {
-//                return new EnumTypeDefinition(typeName, enumValueDefinitions, new ArrayList<>(0));
-                EnumTypeDefinition typeDefinition = ENUM_TYPE_DEFINITION_CONSTRUCTOR.newInstance(typeName, enumValueDefinitions, new ArrayList<>(0));
-                if (description != null) {
-                    ENUM_TYPE_DEFINITION_SET_DESCRIPTION.invoke(typeDefinition, new Description(description, null, false));
-                }
-                return typeDefinition;
-            } else {
-//                EnumTypeDefinition.newEnumTypeDefinition()
-//                        .name(typeName)
-//                        .enumValueDefinitions(enumValueDefinitions)
-//                        .build()
-                Object newEnumTypeDefinitionBuilder = ENUM_TYPE_DEFINITION_NEW_BUILDER.invoke(null);
-                ENUM_TYPE_DEFINITION_BUILDER_NAME.invoke(newEnumTypeDefinitionBuilder, typeName);
-                if (description != null) {
-                    ENUM_TYPE_DEFINITION_BUILDER_DESCRIPTION.invoke(newEnumTypeDefinitionBuilder, new Description(description, null, false));
-                }
-                ENUM_TYPE_DEFINITION_BUILDER_FIELD_DEFINITIONS.invoke(newEnumTypeDefinitionBuilder, enumValueDefinitions);
-                return (EnumTypeDefinition) ENUM_TYPE_DEFINITION_BUILDER_BUILD.invoke(newEnumTypeDefinitionBuilder);
-            }
-        } catch (Exception e) {
-            throw new RuntimeException("Could not build object type definition", e);
-        }
+        return EnumTypeDefinition.newEnumTypeDefinition()
+                .name(typeName)
+                .description(new Description(description, null, false))
+                .enumValueDefinitions(enumValueDefinitions)
+                .build();
     }
 
     protected void addObjectTypeDefinition(TypeDefinitionRegistry typeRegistry, Map<String, ManagedViewType<?>> typeNameToViewType, ManagedViewType<?> managedView, ObjectTypeDefinition objectTypeDefinition, InputObjectTypeDefinition inputObjectTypeDefinition) {
         registerManagedViewType(typeRegistry, typeNameToViewType, managedView, objectTypeDefinition);
         if (isDefineNormalTypes()) {
-            addDefinition(typeRegistry, objectTypeDefinition);
+            typeRegistry.add(objectTypeDefinition);
         }
         if (inputObjectTypeDefinition != null) {
             registerManagedViewType(typeRegistry, typeNameToViewType, managedView, inputObjectTypeDefinition);
             if (isDefineNormalTypes()) {
-                addDefinition(typeRegistry, inputObjectTypeDefinition);
+                typeRegistry.add(inputObjectTypeDefinition);
             }
         }
-        List<Type> implementTypes = new ArrayList<>(objectTypeDefinition.getImplements());
-        if (isImplementRelayNode()) {
+        String nodeTypeName;
+        ObjectTypeDefinition nodeType;
+        if (isDefineDedicatedRelayNodes()) {
+            nodeTypeName = objectTypeDefinition.getName() + "Node";
+            List<Type> implementTypes = new ArrayList<>(objectTypeDefinition.getImplements());
             implementTypes.add(new TypeName("Node"));
+            nodeType = newObjectTypeDefinition(nodeTypeName, implementTypes, objectTypeDefinition.getFieldDefinitions(), null);
+        } else {
+            nodeTypeName = objectTypeDefinition.getName();
+            nodeType = null;
         }
-        ObjectTypeDefinition nodeType = newObjectTypeDefinition(objectTypeDefinition.getName() + "Node", implementTypes, objectTypeDefinition.getFieldDefinitions(), null);
 
-        if (!typeRegistry.getType("Node").isPresent() && isImplementRelayNode() && isDefineRelayNodeIfNotExist()) {
+        if (isDefineRelayTypes() && !typeRegistry.getType("Node").isPresent() && (isImplementRelayNode() || isDefineDedicatedRelayNodes()) && isDefineRelayNodeIfNotExist()) {
             List<FieldDefinition> nodeFields = new ArrayList<>(4);
             nodeFields.add(new FieldDefinition("id", new NonNullType(new TypeName("ID"))));
-            addDefinition(typeRegistry, newInterfaceTypeDefinition("Node", nodeFields, null));
+            typeRegistry.add(newInterfaceTypeDefinition("Node", nodeFields, null));
         }
 
         List<FieldDefinition> edgeFields = new ArrayList<>(2);
-        edgeFields.add(new FieldDefinition("node", new NonNullType(new TypeName(nodeType.getName()))));
+        edgeFields.add(new FieldDefinition("node", new NonNullType(new TypeName(nodeTypeName))));
         edgeFields.add(new FieldDefinition("cursor", new NonNullType(new TypeName("String"))));
         ObjectTypeDefinition edgeType = newObjectTypeDefinition(objectTypeDefinition.getName() + "Edge", edgeFields, null);
 
@@ -972,47 +791,56 @@ public class GraphQLEntityViewSupportFactory {
         connectionFields.add(new FieldDefinition("totalCount", new NonNullType(new TypeName("Int"))));
         ObjectTypeDefinition connectionType = newObjectTypeDefinition(objectTypeDefinition.getName() + "Connection", connectionFields, null);
 
-        if (!typeRegistry.getType("PageInfo").isPresent() && isDefineRelayNodeIfNotExist()) {
+        if (isDefineRelayTypes() && !typeRegistry.getType("PageInfo").isPresent() && isDefineRelayNodeIfNotExist()) {
             List<FieldDefinition> pageInfoFields = new ArrayList<>(4);
             pageInfoFields.add(new FieldDefinition("hasNextPage", new NonNullType(new TypeName("Boolean"))));
             pageInfoFields.add(new FieldDefinition("hasPreviousPage", new NonNullType(new TypeName("Boolean"))));
             pageInfoFields.add(new FieldDefinition("startCursor", new TypeName("String")));
             pageInfoFields.add(new FieldDefinition("endCursor", new TypeName("String")));
-            addDefinition(typeRegistry, newObjectTypeDefinition("PageInfo", pageInfoFields, null));
+            typeRegistry.add(newObjectTypeDefinition("PageInfo", pageInfoFields, null));
         }
 
-        registerManagedViewType(typeRegistry, typeNameToViewType, managedView, nodeType);
+        if (nodeType != null) {
+            registerManagedViewType(typeRegistry, typeNameToViewType, managedView, nodeType);
+        }
         registerManagedViewType(typeRegistry, typeNameToViewType, managedView, edgeType);
         registerManagedViewType(typeRegistry, typeNameToViewType, managedView, connectionType);
         if (isDefineRelayTypes()) {
-            addDefinition(typeRegistry, nodeType);
-            addDefinition(typeRegistry, edgeType);
-            addDefinition(typeRegistry, connectionType);
+            if (nodeType != null) {
+                typeRegistry.add(nodeType);
+            }
+            typeRegistry.add(edgeType);
+            typeRegistry.add(connectionType);
         }
     }
 
     protected void addObjectTypeDefinition(GraphQLSchema.Builder schemaBuilder, Map<String, ManagedViewType<?>> typeNameToViewType, ManagedViewType<?> managedView, GraphQLObjectType objectType, GraphQLInputObjectType inputObjectType) {
-        typeNameToViewType.put(inputObjectType.getName(), managedView);
+        typeNameToViewType.put(objectType.getName(), managedView);
         if (isDefineNormalTypes()) {
-            schemaBuilder.additionalType(inputObjectType);
+            schemaBuilder.additionalType(objectType);
         }
         if (managedView.isUpdatable() || managedView.isCreatable()) {
-            // No need to define relay types for creatable/updatable views
-            return;
+            typeNameToViewType.put(inputObjectType.getName(), managedView);
+            if (isDefineNormalTypes()) {
+                schemaBuilder.additionalType(inputObjectType);
+            }
         }
         String nodeTypeName;
         String edgeTypeName;
         String connectionTypeName;
         String pageInfoTypeName;
         if (scalarTypeMap == null) {
-            nodeTypeName = objectType.getName() + "Node";
+            if (isDefineDedicatedRelayNodes()) {
+                nodeTypeName = objectType.getName() + "Node";
+            } else {
+                nodeTypeName = objectType.getName();
+            }
             edgeTypeName = objectType.getName() + "Edge";
             connectionTypeName = objectType.getName() + "Connection";
             pageInfoTypeName = "PageInfo";
-
-            GraphQLObjectType.Builder nodeType = GraphQLObjectType.newObject().name(nodeTypeName);
-            nodeType.fields(objectType.getFieldDefinitions());
-            if (isImplementRelayNode()) {
+            if (isDefineRelayTypes() && (isImplementRelayNode() || isDefineDedicatedRelayNodes())) {
+                GraphQLObjectType.Builder nodeType = GraphQLObjectType.newObject().name(nodeTypeName);
+                nodeType.fields(objectType.getFieldDefinitions());
                 nodeType.withInterface(new GraphQLTypeReference("Node"));
                 if (!typeNameToViewType.containsKey("Node") && isDefineRelayNodeIfNotExist()) {
                     GraphQLInterfaceType.Builder nodeInterfaceType = GraphQLInterfaceType.newInterface().name("Node")
@@ -1023,8 +851,6 @@ public class GraphQLEntityViewSupportFactory {
                             );
                     schemaBuilder.additionalType(nodeInterfaceType.build());
                 }
-            }
-            if (isDefineNormalTypes()) {
                 schemaBuilder.additionalType(nodeType.build());
             }
             typeNameToViewType.put(nodeTypeName, managedView);
@@ -1075,9 +901,6 @@ public class GraphQLEntityViewSupportFactory {
         typeNameToViewType.put(edgeTypeName, managedView);
         typeNameToViewType.put(connectionTypeName, managedView);
         typeNameToViewType.put(objectType.getName(), managedView);
-        if (isDefineNormalTypes()) {
-            schemaBuilder.additionalType(objectType);
-        }
 
         if (isDefineRelayTypes()) {
             schemaBuilder.additionalType(edgeType.build());
@@ -1085,17 +908,9 @@ public class GraphQLEntityViewSupportFactory {
         }
     }
 
-    protected void addDefinition(TypeDefinitionRegistry typeRegistry, Definition<?> definition) {
-        try {
-            TYPE_REGISTRY_ADD.invoke(typeRegistry, definition);
-        } catch (Exception e) {
-            throw new RuntimeException("Could not add definition", e);
-        }
-    }
-
     protected void registerManagedViewType(TypeDefinitionRegistry typeRegistry, Map<String, ManagedViewType<?>> typeNameToViewType, ManagedViewType<?> managedView, TypeDefinition<?> objectTypeDefinition) {
         if (isDefineNormalTypes()) {
-            addDefinition(typeRegistry, objectTypeDefinition);
+            typeRegistry.add(objectTypeDefinition);
         }
         ManagedViewType<?> old;
         if ((old = typeNameToViewType.put(objectTypeDefinition.getName(), managedView)) != null) {
@@ -1217,7 +1032,7 @@ public class GraphQLEntityViewSupportFactory {
         fields.add(new FieldDefinition("key", key));
         fields.add(new FieldDefinition("value", value));
         if (isDefineNormalTypes()) {
-            addDefinition(typeRegistry, newObjectTypeDefinition(entryName, fields, null));
+            typeRegistry.add(newObjectTypeDefinition(entryName, fields, null));
         }
         return new ListType(new TypeName(entryName));
     }
@@ -1257,7 +1072,7 @@ public class GraphQLEntityViewSupportFactory {
         fields.add(new FieldDefinition("key", key));
         fields.add(new FieldDefinition("value", value));
         if (isDefineNormalTypes()) {
-            addDefinition(typeRegistry, newObjectTypeDefinition(entryName, fields, null));
+            typeRegistry.add(newObjectTypeDefinition(entryName, fields, null));
         }
         return new ListType(new TypeName(entryName));
     }
@@ -2023,7 +1838,7 @@ public class GraphQLEntityViewSupportFactory {
                     }
 
                     if (isDefineNormalTypes()) {
-                        addDefinition(typeRegistry, newEnumTypeDefinition(typeName, enumValueDefinitions, getDescription(javaType)));
+                        typeRegistry.add(newEnumTypeDefinition(typeName, enumValueDefinitions, getDescription(javaType)));
                     }
                 }
             } else {

--- a/integration/graphql/src/main/java/com/blazebit/persistence/integration/graphql/GraphQLEntityViewSupportFactory.java
+++ b/integration/graphql/src/main/java/com/blazebit/persistence/integration/graphql/GraphQLEntityViewSupportFactory.java
@@ -502,6 +502,9 @@ public class GraphQLEntityViewSupportFactory {
                     fieldDefinitions.add(fieldDefinition);
                     fieldNames.add(fieldName);
                     addFieldMapping(typeNameToFieldMapping, typeName, attribute, fieldName);
+                    if ( isDefineRelayTypes() ) {
+                        addFieldMapping(typeNameToFieldMapping, typeName + "Node", attribute, fieldName);
+                    }
                     valueDefinitions.add(new InputValueDefinition(fieldName, inputType));
                     addFieldMapping(typeNameToFieldMapping, inputTypeName, attribute, fieldName);
                 }
@@ -682,6 +685,9 @@ public class GraphQLEntityViewSupportFactory {
                     fieldBuilder.type(type);
                     builder.field(fieldBuilder);
                     addFieldMapping(typeNameToFieldMapping, typeName, attribute, fieldName);
+                    if ( isDefineRelayTypes() ) {
+                        addFieldMapping(typeNameToFieldMapping, typeName + "Node", attribute, fieldName);
+                    }
                     inputBuilder.field(GraphQLInputObjectField.newInputObjectField().name(fieldName).type(inputType).build());
                     addFieldMapping(typeNameToFieldMapping, inputTypeName, attribute, fieldName);
                 }


### PR DESCRIPTION
Beforehand, we created a specific type `ViewNode` for the connection.edge.node type, which was a clone of the actual `View` that was to be returned. With this PR this is changed, by default, the actual `View` is used as an connection.edge.node type.

See #1719 for more information.

You can activate the old bahavior by setting `GraphQLEntityViewSupportFactory.setCreateNodeViewTypeForEdge(true)`

Misc:
- Also reproduces the `__typename` issue in #1707 (for DGS)

Fixes #1707. Fixes #1719 