### PR TITLE
[#1858] Fix EntityViewAwareMappingJackson2HttpMessageConverter to use Spring Boot's ObjectMapper

### DIFF
--- a/integration/spring-data/webmvc-jakarta/src/main/java/com/blazebit/persistence/spring/data/webmvc/impl/BlazePersistenceWebConfiguration.java
+++ b/integration/spring-data/webmvc-jakarta/src/main/java/com/blazebit/persistence/spring/data/webmvc/impl/BlazePersistenceWebConfiguration.java
@@ -48,11 +48,9 @@ public class BlazePersistenceWebConfiguration implements WebMvcConfigurer {
     protected final ObjectMapper objectMapper;
     private final EntityViewManager entityViewManager;
 
-    public BlazePersistenceWebConfiguration(
-      EntityViewManager entityViewManager,
-      @Qualifier("mvcConversionService") ObjectFactory<ConversionService> conversionService,
-      @Autowired(required = false) ObjectMapper objectMapper
-    ) {
+    public BlazePersistenceWebConfiguration(EntityViewManager entityViewManager,
+            @Qualifier("mvcConversionService") ObjectFactory<ConversionService> conversionService,
+            @Autowired(required = false) ObjectMapper objectMapper) {
         this.entityViewManager = entityViewManager;
         this.conversionService = conversionService;
         this.objectMapper = objectMapper == null ? new ObjectMapper() : objectMapper.copy();
@@ -87,7 +85,7 @@ public class BlazePersistenceWebConfiguration implements WebMvcConfigurer {
     @Override
     public void extendMessageConverters(List<HttpMessageConverter<?>> converters) {
         // Add it to the beginning, so it has precedence over the builtin
-        converters.add(0, new EntityViewAwareMappingJackson2HttpMessageConverter(entityViewManager, blazeWebmvcIdAttributeAccessor()));
+        converters.add(0, new EntityViewAwareMappingJackson2HttpMessageConverter(entityViewManager, blazeWebmvcIdAttributeAccessor(), objectMapper()));
     }
 
     @Override

--- a/integration/spring-data/webmvc-jakarta/src/main/java/com/blazebit/persistence/spring/data/webmvc/impl/json/EntityViewAwareMappingJackson2HttpMessageConverter.java
+++ b/integration/spring-data/webmvc-jakarta/src/main/java/com/blazebit/persistence/spring/data/webmvc/impl/json/EntityViewAwareMappingJackson2HttpMessageConverter.java
@@ -20,6 +20,7 @@ import com.blazebit.persistence.integration.jackson.EntityViewAwareObjectMapper;
 import com.blazebit.persistence.integration.jackson.EntityViewIdValueAccessor;
 import com.blazebit.persistence.view.EntityViewManager;
 import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.http.HttpInputMessage;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -38,8 +39,9 @@ public class EntityViewAwareMappingJackson2HttpMessageConverter extends MappingJ
 
     private final EntityViewAwareObjectMapper entityViewAwareObjectMapper;
 
-    public EntityViewAwareMappingJackson2HttpMessageConverter(final EntityViewManager entityViewManager, EntityViewIdValueAccessor entityViewIdValueAccessor) {
-        this.entityViewAwareObjectMapper = new EntityViewAwareObjectMapper(entityViewManager, getObjectMapper(), entityViewIdValueAccessor);
+    public EntityViewAwareMappingJackson2HttpMessageConverter(final EntityViewManager entityViewManager, EntityViewIdValueAccessor entityViewIdValueAccessor, ObjectMapper objectMapper) {
+        super(objectMapper);
+        this.entityViewAwareObjectMapper = new EntityViewAwareObjectMapper(entityViewManager, objectMapper, entityViewIdValueAccessor);
     }
 
     @Override

--- a/integration/spring-data/webmvc/src/main/java/com/blazebit/persistence/spring/data/webmvc/impl/BlazePersistenceWebConfiguration.java
+++ b/integration/spring-data/webmvc/src/main/java/com/blazebit/persistence/spring/data/webmvc/impl/BlazePersistenceWebConfiguration.java
@@ -43,15 +43,14 @@ import java.util.List;
  */
 @Configuration
 public class BlazePersistenceWebConfiguration extends WebMvcConfigurerAdapter {
+
     protected final ObjectFactory<ConversionService> conversionService;
     protected final ObjectMapper objectMapper;
     private final EntityViewManager entityViewManager;
 
-    public BlazePersistenceWebConfiguration(
-      EntityViewManager entityViewManager,
-      @Qualifier("mvcConversionService") ObjectFactory<ConversionService> conversionService,
-      @Autowired(required = false) ObjectMapper objectMapper
-    ) {
+    public BlazePersistenceWebConfiguration(EntityViewManager entityViewManager,
+            @Qualifier("mvcConversionService") ObjectFactory<ConversionService> conversionService,
+            @Autowired(required = false) ObjectMapper objectMapper) {
         this.entityViewManager = entityViewManager;
         this.conversionService = conversionService;
         this.objectMapper = objectMapper == null ? new ObjectMapper() : objectMapper.copy();
@@ -87,7 +86,7 @@ public class BlazePersistenceWebConfiguration extends WebMvcConfigurerAdapter {
     @Override
     public void extendMessageConverters(List<HttpMessageConverter<?>> converters) {
         // Add it to the beginning so it has precedence over the builtin
-        converters.add(0, new EntityViewAwareMappingJackson2HttpMessageConverter(entityViewManager, blazeWebmvcIdAttributeAccessor()));
+        converters.add(0, new EntityViewAwareMappingJackson2HttpMessageConverter(entityViewManager, blazeWebmvcIdAttributeAccessor(), objectMapper()));
     }
 
     @Override

--- a/integration/spring-data/webmvc/src/main/java/com/blazebit/persistence/spring/data/webmvc/impl/json/EntityViewAwareMappingJackson2HttpMessageConverter.java
+++ b/integration/spring-data/webmvc/src/main/java/com/blazebit/persistence/spring/data/webmvc/impl/json/EntityViewAwareMappingJackson2HttpMessageConverter.java
@@ -20,6 +20,7 @@ import com.blazebit.persistence.integration.jackson.EntityViewAwareObjectMapper;
 import com.blazebit.persistence.integration.jackson.EntityViewIdValueAccessor;
 import com.blazebit.persistence.view.EntityViewManager;
 import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.http.HttpInputMessage;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -37,8 +38,9 @@ public class EntityViewAwareMappingJackson2HttpMessageConverter extends MappingJ
 
     private final EntityViewAwareObjectMapper entityViewAwareObjectMapper;
 
-    public EntityViewAwareMappingJackson2HttpMessageConverter(final EntityViewManager entityViewManager, EntityViewIdValueAccessor entityViewIdValueAccessor) {
-        this.entityViewAwareObjectMapper = new EntityViewAwareObjectMapper(entityViewManager, getObjectMapper(), entityViewIdValueAccessor);
+    public EntityViewAwareMappingJackson2HttpMessageConverter(final EntityViewManager entityViewManager, EntityViewIdValueAccessor entityViewIdValueAccessor, ObjectMapper objectMapper) {
+        super(objectMapper);
+        this.entityViewAwareObjectMapper = new EntityViewAwareObjectMapper(entityViewManager, objectMapper, entityViewIdValueAccessor);
     }
 
     @Override


### PR DESCRIPTION
## Description

The `EntityViewAwareMappingJackson2HttpMessageConverter` now uses the `ObjectMapper` provided by the Spring Boot context. This ensures that users' custom configurations are used.

## Related Issue

Fixes #1858

## Motivation and Context

This change allows users to use custom deserializers and other `ObjectMapper` configurations with Blaze Persistence Entity Views.