### PR TITLE
[#1973] Properly handle unmapped view types in GraphQLEntityViewSupport

### DIFF
--- a/integration/graphql/src/main/java/com/blazebit/persistence/integration/graphql/GraphQLEntityViewSupport.java
+++ b/integration/graphql/src/main/java/com/blazebit/persistence/integration/graphql/GraphQLEntityViewSupport.java
@@ -235,11 +235,11 @@ public class GraphQLEntityViewSupport {
             objectRoot = elementRoot + "/" + pageElementObjectName;
         }
         String typeName = getElementTypeName(dataFetchingEnvironment, objectRoot);
-        Class<?> entityViewClass = typeNameToViewType.get(typeName).getJavaType();
+        ManagedViewType<?> entityViewClass = typeNameToViewType.get(typeName);
         if (entityViewClass == null) {
             throw new IllegalArgumentException("No entity view type is registered for the name: " + typeName);
         }
-        return createPaginatedSetting((Class<T>) entityViewClass, dataFetchingEnvironment, elementRoot);
+        return createPaginatedSetting((Class<T>) entityViewClass.getJavaType(), dataFetchingEnvironment, elementRoot);
     }
 
     /**
@@ -265,11 +265,11 @@ public class GraphQLEntityViewSupport {
             objectRoot = elementRoot + "/" + pageElementObjectName;
         }
         String typeName = getElementTypeName(dataFetchingEnvironment, objectRoot);
-        Class<?> entityViewClass = typeNameToViewType.get(typeName).getJavaType();
+        ManagedViewType<?> entityViewClass = typeNameToViewType.get(typeName);
         if (entityViewClass == null) {
             throw new IllegalArgumentException("No entity view type is registered for the name: " + typeName);
         }
-        return createPaginatedSetting((Class<T>) entityViewClass, dataFetchingEnvironment, elementRoot, extractKeysetPage(first, last, beforeCursor, afterCursor), first, last, offset);
+        return createPaginatedSetting((Class<T>) entityViewClass.getJavaType(), dataFetchingEnvironment, elementRoot, extractKeysetPage(first, last, beforeCursor, afterCursor), first, last, offset);
     }
 
     /**
@@ -372,11 +372,11 @@ public class GraphQLEntityViewSupport {
      */
     public <T> EntityViewSetting<T, CriteriaBuilder<T>> createSetting(DataFetchingEnvironment dataFetchingEnvironment, String elementRoot) {
         String typeName = getElementTypeName(dataFetchingEnvironment, elementRoot);
-        Class<?> entityViewClass = typeNameToViewType.get(typeName).getJavaType();
+        ManagedViewType<?> entityViewClass = typeNameToViewType.get(typeName);
         if (entityViewClass == null) {
             throw new IllegalArgumentException("No entity view type is registered for the name: " + typeName);
         }
-        return createSetting((Class<T>) entityViewClass, dataFetchingEnvironment, elementRoot);
+        return createSetting((Class<T>) entityViewClass.getJavaType(), dataFetchingEnvironment, elementRoot);
     }
 
     public String getElementTypeName(DataFetchingEnvironment dataFetchingEnvironment, String elementRoot) {
@@ -699,7 +699,11 @@ public class GraphQLEntityViewSupport {
      * @return the entity view class or <code>null</code>
      */
     public Class<?> getEntityViewClass(String typeName) {
-        return typeNameToViewType.get(typeName).getJavaType();
+        ManagedViewType<?> entityViewClass = typeNameToViewType.get(typeName);
+        if (entityViewClass == null) {
+            throw new IllegalArgumentException("No entity view type is registered for the name: " + typeName);
+        }
+        return entityViewClass.getJavaType();
     }
 
     /**

--- a/integration/graphql/src/main/java/com/blazebit/persistence/integration/graphql/GraphQLEntityViewSupport.java
+++ b/integration/graphql/src/main/java/com/blazebit/persistence/integration/graphql/GraphQLEntityViewSupport.java
@@ -640,7 +640,14 @@ public class GraphQLEntityViewSupport {
                     }
                     continue;
                 }
-                String mappedFieldPart = typeNameToFieldMapping.get(typeName).get(fieldName);
+
+                Map<String, String> typeMapping = typeNameToFieldMapping.get(typeName);
+                if (typeMapping == null) {
+                    throw new IllegalArgumentException(
+                        "No type is registered for the name: " + typeName);
+                }
+
+               String mappedFieldPart = typeMapping.get(fieldName);
                 if (mappedFieldPart == null) {
                     // fieldName cannot be mapped to an entity view field, probably because it's a non-DB field with a default -> ignore the whole field
                     continue OUTER;

--- a/integration/graphql/src/main/java/com/blazebit/persistence/integration/graphql/GraphQLEntityViewSupport.java
+++ b/integration/graphql/src/main/java/com/blazebit/persistence/integration/graphql/GraphQLEntityViewSupport.java
@@ -647,7 +647,7 @@ public class GraphQLEntityViewSupport {
                         "No type is registered for the name: " + typeName);
                 }
 
-               String mappedFieldPart = typeMapping.get(fieldName);
+                String mappedFieldPart = typeMapping.get(fieldName);
                 if (mappedFieldPart == null) {
                     // fieldName cannot be mapped to an entity view field, probably because it's a non-DB field with a default -> ignore the whole field
                     continue OUTER;


### PR DESCRIPTION
<!--- This template is for code related PRs. Remove it for e.g. documentation PRs. -->

<!--- Prefix the title with the issue number like "[#123] Some title" and try to summarize the changes in the title -->

<!--- Before submitting the PR, please make sure it satisfies the following guidelines -->
<!---  * Tests for issues should have one commit that has the form "Test for #123" where "#123" is the issue number -->
<!---  * Fixes for issues should have one commit that has the form "Fix for #123" where "#123" is the issue number -->
<!---  * Commits for the test and the fix should be separate -->

## Description
A NullPointerExceptions is thrown when a view type is not mapped for a requested GraphQL type.

## Related Issue
#1973

## Motivation and Context
See #1973

