### PR TITLE
[#1799] JDK 21 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,14 @@ name: "Blaze-Persistence CI"
 on: [push, pull_request]
 env:
   MAVEN_SKIP_RC: true
+# See https://github.com/hibernate/hibernate-orm/pull/4615 for a description of the behavior we're getting.
+concurrency:
+  # Consider that two builds are in the same concurrency group (cannot run concurrently)
+  # if they use the same workflow and are about the same branch ("ref") or pull request.
+  group: "workflow = ${{ github.workflow }}, ref = ${{ github.event.ref }}, pr = ${{ github.event.pull_request.id }}"
+  # Cancel previous builds in the same concurrency group even if they are in process
+  # for pull requests or pushes to forks (not the upstream repository).
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository != 'Blazebit/blaze-persistence' }}
 jobs:
   build:
     name: Test
@@ -13,7 +21,7 @@ jobs:
       matrix:
         include:
 ################################################
-# hibernate-5.2
+# hibernate-5.6
 ################################################
           - rdbms: h2
             provider: hibernate-5.6
@@ -583,21 +591,21 @@ jobs:
 ################################################
           - rdbms: h2
             provider: hibernate-5.6
-            jdk: 20
+            jdk: 21
           - rdbms: h2
             provider: hibernate-5.6
-            jdk: 20
-            build-jdk: 20
+            jdk: 21
+            build-jdk: 21
 ################################################
 # Early access JDKs
 ################################################
 #          - rdbms: h2
 #            provider: hibernate-5.6
-#            jdk: 21-ea
+#            jdk: 22-ea
 #          - rdbms: h2
 #            provider: hibernate-5.6
-#            jdk: 21-ea
-#            build-jdk: 21-ea
+#            jdk: 22-ea
+#            build-jdk: 22-ea
     steps:
       - uses: actions/checkout@v2
       - name: Update /etc/hosts file
@@ -617,13 +625,13 @@ jobs:
           targets: JDK8_HOME;JAVA_HOME
       - name: Set up Requested JDK
         uses: actions/setup-java@v3
-        if: ${{ matrix.jdk != 8 && !endsWith(matrix.jdk, '-ea') }}
+        if: ${{ matrix.jdk != 8 && !endsWith(matrix.jdk, '-ea') && matrix.jdk != '21' }}
         with:
           java-version: ${{ matrix.jdk }}
           distribution: 'temurin'
       - name: Set up EA JDK
         uses: actions/setup-java@v3
-        if: ${{ matrix.jdk != 8 && endsWith(matrix.jdk, '-ea') }}
+        if: ${{ matrix.jdk != 8 && (endsWith(matrix.jdk, '-ea') || matrix.jdk == '21') }}
         with:
           java-version: ${{ matrix.jdk }}
           distribution: 'zulu'

--- a/build.sh
+++ b/build.sh
@@ -29,7 +29,7 @@ if [[ "$BUILD_JDK" != "" ]]; then
     export BUILD_JDK=${BUILD_JDK::-3}
   fi
   PROPERTIES="$PROPERTIES -Dmain.java.version=$BUILD_JDK -Dtest.java.version=$BUILD_JDK -Djdk8.home=$JDK8_HOME"
-  if [[ "$BUILD_JDK" == "20" ]] || [[ "$BUILD_JDK" == "21" ]]; then
+  if [[ "$BUILD_JDK" == "21" ]] || [[ "$BUILD_JDK" == "22" ]]; then
     # Until Deltaspike releases a version with ASM 9.5, we have to exclude these parts from the build
     PROPERTIES="-pl !integration/deltaspike-data/testsuite $PROPERTIES"
 #    PROPERTIES="-pl !integration/deltaspike-data/testsuite,!examples/deltaspike-data-rest,!integration/quarkus/deployment,!integration/quarkus/runtime,!examples/quarkus/testsuite/base,!examples/quarkus/base $PROPERTIES"
@@ -47,6 +47,10 @@ fi
 if [[ "$JDK" != "" ]]; then
   if [[ "$JDK" == *-ea ]]; then
     export JDK=${JDK::-3}
+  fi
+  if [[ "$JDK" == "21" ]] || [[ "$JDK" == "22" ]]; then
+    # As of JDK 21 Javac produces parameter attributes with a null name that old BND versions can't read
+    PROPERTIES="$PROPERTIES -Dversion.bnd=7.0.0-SNAPSHOT"
   fi
   PROPERTIES="$PROPERTIES -Djdk8.home=$JDK8_HOME"
 fi

--- a/core/api-jakarta/pom.xml
+++ b/core/api-jakarta/pom.xml
@@ -60,7 +60,7 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${com.blazebit:blaze-persistence-core-api:jar}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}.jar" />
@@ -87,7 +87,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-core-api:jar}" regexp="\.jar$" replace="-sources.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-sources.jar" />
@@ -114,7 +114,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-core-api:jar}" regexp="\.jar$" replace="-javadoc.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-javadoc.jar" />
@@ -161,7 +161,7 @@
                     <dependency>
                         <groupId>org.eclipse.transformer</groupId>
                         <artifactId>org.eclipse.transformer.cli</artifactId>
-                        <version>0.2.0</version>
+                        <version>0.5.0</version>
                     </dependency>
                     <dependency>
                         <groupId>ant-contrib</groupId>
@@ -173,6 +173,12 @@
                                 <artifactId>ant</artifactId>
                             </exclusion>
                         </exclusions>
+                    </dependency>
+                    <dependency>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>biz.aQute.bnd.transform</artifactId>
+                        <version>${version.bnd}</version>
+                        <scope>compile</scope>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/core/impl-jakarta/pom.xml
+++ b/core/impl-jakarta/pom.xml
@@ -72,7 +72,7 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${com.blazebit:blaze-persistence-core-impl:jar}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}.jar" />
@@ -99,7 +99,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-core-impl:jar}" regexp="\.jar$" replace="-sources.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-sources.jar" />
@@ -126,7 +126,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-core-impl:jar}" regexp="\.jar$" replace="-javadoc.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-javadoc.jar" />
@@ -160,7 +160,7 @@
                     <dependency>
                         <groupId>org.eclipse.transformer</groupId>
                         <artifactId>org.eclipse.transformer.cli</artifactId>
-                        <version>0.2.0</version>
+                        <version>0.5.0</version>
                     </dependency>
                     <dependency>
                         <groupId>ant-contrib</groupId>
@@ -172,6 +172,12 @@
                                 <artifactId>ant</artifactId>
                             </exclusion>
                         </exclusions>
+                    </dependency>
+                    <dependency>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>biz.aQute.bnd.transform</artifactId>
+                        <version>${version.bnd}</version>
+                        <scope>compile</scope>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/core/parser-jakarta/pom.xml
+++ b/core/parser-jakarta/pom.xml
@@ -64,7 +64,7 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${com.blazebit:blaze-persistence-core-parser:jar}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}.jar" />
@@ -91,7 +91,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-core-parser:jar}" regexp="\.jar$" replace="-sources.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-sources.jar" />
@@ -118,7 +118,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-core-parser:jar}" regexp="\.jar$" replace="-javadoc.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-javadoc.jar" />
@@ -152,7 +152,7 @@
                     <dependency>
                         <groupId>org.eclipse.transformer</groupId>
                         <artifactId>org.eclipse.transformer.cli</artifactId>
-                        <version>0.2.0</version>
+                        <version>0.5.0</version>
                     </dependency>
                     <dependency>
                         <groupId>ant-contrib</groupId>
@@ -164,6 +164,12 @@
                                 <artifactId>ant</artifactId>
                             </exclusion>
                         </exclusions>
+                    </dependency>
+                    <dependency>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>biz.aQute.bnd.transform</artifactId>
+                        <version>${version.bnd}</version>
+                        <scope>compile</scope>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/core/testsuite-jakarta/pom.xml
+++ b/core/testsuite-jakarta/pom.xml
@@ -86,7 +86,7 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${com.blazebit:blaze-persistence-core-testsuite:jar}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}.jar" />
@@ -113,7 +113,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-core-testsuite:jar}" regexp="\.jar$" replace="-sources.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-sources.jar" />
@@ -140,7 +140,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-core-testsuite:jar}" regexp="\.jar$" replace="-javadoc.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-javadoc.jar" />
@@ -167,7 +167,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-core-testsuite:jar}" regexp="\.jar$" replace="-tests.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-tests.jar" />
@@ -188,7 +188,7 @@
                     <dependency>
                         <groupId>org.eclipse.transformer</groupId>
                         <artifactId>org.eclipse.transformer.cli</artifactId>
-                        <version>0.2.0</version>
+                        <version>0.5.0</version>
                     </dependency>
                     <dependency>
                         <groupId>ant-contrib</groupId>
@@ -200,6 +200,12 @@
                                 <artifactId>ant</artifactId>
                             </exclusion>
                         </exclusions>
+                    </dependency>
+                    <dependency>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>biz.aQute.bnd.transform</artifactId>
+                        <version>${version.bnd}</version>
+                        <scope>compile</scope>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/entity-view/api-jakarta/pom.xml
+++ b/entity-view/api-jakarta/pom.xml
@@ -64,7 +64,7 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${com.blazebit:blaze-persistence-entity-view-api:jar}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}.jar" />
@@ -91,7 +91,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-entity-view-api:jar}" regexp="\.jar$" replace="-sources.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-sources.jar" />
@@ -118,7 +118,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-entity-view-api:jar}" regexp="\.jar$" replace="-javadoc.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-javadoc.jar" />
@@ -152,7 +152,7 @@
                     <dependency>
                         <groupId>org.eclipse.transformer</groupId>
                         <artifactId>org.eclipse.transformer.cli</artifactId>
-                        <version>0.2.0</version>
+                        <version>0.5.0</version>
                     </dependency>
                     <dependency>
                         <groupId>ant-contrib</groupId>
@@ -164,6 +164,12 @@
                                 <artifactId>ant</artifactId>
                             </exclusion>
                         </exclusions>
+                    </dependency>
+                    <dependency>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>biz.aQute.bnd.transform</artifactId>
+                        <version>${version.bnd}</version>
+                        <scope>compile</scope>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/entity-view/impl-jakarta/pom.xml
+++ b/entity-view/impl-jakarta/pom.xml
@@ -82,7 +82,7 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${com.blazebit:blaze-persistence-entity-view-impl:jar}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}.jar" />
@@ -109,7 +109,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-entity-view-impl:jar}" regexp="\.jar$" replace="-sources.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-sources.jar" />
@@ -136,7 +136,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-entity-view-impl:jar}" regexp="\.jar$" replace="-javadoc.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-javadoc.jar" />
@@ -170,7 +170,7 @@
                     <dependency>
                         <groupId>org.eclipse.transformer</groupId>
                         <artifactId>org.eclipse.transformer.cli</artifactId>
-                        <version>0.2.0</version>
+                        <version>0.5.0</version>
                     </dependency>
                     <dependency>
                         <groupId>ant-contrib</groupId>
@@ -182,6 +182,12 @@
                                 <artifactId>ant</artifactId>
                             </exclusion>
                         </exclusions>
+                    </dependency>
+                    <dependency>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>biz.aQute.bnd.transform</artifactId>
+                        <version>${version.bnd}</version>
+                        <scope>compile</scope>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/entity-view/processor-jakarta/pom.xml
+++ b/entity-view/processor-jakarta/pom.xml
@@ -60,7 +60,7 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${com.blazebit:blaze-persistence-entity-view-processor:jar}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}.jar" />
@@ -87,7 +87,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-entity-view-processor:jar}" regexp="\.jar$" replace="-sources.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-sources.jar" />
@@ -114,7 +114,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-entity-view-processor:jar}" regexp="\.jar$" replace="-javadoc.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-javadoc.jar" />
@@ -148,7 +148,7 @@
                     <dependency>
                         <groupId>org.eclipse.transformer</groupId>
                         <artifactId>org.eclipse.transformer.cli</artifactId>
-                        <version>0.2.0</version>
+                        <version>0.5.0</version>
                     </dependency>
                     <dependency>
                         <groupId>ant-contrib</groupId>
@@ -160,6 +160,12 @@
                                 <artifactId>ant</artifactId>
                             </exclusion>
                         </exclusions>
+                    </dependency>
+                    <dependency>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>biz.aQute.bnd.transform</artifactId>
+                        <version>${version.bnd}</version>
+                        <scope>compile</scope>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/entity-view/testsuite-jakarta/pom.xml
+++ b/entity-view/testsuite-jakarta/pom.xml
@@ -86,7 +86,7 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${com.blazebit:blaze-persistence-entity-view-testsuite:jar}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}.jar" />
@@ -113,7 +113,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-entity-view-testsuite:jar}" regexp="\.jar$" replace="-sources.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-sources.jar" />
@@ -140,7 +140,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-entity-view-testsuite:jar}" regexp="\.jar$" replace="-javadoc.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-javadoc.jar" />
@@ -167,7 +167,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-entity-view-testsuite:jar}" regexp="\.jar$" replace="-tests.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-tests.jar" />
@@ -188,7 +188,7 @@
                     <dependency>
                         <groupId>org.eclipse.transformer</groupId>
                         <artifactId>org.eclipse.transformer.cli</artifactId>
-                        <version>0.2.0</version>
+                        <version>0.5.0</version>
                     </dependency>
                     <dependency>
                         <groupId>ant-contrib</groupId>
@@ -200,6 +200,12 @@
                                 <artifactId>ant</artifactId>
                             </exclusion>
                         </exclusions>
+                    </dependency>
+                    <dependency>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>biz.aQute.bnd.transform</artifactId>
+                        <version>${version.bnd}</version>
+                        <scope>compile</scope>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/integration/entity-view-cdi-jakarta/pom.xml
+++ b/integration/entity-view-cdi-jakarta/pom.xml
@@ -73,7 +73,7 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${com.blazebit:blaze-persistence-integration-entity-view-cdi:jar}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}.jar" />
@@ -100,7 +100,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-integration-entity-view-cdi:jar}" regexp="\.jar$" replace="-sources.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-sources.jar" />
@@ -127,7 +127,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-integration-entity-view-cdi:jar}" regexp="\.jar$" replace="-javadoc.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-javadoc.jar" />
@@ -148,7 +148,7 @@
                     <dependency>
                         <groupId>org.eclipse.transformer</groupId>
                         <artifactId>org.eclipse.transformer.cli</artifactId>
-                        <version>0.2.0</version>
+                        <version>0.5.0</version>
                     </dependency>
                     <dependency>
                         <groupId>ant-contrib</groupId>
@@ -160,6 +160,12 @@
                                 <artifactId>ant</artifactId>
                             </exclusion>
                         </exclusions>
+                    </dependency>
+                    <dependency>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>biz.aQute.bnd.transform</artifactId>
+                        <version>${version.bnd}</version>
+                        <scope>compile</scope>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/integration/graphql-jakarta/pom.xml
+++ b/integration/graphql-jakarta/pom.xml
@@ -82,7 +82,7 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${com.blazebit:blaze-persistence-integration-graphql:jar}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}.jar" />
@@ -109,7 +109,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-integration-graphql:jar}" regexp="\.jar$" replace="-sources.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-sources.jar" />
@@ -136,7 +136,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-integration-graphql:jar}" regexp="\.jar$" replace="-javadoc.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-javadoc.jar" />
@@ -157,7 +157,7 @@
                     <dependency>
                         <groupId>org.eclipse.transformer</groupId>
                         <artifactId>org.eclipse.transformer.cli</artifactId>
-                        <version>0.2.0</version>
+                        <version>0.5.0</version>
                     </dependency>
                     <dependency>
                         <groupId>ant-contrib</groupId>
@@ -169,6 +169,12 @@
                                 <artifactId>ant</artifactId>
                             </exclusion>
                         </exclusions>
+                    </dependency>
+                    <dependency>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>biz.aQute.bnd.transform</artifactId>
+                        <version>${version.bnd}</version>
+                        <scope>compile</scope>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/integration/graphql-spqr-jakarta/pom.xml
+++ b/integration/graphql-spqr-jakarta/pom.xml
@@ -72,7 +72,7 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${com.blazebit:blaze-persistence-integration-graphql-spqr:jar}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}.jar" />
@@ -99,7 +99,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-integration-graphql-spqr:jar}" regexp="\.jar$" replace="-sources.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-sources.jar" />
@@ -126,7 +126,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-integration-graphql-spqr:jar}" regexp="\.jar$" replace="-javadoc.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-javadoc.jar" />
@@ -147,7 +147,7 @@
                     <dependency>
                         <groupId>org.eclipse.transformer</groupId>
                         <artifactId>org.eclipse.transformer.cli</artifactId>
-                        <version>0.2.0</version>
+                        <version>0.5.0</version>
                     </dependency>
                     <dependency>
                         <groupId>ant-contrib</groupId>
@@ -159,6 +159,12 @@
                                 <artifactId>ant</artifactId>
                             </exclusion>
                         </exclusions>
+                    </dependency>
+                    <dependency>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>biz.aQute.bnd.transform</artifactId>
+                        <version>${version.bnd}</version>
+                        <scope>compile</scope>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/integration/hibernate-5.5-jakarta/pom.xml
+++ b/integration/hibernate-5.5-jakarta/pom.xml
@@ -65,7 +65,7 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${com.blazebit:blaze-persistence-integration-hibernate-5.5:jar}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}.jar" />
@@ -92,7 +92,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-integration-hibernate-5.5:jar}" regexp="\.jar$" replace="-sources.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-sources.jar" />
@@ -119,7 +119,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-integration-hibernate-5.5:jar}" regexp="\.jar$" replace="-javadoc.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-javadoc.jar" />
@@ -140,7 +140,7 @@
                     <dependency>
                         <groupId>org.eclipse.transformer</groupId>
                         <artifactId>org.eclipse.transformer.cli</artifactId>
-                        <version>0.2.0</version>
+                        <version>0.5.0</version>
                     </dependency>
                     <dependency>
                         <groupId>ant-contrib</groupId>
@@ -152,6 +152,12 @@
                                 <artifactId>ant</artifactId>
                             </exclusion>
                         </exclusions>
+                    </dependency>
+                    <dependency>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>biz.aQute.bnd.transform</artifactId>
+                        <version>${version.bnd}</version>
+                        <scope>compile</scope>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/integration/hibernate-5.6-jakarta/pom.xml
+++ b/integration/hibernate-5.6-jakarta/pom.xml
@@ -69,7 +69,7 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${com.blazebit:blaze-persistence-integration-hibernate-5.6:jar}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}.jar" />
@@ -96,7 +96,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-integration-hibernate-5.6:jar}" regexp="\.jar$" replace="-sources.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-sources.jar" />
@@ -123,7 +123,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-integration-hibernate-5.6:jar}" regexp="\.jar$" replace="-javadoc.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-javadoc.jar" />
@@ -144,7 +144,7 @@
                     <dependency>
                         <groupId>org.eclipse.transformer</groupId>
                         <artifactId>org.eclipse.transformer.cli</artifactId>
-                        <version>0.2.0</version>
+                        <version>0.5.0</version>
                     </dependency>
                     <dependency>
                         <groupId>ant-contrib</groupId>
@@ -156,6 +156,12 @@
                                 <artifactId>ant</artifactId>
                             </exclusion>
                         </exclusions>
+                    </dependency>
+                    <dependency>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>biz.aQute.bnd.transform</artifactId>
+                        <version>${version.bnd}</version>
+                        <scope>compile</scope>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/integration/hibernate-base-jakarta/pom.xml
+++ b/integration/hibernate-base-jakarta/pom.xml
@@ -78,7 +78,7 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${com.blazebit:blaze-persistence-integration-hibernate-base:jar}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}.jar" />
@@ -105,7 +105,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-integration-hibernate-base:jar}" regexp="\.jar$" replace="-sources.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-sources.jar" />
@@ -132,7 +132,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-integration-hibernate-base:jar}" regexp="\.jar$" replace="-javadoc.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-javadoc.jar" />
@@ -153,7 +153,7 @@
                     <dependency>
                         <groupId>org.eclipse.transformer</groupId>
                         <artifactId>org.eclipse.transformer.cli</artifactId>
-                        <version>0.2.0</version>
+                        <version>0.5.0</version>
                     </dependency>
                     <dependency>
                         <groupId>ant-contrib</groupId>
@@ -165,6 +165,12 @@
                                 <artifactId>ant</artifactId>
                             </exclusion>
                         </exclusions>
+                    </dependency>
+                    <dependency>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>biz.aQute.bnd.transform</artifactId>
+                        <version>${version.bnd}</version>
+                        <scope>compile</scope>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/integration/jackson-jakarta/pom.xml
+++ b/integration/jackson-jakarta/pom.xml
@@ -68,7 +68,7 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${com.blazebit:blaze-persistence-integration-jackson:jar}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}.jar" />
@@ -95,7 +95,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-integration-jackson:jar}" regexp="\.jar$" replace="-sources.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-sources.jar" />
@@ -122,7 +122,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-integration-jackson:jar}" regexp="\.jar$" replace="-javadoc.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-javadoc.jar" />
@@ -156,7 +156,7 @@
                     <dependency>
                         <groupId>org.eclipse.transformer</groupId>
                         <artifactId>org.eclipse.transformer.cli</artifactId>
-                        <version>0.2.0</version>
+                        <version>0.5.0</version>
                     </dependency>
                     <dependency>
                         <groupId>ant-contrib</groupId>
@@ -168,6 +168,12 @@
                                 <artifactId>ant</artifactId>
                             </exclusion>
                         </exclusions>
+                    </dependency>
+                    <dependency>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>biz.aQute.bnd.transform</artifactId>
+                        <version>${version.bnd}</version>
+                        <scope>compile</scope>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/integration/jaxrs-jackson-jakarta/pom.xml
+++ b/integration/jaxrs-jackson-jakarta/pom.xml
@@ -76,7 +76,7 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${com.blazebit:blaze-persistence-integration-jaxrs-jackson:jar}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}.jar" />
@@ -103,7 +103,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-integration-jaxrs-jackson:jar}" regexp="\.jar$" replace="-sources.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-sources.jar" />
@@ -130,7 +130,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-integration-jaxrs-jackson:jar}" regexp="\.jar$" replace="-javadoc.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-javadoc.jar" />
@@ -164,7 +164,7 @@
                     <dependency>
                         <groupId>org.eclipse.transformer</groupId>
                         <artifactId>org.eclipse.transformer.cli</artifactId>
-                        <version>0.2.0</version>
+                        <version>0.5.0</version>
                     </dependency>
                     <dependency>
                         <groupId>ant-contrib</groupId>
@@ -176,6 +176,12 @@
                                 <artifactId>ant</artifactId>
                             </exclusion>
                         </exclusions>
+                    </dependency>
+                    <dependency>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>biz.aQute.bnd.transform</artifactId>
+                        <version>${version.bnd}</version>
+                        <scope>compile</scope>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/integration/jaxrs-jsonb-jakarta/pom.xml
+++ b/integration/jaxrs-jsonb-jakarta/pom.xml
@@ -72,7 +72,7 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${com.blazebit:blaze-persistence-integration-jaxrs-jsonb:jar}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}.jar" />
@@ -99,7 +99,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-integration-jaxrs-jsonb:jar}" regexp="\.jar$" replace="-sources.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-sources.jar" />
@@ -126,7 +126,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-integration-jaxrs-jsonb:jar}" regexp="\.jar$" replace="-javadoc.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-javadoc.jar" />
@@ -147,7 +147,7 @@
                     <dependency>
                         <groupId>org.eclipse.transformer</groupId>
                         <artifactId>org.eclipse.transformer.cli</artifactId>
-                        <version>0.2.0</version>
+                        <version>0.5.0</version>
                     </dependency>
                     <dependency>
                         <groupId>ant-contrib</groupId>
@@ -159,6 +159,12 @@
                                 <artifactId>ant</artifactId>
                             </exclusion>
                         </exclusions>
+                    </dependency>
+                    <dependency>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>biz.aQute.bnd.transform</artifactId>
+                        <version>${version.bnd}</version>
+                        <scope>compile</scope>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/integration/jpa-base-jakarta/pom.xml
+++ b/integration/jpa-base-jakarta/pom.xml
@@ -74,7 +74,7 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${com.blazebit:blaze-persistence-integration-jpa-base:jar}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}.jar" />
@@ -101,7 +101,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-integration-jpa-base:jar}" regexp="\.jar$" replace="-sources.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-sources.jar" />
@@ -128,7 +128,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-integration-jpa-base:jar}" regexp="\.jar$" replace="-javadoc.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-javadoc.jar" />
@@ -175,7 +175,7 @@
                     <dependency>
                         <groupId>org.eclipse.transformer</groupId>
                         <artifactId>org.eclipse.transformer.cli</artifactId>
-                        <version>0.2.0</version>
+                        <version>0.5.0</version>
                     </dependency>
                     <dependency>
                         <groupId>ant-contrib</groupId>
@@ -187,6 +187,12 @@
                                 <artifactId>ant</artifactId>
                             </exclusion>
                         </exclusions>
+                    </dependency>
+                    <dependency>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>biz.aQute.bnd.transform</artifactId>
+                        <version>${version.bnd}</version>
+                        <scope>compile</scope>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/integration/jsonb-jakarta/pom.xml
+++ b/integration/jsonb-jakarta/pom.xml
@@ -68,7 +68,7 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${com.blazebit:blaze-persistence-integration-jsonb:jar}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}.jar" />
@@ -95,7 +95,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-integration-jsonb:jar}" regexp="\.jar$" replace="-sources.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-sources.jar" />
@@ -122,7 +122,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-integration-jsonb:jar}" regexp="\.jar$" replace="-javadoc.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-javadoc.jar" />
@@ -143,7 +143,7 @@
                     <dependency>
                         <groupId>org.eclipse.transformer</groupId>
                         <artifactId>org.eclipse.transformer.cli</artifactId>
-                        <version>0.2.0</version>
+                        <version>0.5.0</version>
                     </dependency>
                     <dependency>
                         <groupId>ant-contrib</groupId>
@@ -155,6 +155,12 @@
                                 <artifactId>ant</artifactId>
                             </exclusion>
                         </exclusions>
+                    </dependency>
+                    <dependency>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>biz.aQute.bnd.transform</artifactId>
+                        <version>${version.bnd}</version>
+                        <scope>compile</scope>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/integration/querydsl/expressions-jakarta/pom.xml
+++ b/integration/querydsl/expressions-jakarta/pom.xml
@@ -80,7 +80,7 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${com.blazebit:blaze-persistence-integration-querydsl-expressions:jar}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}.jar" />
@@ -107,7 +107,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-integration-querydsl-expressions:jar}" regexp="\.jar$" replace="-sources.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-sources.jar" />
@@ -134,7 +134,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-integration-querydsl-expressions:jar}" regexp="\.jar$" replace="-javadoc.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-javadoc.jar" />
@@ -155,7 +155,7 @@
                     <dependency>
                         <groupId>org.eclipse.transformer</groupId>
                         <artifactId>org.eclipse.transformer.cli</artifactId>
-                        <version>0.2.0</version>
+                        <version>0.5.0</version>
                     </dependency>
                     <dependency>
                         <groupId>ant-contrib</groupId>
@@ -167,6 +167,12 @@
                                 <artifactId>ant</artifactId>
                             </exclusion>
                         </exclusions>
+                    </dependency>
+                    <dependency>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>biz.aQute.bnd.transform</artifactId>
+                        <version>${version.bnd}</version>
+                        <scope>compile</scope>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/integration/spring-data/base-3.1/pom.xml
+++ b/integration/spring-data/base-3.1/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>jakarta.persistence</groupId>
             <artifactId>jakarta.persistence-api</artifactId>
-            <version>${version.jakarta-jpa-api}</version>
+            <version>${version.jakarta-jpa-3.1-api}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/integration/spring-data/testsuite/webflux-jakarta/pom.xml
+++ b/integration/spring-data/testsuite/webflux-jakarta/pom.xml
@@ -51,7 +51,7 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${com.blazebit:blaze-persistence-integration-spring-data-testsuite-webflux:jar}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}.jar" />
@@ -78,7 +78,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-integration-spring-data-testsuite-webflux:jar}" regexp="\.jar$" replace="-sources.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-sources.jar" />
@@ -105,7 +105,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-integration-spring-data-testsuite-webflux:jar}" regexp="\.jar$" replace="-javadoc.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-javadoc.jar" />
@@ -132,7 +132,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-integration-spring-data-testsuite-webflux:jar}" regexp="\.jar$" replace="-tests.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-tests.jar" />
@@ -153,7 +153,7 @@
                     <dependency>
                         <groupId>org.eclipse.transformer</groupId>
                         <artifactId>org.eclipse.transformer.cli</artifactId>
-                        <version>0.2.0</version>
+                        <version>0.5.0</version>
                     </dependency>
                     <dependency>
                         <groupId>ant-contrib</groupId>
@@ -165,6 +165,12 @@
                                 <artifactId>ant</artifactId>
                             </exclusion>
                         </exclusions>
+                    </dependency>
+                    <dependency>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>biz.aQute.bnd.transform</artifactId>
+                        <version>${version.bnd}</version>
+                        <scope>compile</scope>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/integration/spring-data/testsuite/webmvc-jakarta/pom.xml
+++ b/integration/spring-data/testsuite/webmvc-jakarta/pom.xml
@@ -51,7 +51,7 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${com.blazebit:blaze-persistence-integration-spring-data-testsuite-webmvc:jar}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}.jar" />
@@ -78,7 +78,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-integration-spring-data-testsuite-webmvc:jar}" regexp="\.jar$" replace="-sources.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-sources.jar" />
@@ -105,7 +105,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-integration-spring-data-testsuite-webmvc:jar}" regexp="\.jar$" replace="-javadoc.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-javadoc.jar" />
@@ -132,7 +132,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-integration-spring-data-testsuite-webmvc:jar}" regexp="\.jar$" replace="-tests.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-tests.jar" />
@@ -153,7 +153,7 @@
                     <dependency>
                         <groupId>org.eclipse.transformer</groupId>
                         <artifactId>org.eclipse.transformer.cli</artifactId>
-                        <version>0.2.0</version>
+                        <version>0.5.0</version>
                     </dependency>
                     <dependency>
                         <groupId>ant-contrib</groupId>
@@ -165,6 +165,12 @@
                                 <artifactId>ant</artifactId>
                             </exclusion>
                         </exclusions>
+                    </dependency>
+                    <dependency>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>biz.aQute.bnd.transform</artifactId>
+                        <version>${version.bnd}</version>
+                        <scope>compile</scope>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/jpa-criteria/api-jakarta/pom.xml
+++ b/jpa-criteria/api-jakarta/pom.xml
@@ -64,7 +64,7 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${com.blazebit:blaze-persistence-jpa-criteria-api:jar}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}.jar" />
@@ -91,7 +91,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-jpa-criteria-api:jar}" regexp="\.jar$" replace="-sources.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-sources.jar" />
@@ -118,7 +118,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-jpa-criteria-api:jar}" regexp="\.jar$" replace="-javadoc.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-javadoc.jar" />
@@ -139,7 +139,7 @@
                     <dependency>
                         <groupId>org.eclipse.transformer</groupId>
                         <artifactId>org.eclipse.transformer.cli</artifactId>
-                        <version>0.2.0</version>
+                        <version>0.5.0</version>
                     </dependency>
                     <dependency>
                         <groupId>ant-contrib</groupId>
@@ -151,6 +151,12 @@
                                 <artifactId>ant</artifactId>
                             </exclusion>
                         </exclusions>
+                    </dependency>
+                    <dependency>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>biz.aQute.bnd.transform</artifactId>
+                        <version>${version.bnd}</version>
+                        <scope>compile</scope>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/jpa-criteria/impl-jakarta/pom.xml
+++ b/jpa-criteria/impl-jakarta/pom.xml
@@ -72,7 +72,7 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${com.blazebit:blaze-persistence-jpa-criteria-impl:jar}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}.jar" />
@@ -99,7 +99,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-jpa-criteria-impl:jar}" regexp="\.jar$" replace="-sources.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-sources.jar" />
@@ -126,7 +126,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-jpa-criteria-impl:jar}" regexp="\.jar$" replace="-javadoc.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-javadoc.jar" />
@@ -147,7 +147,7 @@
                     <dependency>
                         <groupId>org.eclipse.transformer</groupId>
                         <artifactId>org.eclipse.transformer.cli</artifactId>
-                        <version>0.2.0</version>
+                        <version>0.5.0</version>
                     </dependency>
                     <dependency>
                         <groupId>ant-contrib</groupId>
@@ -159,6 +159,12 @@
                                 <artifactId>ant</artifactId>
                             </exclusion>
                         </exclusions>
+                    </dependency>
+                    <dependency>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>biz.aQute.bnd.transform</artifactId>
+                        <version>${version.bnd}</version>
+                        <scope>compile</scope>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/jpa-criteria/testsuite-jakarta/pom.xml
+++ b/jpa-criteria/testsuite-jakarta/pom.xml
@@ -86,7 +86,7 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${com.blazebit:blaze-persistence-jpa-criteria-testsuite:jar}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}.jar" />
@@ -113,7 +113,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-jpa-criteria-testsuite:jar}" regexp="\.jar$" replace="-sources.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-sources.jar" />
@@ -140,7 +140,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-jpa-criteria-testsuite:jar}" regexp="\.jar$" replace="-javadoc.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-javadoc.jar" />
@@ -167,7 +167,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-jpa-criteria-testsuite:jar}" regexp="\.jar$" replace="-tests.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-tests.jar" />
@@ -188,7 +188,7 @@
                     <dependency>
                         <groupId>org.eclipse.transformer</groupId>
                         <artifactId>org.eclipse.transformer.cli</artifactId>
-                        <version>0.2.0</version>
+                        <version>0.5.0</version>
                     </dependency>
                     <dependency>
                         <groupId>ant-contrib</groupId>
@@ -200,6 +200,12 @@
                                 <artifactId>ant</artifactId>
                             </exclusion>
                         </exclusions>
+                    </dependency>
+                    <dependency>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>biz.aQute.bnd.transform</artifactId>
+                        <version>${version.bnd}</version>
+                        <scope>compile</scope>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -146,7 +146,7 @@
         <version.antrun.plugin>3.1.0</version.antrun.plugin>
         <version.checkstyle.plugin>3.3.0</version.checkstyle.plugin>
         <version.compiler.plugin>3.11.0</version.compiler.plugin>
-        <version.jandex.plugin>3.1.1</version.jandex.plugin>
+        <version.jandex.plugin>3.1.2</version.jandex.plugin>
         <version.processor.plugin>3.3.2</version.processor.plugin>
         <version.exec.plugin>1.6.0</version.exec.plugin>
         <version.injection.plugin>1.0.2</version.injection.plugin>
@@ -156,6 +156,8 @@
         <version.surefire.plugin>3.1.0</version.surefire.plugin>
         <version.failsafe.plugin>3.1.0</version.failsafe.plugin>
         <asmVersion>9.5</asmVersion>
+        <version.bnd>6.4.1</version.bnd>
+<!--        <version.bnd>7.0.0-SNAPSHOT</version.bnd>-->
 
         <h2.version>1.4.200</h2.version>
         <mssql.version>7.2.2.jre8</mssql.version>
@@ -167,6 +169,16 @@
         <!-- Hibernate user types used for testing -->
         <version.hibernate-types>2.12.1</version.hibernate-types>
     </properties>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>bnd-snapshots</id>
+            <url>https://bndtools.jfrog.io/bndtools/libs-snapshot/</url>
+            <layout>default</layout>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </pluginRepository>
+    </pluginRepositories>
 
     <dependencyManagement>
         <dependencies>

--- a/testsuite-base/hibernate-jakarta/pom.xml
+++ b/testsuite-base/hibernate-jakarta/pom.xml
@@ -68,7 +68,7 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${com.blazebit:blaze-persistence-testsuite-base-hibernate:jar}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}.jar" />
@@ -95,7 +95,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-testsuite-base-hibernate:jar}" regexp="\.jar$" replace="-sources.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-sources.jar" />
@@ -122,7 +122,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-testsuite-base-hibernate:jar}" regexp="\.jar$" replace="-javadoc.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-javadoc.jar" />
@@ -143,7 +143,7 @@
                     <dependency>
                         <groupId>org.eclipse.transformer</groupId>
                         <artifactId>org.eclipse.transformer.cli</artifactId>
-                        <version>0.2.0</version>
+                        <version>0.5.0</version>
                     </dependency>
                     <dependency>
                         <groupId>ant-contrib</groupId>
@@ -155,6 +155,12 @@
                                 <artifactId>ant</artifactId>
                             </exclusion>
                         </exclusions>
+                    </dependency>
+                    <dependency>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>biz.aQute.bnd.transform</artifactId>
+                        <version>${version.bnd}</version>
+                        <scope>compile</scope>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/testsuite-base/hibernate6/src/main/java/com/blazebit/persistence/testsuite/base/AbstractPersistenceTest.java
+++ b/testsuite-base/hibernate6/src/main/java/com/blazebit/persistence/testsuite/base/AbstractPersistenceTest.java
@@ -113,16 +113,16 @@ public abstract class AbstractPersistenceTest extends AbstractJpaPersistenceTest
 
     @Override
     protected Properties applyProperties(Properties properties) {
-        boolean isMySql = properties.get("javax.persistence.jdbc.url").toString().contains("mysql");
+        boolean isMySql = properties.get("jakarta.persistence.jdbc.url").toString().contains("mysql");
         if (System.getProperty("hibernate.dialect") != null) {
             properties.put("hibernate.dialect", System.getProperty("hibernate.dialect"));
         } else if (isMySql) {
             // Since MySQL has no sequences, the native strategy is needed for batch inserts
             properties.put("hibernate.id.new_generator_mappings", "false");
-        } else if (properties.get("javax.persistence.jdbc.url").toString().contains("h2")) {
+        } else if (properties.get("jakarta.persistence.jdbc.url").toString().contains("h2")) {
             // Hibernate 5 uses sequences by default but h2 seems to have a bug with sequences in a limited query
             properties.put("hibernate.id.new_generator_mappings", "false");
-        } else if (properties.get("javax.persistence.jdbc.url").toString().contains("sqlserver")) {
+        } else if (properties.get("jakarta.persistence.jdbc.url").toString().contains("sqlserver")) {
             // Not sure what is happening, but when the sequence is tried to be fetched, it doesn't exist in SQL Server
             properties.put("hibernate.id.new_generator_mappings", "false");
         }

--- a/testsuite-base/jpa-jakarta/pom.xml
+++ b/testsuite-base/jpa-jakarta/pom.xml
@@ -102,7 +102,7 @@
                         <configuration>
                             <target>
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${com.blazebit:blaze-persistence-testsuite-base-jpa:jar}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}.jar" />
@@ -129,7 +129,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-testsuite-base-jpa:jar}" regexp="\.jar$" replace="-sources.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-sources.jar" />
@@ -156,7 +156,7 @@
                                 <property name="plugin_classpath" refid="maven.plugin.classpath" />
                                 <!--suppress UnresolvedMavenProperty -->
                                 <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-testsuite-base-jpa:jar}" regexp="\.jar$" replace="-javadoc.jar" global="true" />
-                                <java classname="org.eclipse.transformer.jakarta.JakartaTransformer" fork="true">
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
                                     <!--suppress UnresolvedMavenProperty -->
                                     <arg value="${source}" />
                                     <arg value="${project.build.directory}/${project.build.finalName}-javadoc.jar" />
@@ -177,7 +177,7 @@
                     <dependency>
                         <groupId>org.eclipse.transformer</groupId>
                         <artifactId>org.eclipse.transformer.cli</artifactId>
-                        <version>0.2.0</version>
+                        <version>0.5.0</version>
                     </dependency>
                     <dependency>
                         <groupId>ant-contrib</groupId>
@@ -189,6 +189,12 @@
                                 <artifactId>ant</artifactId>
                             </exclusion>
                         </exclusions>
+                    </dependency>
+                    <dependency>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>biz.aQute.bnd.transform</artifactId>
+                        <version>${version.bnd}</version>
+                        <scope>compile</scope>
                     </dependency>
                 </dependencies>
             </plugin>


### PR DESCRIPTION
Uses BND 7.0.0-SNAPSHOT for now when running on JDK 21 due to: https://github.com/bndtools/bnd/issues/5689

Fixes #1799