### PR TITLE
[#1904] LocalDateBasicUserType incorrectly converting to java.sql.Timestamp (Multiset fetching)

### DIFF
--- a/entity-view/impl/src/main/java/com/blazebit/persistence/view/impl/type/LocalDateBasicUserType.java
+++ b/entity-view/impl/src/main/java/com/blazebit/persistence/view/impl/type/LocalDateBasicUserType.java
@@ -18,22 +18,46 @@ package com.blazebit.persistence.view.impl.type;
 
 import com.blazebit.persistence.view.spi.type.BasicUserType;
 
-import java.sql.Timestamp;
 import java.time.LocalDate;
-import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
 
 /**
- *
  * @author Christian Beikov
  * @since 1.5.0
  */
 public class LocalDateBasicUserType extends TimestampishImmutableBasicUserType<LocalDate> {
 
     public static final BasicUserType<LocalDate> INSTANCE = new LocalDateBasicUserType();
+    private static final DateTimeFormatter OPTIONAL_TIME_OFFSET_AND_ZONE_FORMATTER = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .append(DateTimeFormatter.ISO_LOCAL_DATE)
+            .optionalStart()
+            .optionalStart()
+            .appendLiteral(' ')
+            .optionalEnd()
+            .optionalStart()
+            .appendLiteral('T')
+            .optionalEnd()
+            .append(DateTimeFormatter.ISO_LOCAL_TIME)
+            .optionalStart()
+            .appendOffsetId()
+            .optionalEnd()
+            .optionalStart()
+            .appendLiteral('[')
+            .appendZoneRegionId()
+            .appendLiteral(']')
+            .optionalEnd()
+            .optionalEnd().toFormatter();
 
     @Override
     public LocalDate fromString(CharSequence sequence) {
-        return Timestamp.valueOf(sequence.toString()).toInstant().atZone(ZoneOffset.UTC).toLocalDate();
+        String input = sequence.toString();
+        try {
+            return LocalDate.parse(input, OPTIONAL_TIME_OFFSET_AND_ZONE_FORMATTER);
+        } catch (DateTimeParseException e) {
+            throw new IllegalArgumentException("Invalid date or date-time format: " + input, e);
+        }
     }
-
 }

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/collections/entity/simple/DocumentForCollections.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/collections/entity/simple/DocumentForCollections.java
@@ -28,6 +28,7 @@ import javax.persistence.OneToMany;
 import javax.persistence.OrderColumn;
 import javax.persistence.Table;
 import java.io.Serializable;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -48,6 +49,7 @@ public class DocumentForCollections implements Serializable {
 
     private Long id;
     private String name;
+    private LocalDate dateCollected;
     private PersonForCollections owner;
     private Set<PersonForCollections> partners = new HashSet<PersonForCollections>();
     private Map<Integer, PersonForCollections> contacts = new HashMap<Integer, PersonForCollections>();
@@ -117,6 +119,14 @@ public class DocumentForCollections implements Serializable {
 
     public void setPersonList(List<PersonForCollections> personList) {
         this.personList = personList;
+    }
+
+    public LocalDate getDateCollected() {
+        return dateCollected;
+    }
+
+    public void setDateCollected(LocalDate dateCollected) {
+        this.dateCollected = dateCollected;
     }
 
     @Override

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/collections/subview/MultisetFetchCollectionsTest.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/collections/subview/MultisetFetchCollectionsTest.java
@@ -41,6 +41,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import javax.persistence.EntityManager;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -90,6 +91,8 @@ public class MultisetFetchCollectionsTest extends AbstractEntityViewTest {
 
                 doc1.getContacts().put(1, pers1);
                 doc1.getContacts().put(2, pers2);
+
+                doc1.setDateCollected(LocalDate.now());
 
                 em.persist(pers1);
                 em.persist(pers2);

--- a/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/collections/subview/model/SubviewDocumentMultisetFetchView.java
+++ b/entity-view/testsuite/src/test/java/com/blazebit/persistence/view/testsuite/collections/subview/model/SubviewDocumentMultisetFetchView.java
@@ -23,6 +23,7 @@ import com.blazebit.persistence.view.Mapping;
 import com.blazebit.persistence.view.UpdatableEntityView;
 import com.blazebit.persistence.view.testsuite.collections.entity.simple.DocumentForCollections;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -40,6 +41,8 @@ public interface SubviewDocumentMultisetFetchView extends SubviewSimpleDocumentM
     public Long getId();
 
     public String getName();
+
+    public LocalDate getDateCollected();
 
     @Mapping(value = "partners", fetch = FetchStrategy.MULTISET)
     public Set<SubviewPersonForCollectionsMultisetFetchView> getMultisetPartners();


### PR DESCRIPTION
<!--- This template is for code related PRs. Remove it for e.g. documentation PRs. -->

<!--- Prefix the title with the issue number like "[#123] Some title" and try to summarize the changes in the title -->

<!--- Before submitting the PR, please make sure it satisfies the following guidelines -->
<!---  * Tests for issues should have one commit that has the form "Test for #123" where "#123" is the issue number -->
<!---  * Fixes for issues should have one commit that has the form "Fix for #123" where "#123" is the issue number -->
<!---  * Commits for the test and the fix should be separate -->

## Description
- Changed fromString method to convert date/date time strings to a LocalDate instead of to a java.sql.Timestamp first
- Added a LocalDate field to DocumentForCollections entity and the MultiSet fetch view associated with said backing entity
- Updated multiset fetch test case to use the LocalDate to make sure exception is no longer thrown and test passes

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue(s) here: -->
Fixes #1904 


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allows us to safely use a LocalDate in an entity view fetched using the Multiset fetch strategy without having to use a custom BasicUserType to override the behavior.

