### PR TITLE
Fix spring boot 3.2 compatibility

### DIFF
--- a/integration/entity-view-spring/src/main/java/com/blazebit/persistence/integration/view/spring/impl/AnnotationEntityViewConfigurationSource.java
+++ b/integration/entity-view-spring/src/main/java/com/blazebit/persistence/integration/view/spring/impl/AnnotationEntityViewConfigurationSource.java
@@ -55,9 +55,9 @@ public class AnnotationEntityViewConfigurationSource extends AbstractEntityViewC
     public AnnotationEntityViewConfigurationSource(AnnotationMetadata metadata, Class<? extends Annotation> annotation,
                                                    ResourceLoader resourceLoader, Environment environment) {
         super(environment);
-        Assert.notNull(metadata);
-        Assert.notNull(annotation);
-        Assert.notNull(resourceLoader);
+        Assert.notNull(metadata,() -> "metadata cannot be null");
+        Assert.notNull(annotation,() -> "annotation cannot be null");
+        Assert.notNull(resourceLoader,() -> "resourceLoader cannot be null");
 
         this.attributes = new AnnotationAttributes(metadata.getAnnotationAttributes(annotation.getName()));
         this.configMetadata = metadata;

--- a/integration/entity-view-spring/src/main/java/com/blazebit/persistence/integration/view/spring/impl/AnnotationEntityViewConfigurationSource.java
+++ b/integration/entity-view-spring/src/main/java/com/blazebit/persistence/integration/view/spring/impl/AnnotationEntityViewConfigurationSource.java
@@ -55,9 +55,9 @@ public class AnnotationEntityViewConfigurationSource extends AbstractEntityViewC
     public AnnotationEntityViewConfigurationSource(AnnotationMetadata metadata, Class<? extends Annotation> annotation,
                                                    ResourceLoader resourceLoader, Environment environment) {
         super(environment);
-        Assert.notNull(metadata,() -> "metadata cannot be null");
-        Assert.notNull(annotation,() -> "annotation cannot be null");
-        Assert.notNull(resourceLoader,() -> "resourceLoader cannot be null");
+        Assert.notNull(metadata, "metadata cannot be null");
+        Assert.notNull(annotation, "annotation cannot be null");
+        Assert.notNull(resourceLoader, "resourceLoader cannot be null");
 
         this.attributes = new AnnotationAttributes(metadata.getAnnotationAttributes(annotation.getName()));
         this.configMetadata = metadata;

--- a/integration/entity-view-spring/src/main/java/com/blazebit/persistence/integration/view/spring/impl/EntityViewComponentProvider.java
+++ b/integration/entity-view-spring/src/main/java/com/blazebit/persistence/integration/view/spring/impl/EntityViewComponentProvider.java
@@ -38,7 +38,7 @@ public class EntityViewComponentProvider extends ClassPathScanningCandidateCompo
     public EntityViewComponentProvider(Iterable<? extends TypeFilter> includeFilters) {
         super(false);
 
-        Assert.notNull(includeFilters);
+        Assert.notNull(includeFilters, "includeFilters must not be null!");
 
         if (includeFilters.iterator().hasNext()) {
             for (TypeFilter filter : includeFilters) {

--- a/integration/entity-view-spring/src/main/java/com/blazebit/persistence/integration/view/spring/impl/XmlEntityViewConfigurationSource.java
+++ b/integration/entity-view-spring/src/main/java/com/blazebit/persistence/integration/view/spring/impl/XmlEntityViewConfigurationSource.java
@@ -42,8 +42,8 @@ public class XmlEntityViewConfigurationSource extends AbstractEntityViewConfigur
 
     public XmlEntityViewConfigurationSource(Element element, ParserContext context, Environment environment) {
         super(environment);
-        Assert.notNull(element);
-        Assert.notNull(context);
+        Assert.notNull(element, "element must not be null!");
+        Assert.notNull(context, "context must not be null!");
 
         this.element = element;
         this.context = context;

--- a/integration/spring-data/base/src/main/java/org/springframework/data/jpa/repository/query/FixedJpaQueryCreator.java
+++ b/integration/spring-data/base/src/main/java/org/springframework/data/jpa/repository/query/FixedJpaQueryCreator.java
@@ -150,8 +150,8 @@ public class FixedJpaQueryCreator extends AbstractQueryCreator<CriteriaQuery<Obj
          */
         public PredicateBuilder(Part part, Root<?> root) {
 
-            Assert.notNull(part);
-            Assert.notNull(root);
+            Assert.notNull(part, "part must not be null!");
+            Assert.notNull(root, "root must not be null!");
             this.part = part;
             this.root = root;
         }


### PR DESCRIPTION
From Spring 6.2, `Assert.notNull(Object)` is removed, hence adding supplier message to fix it.

This is stopping users from migrating to 3.2.x version of spring boot
