### PR TITLE
[#1722] avoid NPE in TupleTransformatorFactory

### DIFF
--- a/entity-view/impl/src/main/java/com/blazebit/persistence/view/impl/objectbuilder/ViewTypeObjectBuilder.java
+++ b/entity-view/impl/src/main/java/com/blazebit/persistence/view/impl/objectbuilder/ViewTypeObjectBuilder.java
@@ -120,6 +120,6 @@ public class ViewTypeObjectBuilder<T> implements ObjectBuilder<T> {
 
     private boolean hasSubFetches(String attributePath) {
         String fetchedPath = fetches.ceiling(attributePath);
-        return fetchedPath != null && (fetchedPath.length() == attributePath.length() || fetchedPath.startsWith(attributePath) && fetchedPath.length() > attributePath.length() && fetchedPath.charAt(attributePath.length()) == '.');
+        return fetchedPath != null && (fetchedPath.equals(attributePath) || fetchedPath.startsWith(attributePath) && fetchedPath.charAt(attributePath.length()) == '.');
     }
 }

--- a/entity-view/impl/src/main/java/com/blazebit/persistence/view/impl/objectbuilder/transformator/TupleTransformatorFactory.java
+++ b/entity-view/impl/src/main/java/com/blazebit/persistence/view/impl/objectbuilder/transformator/TupleTransformatorFactory.java
@@ -132,7 +132,9 @@ public class TupleTransformatorFactory {
 
         @Override
         public Object[] transform(Object[] tuple, UpdatableViewMap updatableViewMap) {
-            if (Arrays.binarySearch(subtypeIndexes, ((Number) tuple[classMappingIndex]).intValue()) >= 0) {
+            Number index = (Number) tuple[classMappingIndex];
+            // FIXME: The null check is just a crude fix for https://github.com/Blazebit/blaze-persistence/issues/1722
+            if (index != null && Arrays.binarySearch(subtypeIndexes, index.intValue()) >= 0) {
                 return delegate.transform(tuple, updatableViewMap);
             } else {
                 return tuple;


### PR DESCRIPTION
For some unknown reason a classMappingIndex sometimes
points to a non-present field in the tuple (filtered
via fetches mechanism). The correct fix should be somewhere
else but that this is probably good enough - just don't
perfomr any tuple transformation for non-present fields.

Also, fix a small bug in hasSubFetches. The wrongly
implemented equality check lead to overfetching.


<!--- This template is for code related PRs. Remove it for e.g. documentation PRs. -->

<!--- Prefix the title with the issue number like "[#123] Some title" and try to summarize the changes in the title -->

<!--- Before submitting the PR, please make sure it satisfies the following guidelines -->
<!---  * Tests for issues should have one commit that has the form "Test for #123" where "#123" is the issue number -->
<!---  * Fixes for issues should have one commit that has the form "Fix for #123" where "#123" is the issue number -->
<!---  * Commits for the test and the fix should be separate -->

## Description
<!--- Give an overview of what you changed -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue(s) here: -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->