### PR TITLE
[1756] Remove second call to applyJpaLimit when building lateral query

### DIFF
--- a/core/impl/src/main/java/com/blazebit/persistence/impl/AbstractCommonQueryBuilder.java
+++ b/core/impl/src/main/java/com/blazebit/persistence/impl/AbstractCommonQueryBuilder.java
@@ -3747,7 +3747,6 @@ public abstract class AbstractCommonQueryBuilder<QueryResultType, BuilderType, S
         buildBaseQueryString(sbSelectFrom, false, lateralJoinNode, false);
         if (hasLimit()) {
             if (mainQuery.jpaProvider.supportsSubqueryLimitOffset()) {
-                applyJpaLimit(sbSelectFrom);
                 sbSelectFrom.append(')');
             } else {
                 final boolean hasFirstResult = firstResult != 0;


### PR DESCRIPTION
## Description
Just removed a second call to `applyJpaLimit` which seems to unnecessarily add a second time the "LIMIT x" to the query

## Related Issue
https://github.com/Blazebit/blaze-persistence/issues/1756

## Motivation and Context
This bug makes it impossible to use LIMIT in a lateral query

