### PR TITLE
[#1842] fix incompatibility with Spring 6.1

### DIFF
--- a/integration/entity-view-spring-6.0/src/main/java/com/blazebit/persistence/integration/view/spring/impl/AnnotationEntityViewConfigurationSource.java
+++ b/integration/entity-view-spring-6.0/src/main/java/com/blazebit/persistence/integration/view/spring/impl/AnnotationEntityViewConfigurationSource.java
@@ -55,9 +55,9 @@ public class AnnotationEntityViewConfigurationSource extends AbstractEntityViewC
     public AnnotationEntityViewConfigurationSource(AnnotationMetadata metadata, Class<? extends Annotation> annotation,
                                                    ResourceLoader resourceLoader, Environment environment) {
         super(environment);
-        Assert.notNull(metadata);
-        Assert.notNull(annotation);
-        Assert.notNull(resourceLoader);
+        Assert.notNull(metadata, "metadata must not be null");
+        Assert.notNull(annotation, "annotation must not be null");
+        Assert.notNull(resourceLoader, "resourceLoader must not be null");
 
         this.attributes = new AnnotationAttributes(metadata.getAnnotationAttributes(annotation.getName()));
         this.configMetadata = metadata;


### PR DESCRIPTION
## Description
Fixed `AnnotationEntityViewConfigurationSource.java` to use `Assert.notNull(Object object, String message)` instead of `Assert.notNull(Object object)` which was removed in Spring 6.1.

## Related Issue
#1842 

## Motivation and Context
Projects cannot upgrade to Spring 6.1 (Spring Boot 3.2) unless this is fixed.

