### PR TITLE
Fix HibernateJpaProvider

### DIFF
--- a/integration/hibernate6-base/src/main/java/com/blazebit/persistence/integration/hibernate/base/HibernateJpaProvider.java
+++ b/integration/hibernate6-base/src/main/java/com/blazebit/persistence/integration/hibernate/base/HibernateJpaProvider.java
@@ -1260,8 +1260,8 @@ public class HibernateJpaProvider implements JpaProvider {
                 break;
             }
         }
-
-        return componentType.getCascadeStyle(propertyIndex).hasOrphanDelete();
+        int index = componentType.getPropertyIndex(propertyParts[propertyIndex]);
+        return componentType.getCascadeStyle(index).hasOrphanDelete();
     }
 
     @Override


### PR DESCRIPTION

<!--- This template is for code related PRs. Remove it for e.g. documentation PRs. -->

<!--- Prefix the title with the issue number like "[#123] Some title" and try to summarize the changes in the title -->

<!--- Before submitting the PR, please make sure it satisfies the following guidelines -->
<!---  * Tests for issues should have one commit that has the form "Test for #123" where "#123" is the issue number -->
<!---  * Fixes for issues should have one commit that has the form "Fix for #123" where "#123" is the issue number -->
<!---  * Commits for the test and the fix should be separate -->

## Description
Small hotfix for #1886


## Related Issue
https://github.com/Blazebit/blaze-persistence/issues/1886


## Motivation and Context
Currently HibernateJpaProvider throws ArrayIndexOutOfBoundsException for ElementCollection of Embeddables having Embeddable. This small hotfix fixes this issue. Otherwise it doesn't work on quarkus 3+
