### PR TITLE
[#1998] Upgrade to Quarkus 3.8 and switch to `@ConfigMapping`

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -49,6 +49,25 @@
                 <module>spring-hateoas</module>
                 <module>it-service-management</module>
                 <module>quarkus</module>
+                <module>microprofile-graphql</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>jdk17+</id>
+            <activation>
+                <jdk>[17,)</jdk>
+            </activation>
+            <modules>
+                <module>showcase</module>
+                <module>deltaspike-data-rest</module>
+                <module>spring-data-webmvc</module>
+                <module>spring-data-webflux</module>
+                <module>spring-data-graphql</module>
+                <module>spring-data-spqr</module>
+                <module>spring-data-dgs</module>
+                <module>spring-hateoas</module>
+                <module>it-service-management</module>
+                <module>quarkus</module>
                 <module>quarkus-3</module>
                 <module>microprofile-graphql</module>
             </modules>

--- a/examples/quarkus-3/pom.xml
+++ b/examples/quarkus-3/pom.xml
@@ -16,8 +16,8 @@
     </modules>
 
     <properties>
-        <main.java.version>11</main.java.version>
-        <version.jandex>3.0.5</version.jandex>
+        <main.java.version>17</main.java.version>
+        <version.jandex>3.1.6</version.jandex>
         <version.hibernate-orm>${version.hibernate-6.2}</version.hibernate-orm>
     </properties>
 

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -112,7 +112,6 @@
                 <module>graphql-dgs</module>
                 <module>querydsl</module>
                 <module>quarkus</module>
-                <module>quarkus-3</module>
 
                 <module>jpa-base-jar</module>
                 <module>openjpa-jar</module>

--- a/integration/quarkus-3/deployment/pom.xml
+++ b/integration/quarkus-3/deployment/pom.xml
@@ -194,10 +194,16 @@
     <profiles>
         <profile>
             <id>hibernate-6.2</id>
+            <!-- Note that we run against 6.4 because Quarkus 3.8 is based on 6.4 -->
             <properties>
                 <jpa.excludedGroups>com.blazebit.persistence.testsuite.base.jpa.category.NoHibernate</jpa.excludedGroups>
             </properties>
             <dependencies>
+                <dependency>
+                    <groupId>org.hibernate.orm</groupId>
+                    <artifactId>hibernate-core</artifactId>
+                    <version>${version.hibernate-6.4}</version>
+                </dependency>
                 <dependency>
                     <groupId>${project.groupId}</groupId>
                     <artifactId>blaze-persistence-entity-view-processor-jakarta</artifactId>
@@ -221,7 +227,7 @@
                                     <!-- source output directory -->
                                     <outputDirectory>${project.build.directory}/test-metamodel</outputDirectory>
                                     <processors>
-<!--                                        <processor>org.hibernate.jpamodelgen.JPAMetaModelEntityProcessor</processor>-->
+                                        <!--                                        <processor>org.hibernate.jpamodelgen.JPAMetaModelEntityProcessor</processor>-->
                                         <processor>
                                             com.blazebit.persistence.view.processor.EntityViewAnnotationProcessor
                                         </processor>
@@ -285,11 +291,11 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <skip>false</skip>
-                            <systemPropertyVariables>
+                            <systemProperties>
                                 <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                                 <!-- Required for JDK 16 -->
                                 <net.bytebuddy.experimental>true</net.bytebuddy.experimental>
-                            </systemPropertyVariables>
+                            </systemProperties>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -297,7 +303,7 @@
         </profile>
         <profile>
             <id>hibernate-6.3</id>
-            <!-- Note that we still run against 6.2 because Quarkus doesn't support 6.3 yet -->
+            <!-- Note that we run against 6.4 because Quarkus 3.8 is based on 6.4 -->
             <properties>
                 <jpa.excludedGroups>com.blazebit.persistence.testsuite.base.jpa.category.NoHibernate</jpa.excludedGroups>
             </properties>
@@ -305,8 +311,7 @@
                 <dependency>
                     <groupId>org.hibernate.orm</groupId>
                     <artifactId>hibernate-core</artifactId>
-                    <version>${version.hibernate-6.2}</version>
-<!--                    <version>${version.hibernate-6.3}</version>-->
+                    <version>${version.hibernate-6.4}</version>
                 </dependency>
                 <dependency>
                     <groupId>${project.groupId}</groupId>
@@ -331,7 +336,7 @@
                                     <!-- source output directory -->
                                     <outputDirectory>${project.build.directory}/test-metamodel</outputDirectory>
                                     <processors>
-<!--                                        <processor>org.hibernate.jpamodelgen.JPAMetaModelEntityProcessor</processor>-->
+                                        <!--                                        <processor>org.hibernate.jpamodelgen.JPAMetaModelEntityProcessor</processor>-->
                                         <processor>
                                             com.blazebit.persistence.view.processor.EntityViewAnnotationProcessor
                                         </processor>
@@ -407,7 +412,6 @@
         </profile>
         <profile>
             <id>hibernate-6.4</id>
-            <!-- Note that we still run against 6.2 because Quarkus doesn't support 6.4 yet -->
             <properties>
                 <jpa.excludedGroups>com.blazebit.persistence.testsuite.base.jpa.category.NoHibernate</jpa.excludedGroups>
             </properties>
@@ -415,8 +419,7 @@
                 <dependency>
                     <groupId>org.hibernate.orm</groupId>
                     <artifactId>hibernate-core</artifactId>
-                    <version>${version.hibernate-6.2}</version>
-<!--                    <version>${version.hibernate-6.4}</version>-->
+                    <version>${version.hibernate-6.4}</version>
                 </dependency>
                 <dependency>
                     <groupId>${project.groupId}</groupId>
@@ -517,7 +520,7 @@
         </profile>
         <profile>
             <id>hibernate-6.5</id>
-            <!-- Note that we still run against 6.2 because Quarkus doesn't support 6.5 yet -->
+            <!-- Note that we run against 6.4 because Quarkus 3.8 is based on 6.4 -->
             <properties>
                 <jpa.excludedGroups>com.blazebit.persistence.testsuite.base.jpa.category.NoHibernate</jpa.excludedGroups>
             </properties>
@@ -525,8 +528,7 @@
                 <dependency>
                     <groupId>org.hibernate.orm</groupId>
                     <artifactId>hibernate-core</artifactId>
-                    <version>${version.hibernate-6.2}</version>
-<!--                    <version>${version.hibernate-6.4}</version>-->
+                    <version>${version.hibernate-6.4}</version>
                 </dependency>
                 <dependency>
                     <groupId>${project.groupId}</groupId>
@@ -551,7 +553,7 @@
                                     <!-- source output directory -->
                                     <outputDirectory>${project.build.directory}/test-metamodel</outputDirectory>
                                     <processors>
-<!--                                        <processor>org.hibernate.jpamodelgen.JPAMetaModelEntityProcessor</processor>-->
+                                        <!--                                        <processor>org.hibernate.jpamodelgen.JPAMetaModelEntityProcessor</processor>-->
                                         <processor>
                                             com.blazebit.persistence.view.processor.EntityViewAnnotationProcessor
                                         </processor>
@@ -627,16 +629,16 @@
         </profile>
         <profile>
             <id>hibernate-6.6</id>
-            <!-- Note that we still run against 6.2 because Quarkus doesn't support 6.6 yet -->
+            <!-- Note that we run against Quarkus 3.15 as it's the version supporting ORM 6.6 -->
             <properties>
-                <jpa.excludedGroups>com.blazebit.persistence.testsuite.base.jpa.category.NoHibernatecom.blazebit.persistence.testsuite.base.jpa.category.NoHibernate66</jpa.excludedGroups>
+                <version.quarkus-3>${version.quarkus-3.15}</version.quarkus-3>
+                <jpa.excludedGroups>com.blazebit.persistence.testsuite.base.jpa.category.NoHibernate,com.blazebit.persistence.testsuite.base.jpa.category.NoHibernate66</jpa.excludedGroups>
             </properties>
             <dependencies>
                 <dependency>
                     <groupId>org.hibernate.orm</groupId>
                     <artifactId>hibernate-core</artifactId>
-                    <version>${version.hibernate-6.2}</version>
-<!--                    <version>${version.hibernate-6.4}</version>-->
+                    <version>${version.hibernate-6.6}</version>
                 </dependency>
                 <dependency>
                     <groupId>${project.groupId}</groupId>

--- a/integration/quarkus-3/deployment/src/main/java/com/blazebit/persistence/integration/quarkus/deployment/BlazePersistenceCdiProcessor.java
+++ b/integration/quarkus-3/deployment/src/main/java/com/blazebit/persistence/integration/quarkus/deployment/BlazePersistenceCdiProcessor.java
@@ -5,8 +5,8 @@
 package com.blazebit.persistence.integration.quarkus.deployment;
 
 import com.blazebit.persistence.CriteriaBuilderFactory;
+import com.blazebit.persistence.integration.quarkus.runtime.BlazePersistenceConfiguration;
 import com.blazebit.persistence.integration.quarkus.runtime.BlazePersistenceInstance;
-import com.blazebit.persistence.integration.quarkus.runtime.BlazePersistenceInstanceConfiguration;
 import com.blazebit.persistence.integration.quarkus.runtime.BlazePersistenceInstanceUtil;
 import com.blazebit.persistence.integration.quarkus.runtime.EntityViewRecorder;
 import com.blazebit.persistence.view.EntityViewManager;
@@ -21,13 +21,13 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
+import jakarta.enterprise.inject.Default;
+import jakarta.inject.Singleton;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.FieldInfo;
 
-import jakarta.enterprise.inject.Default;
-import jakarta.inject.Singleton;
 import java.util.List;
 import java.util.function.Supplier;
 
@@ -91,6 +91,7 @@ class BlazePersistenceCdiProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     @BuildStep
     void generateBeans(EntityViewRecorder recorder,
+                                 BlazePersistenceConfiguration blazePersistenceConfig,
                                  List<BlazePersistenceInstanceDescriptorBuildItem> blazePersistenceDescriptors,
                                  BuildProducer<AdditionalBeanBuildItem> additionalBeans,
                                  BuildProducer<SyntheticBeanBuildItem> syntheticBeanBuildItemBuildProducer) {
@@ -106,8 +107,8 @@ class BlazePersistenceCdiProcessor {
         if (blazePersistenceDescriptors.size() == 1) {
             BlazePersistenceInstanceDescriptorBuildItem blazePersistenceDescriptor = blazePersistenceDescriptors.get(0);
             String blazePersistenceInstanceName = blazePersistenceDescriptor.getBlazePersistenceInstanceName();
-            BlazePersistenceInstanceConfiguration blazePersistenceConfig = blazePersistenceDescriptor.getBlazePersistenceConfig();
-            String persistenceUnitName = blazePersistenceConfig.persistenceUnit.orElse(PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME);
+            String persistenceUnitName = blazePersistenceConfig.blazePersistenceInstances().get(blazePersistenceInstanceName)
+                    .persistenceUnit().orElse(PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME);
 
             syntheticBeanBuildItemBuildProducer
                     .produce(createSyntheticBean(blazePersistenceInstanceName,
@@ -133,8 +134,8 @@ class BlazePersistenceCdiProcessor {
 
         for (BlazePersistenceInstanceDescriptorBuildItem blazePersistenceDescriptor : blazePersistenceDescriptors) {
             String blazePersistenceInstanceName = blazePersistenceDescriptor.getBlazePersistenceInstanceName();
-            BlazePersistenceInstanceConfiguration blazePersistenceConfig = blazePersistenceDescriptor.getBlazePersistenceConfig();
-            String persistenceUnitName = blazePersistenceConfig.persistenceUnit.orElse(PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME);
+            String persistenceUnitName = blazePersistenceConfig.blazePersistenceInstances().get(blazePersistenceInstanceName)
+                    .persistenceUnit().orElse(PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME);
             boolean defaultBlazePersistenceInstance = BlazePersistenceInstanceUtil.isDefaultBlazePersistenceInstance(blazePersistenceInstanceName);
 
             syntheticBeanBuildItemBuildProducer

--- a/integration/quarkus-3/deployment/src/main/java/com/blazebit/persistence/integration/quarkus/deployment/BlazePersistenceInstanceDescriptorBuildItem.java
+++ b/integration/quarkus-3/deployment/src/main/java/com/blazebit/persistence/integration/quarkus/deployment/BlazePersistenceInstanceDescriptorBuildItem.java
@@ -4,7 +4,6 @@
  */
 package com.blazebit.persistence.integration.quarkus.deployment;
 
-import com.blazebit.persistence.integration.quarkus.runtime.BlazePersistenceInstanceConfiguration;
 import io.quarkus.builder.item.MultiBuildItem;
 
 import java.util.Set;
@@ -15,23 +14,17 @@ import java.util.Set;
  */
 public final class BlazePersistenceInstanceDescriptorBuildItem extends MultiBuildItem {
     private final String blazePersistenceInstanceName;
-    private final BlazePersistenceInstanceConfiguration blazePersistenceConfig;
     private final Set<String> entityViewClasses;
     private final Set<String> entityViewListenerClasses;
 
-    public BlazePersistenceInstanceDescriptorBuildItem(String blazePersistenceInstanceName, BlazePersistenceInstanceConfiguration blazePersistenceConfig, Set<String> entityViewClasses, Set<String> entityViewListenerClasses) {
+    public BlazePersistenceInstanceDescriptorBuildItem(String blazePersistenceInstanceName, Set<String> entityViewClasses, Set<String> entityViewListenerClasses) {
         this.blazePersistenceInstanceName = blazePersistenceInstanceName;
-        this.blazePersistenceConfig = blazePersistenceConfig;
         this.entityViewClasses = entityViewClasses;
         this.entityViewListenerClasses = entityViewListenerClasses;
     }
 
     public String getBlazePersistenceInstanceName() {
         return blazePersistenceInstanceName;
-    }
-
-    public BlazePersistenceInstanceConfiguration getBlazePersistenceConfig() {
-        return blazePersistenceConfig;
     }
 
     public Set<String> getEntityViewClasses() {

--- a/integration/quarkus-3/deployment/src/main/java/com/blazebit/persistence/integration/quarkus/deployment/BlazePersistenceProcessor.java
+++ b/integration/quarkus-3/deployment/src/main/java/com/blazebit/persistence/integration/quarkus/deployment/BlazePersistenceProcessor.java
@@ -105,15 +105,9 @@ class BlazePersistenceProcessor {
     @BuildStep
     void includeArchivesHostingEntityViewPackagesInIndex(BlazePersistenceConfiguration blazePersistenceConfig,
                                                      BuildProducer<AdditionalApplicationArchiveMarkerBuildItem> additionalApplicationArchiveMarkers) {
-        if (blazePersistenceConfig.defaultBlazePersistence.packages.isPresent()) {
-            for (String pakkage : blazePersistenceConfig.defaultBlazePersistence.packages.get()) {
-                additionalApplicationArchiveMarkers
-                        .produce(new AdditionalApplicationArchiveMarkerBuildItem(pakkage.replace('.', '/')));
-            }
-        }
-        for (BlazePersistenceInstanceConfiguration blazePersistenceInstanceConfig : blazePersistenceConfig.blazePersistenceInstances.values()) {
-            if (blazePersistenceInstanceConfig.packages.isPresent()) {
-                for (String pakkage : blazePersistenceInstanceConfig.packages.get()) {
+        for (BlazePersistenceInstanceConfiguration blazePersistenceInstanceConfig : blazePersistenceConfig.blazePersistenceInstances().values()) {
+            if (blazePersistenceInstanceConfig.packages().isPresent()) {
+                for (String pakkage : blazePersistenceInstanceConfig.packages().get()) {
                     additionalApplicationArchiveMarkers
                             .produce(new AdditionalApplicationArchiveMarkerBuildItem(pakkage.replace('.', '/')));
                 }
@@ -149,8 +143,8 @@ class BlazePersistenceProcessor {
                 .filter(pu -> PersistenceUnitUtil.isDefaultPersistenceUnit(pu.getPersistenceUnitName()))
                 .findFirst();
         boolean enableDefaultBlazePersistence = (defaultPersistenceUnit.isPresent()
-                && blazePersistenceConfig.blazePersistenceInstances.isEmpty())
-                || blazePersistenceConfig.defaultBlazePersistence.isAnyPropertySet();
+                && blazePersistenceConfig.namedBlazePersistenceInstances().isEmpty())
+                || blazePersistenceConfig.defaultBlazePersistenceInstance().isAnyPropertySet();
         boolean hasPackagesInQuarkusConfig = hasPackagesInQuarkusConfig(blazePersistenceConfig);
         Collection<AnnotationInstance> packageLevelBlazePersistenceInstanceAnnotations = getPackageLevelBlazePersistenceInstanceAnnotations(
                 indexBuildItem.getIndex()
@@ -159,7 +153,7 @@ class BlazePersistenceProcessor {
         Map<String, Set<String>> entityViewListenerClassesPerBlazePersistenceInstance;
         Set<String> entityViewClassesForDefaultBlazePersistenceInstance;
         Set<String> entityViewListenerClassesForDefaultBlazePersistenceInstance;
-        if (enableDefaultBlazePersistence && blazePersistenceConfig.blazePersistenceInstances.isEmpty() &&
+        if (enableDefaultBlazePersistence && blazePersistenceConfig.namedBlazePersistenceInstances().isEmpty() &&
                 !hasPackagesInQuarkusConfig && packageLevelBlazePersistenceInstanceAnnotations.isEmpty()) {
             // Only the default Blaze-Persistence instance exists and no package or annotation configuration is specified.
             // In this case we just assign all entity views to the default instance.
@@ -193,11 +187,10 @@ class BlazePersistenceProcessor {
         if (enableDefaultBlazePersistence) {
             blazePersistenceDescriptorBuildItemProducer.produce(new BlazePersistenceInstanceDescriptorBuildItem(
                     BlazePersistenceInstanceUtil.DEFAULT_BLAZE_PERSISTENCE_NAME,
-                    blazePersistenceConfig.defaultBlazePersistence,
                     entityViewClassesForDefaultBlazePersistenceInstance,
                     entityViewListenerClassesForDefaultBlazePersistenceInstance));
-        } else if ((!blazePersistenceConfig.defaultBlazePersistence.persistenceUnit.isPresent()
-                        || PersistenceUnitUtil.isDefaultPersistenceUnit(blazePersistenceConfig.defaultBlazePersistence.persistenceUnit.get()))
+        } else if ((!blazePersistenceConfig.defaultBlazePersistenceInstance().persistenceUnit().isPresent()
+                        || PersistenceUnitUtil.isDefaultPersistenceUnit(blazePersistenceConfig.defaultBlazePersistenceInstance().persistenceUnit().get()))
                 && !defaultPersistenceUnit.isPresent()) {
             if (!entityViewClassesForDefaultBlazePersistenceInstance.isEmpty()) {
                 LOG.warn(
@@ -209,16 +202,16 @@ class BlazePersistenceProcessor {
             }
         }
 
-        for (Map.Entry<String, BlazePersistenceInstanceConfiguration> namedInstance : blazePersistenceConfig.blazePersistenceInstances
+        for (Map.Entry<String, BlazePersistenceInstanceConfiguration> namedInstance : blazePersistenceConfig.namedBlazePersistenceInstances()
                 .entrySet()) {
             BlazePersistenceInstanceConfiguration blazePersistenceInstanceConfig = namedInstance.getValue();
-            if (blazePersistenceInstanceConfig.persistenceUnit.isPresent()) {
+            if (blazePersistenceInstanceConfig.persistenceUnit().isPresent()) {
                 persistenceUnitDescriptors.stream()
-                        .filter(descriptor -> blazePersistenceInstanceConfig.persistenceUnit.get().equals(descriptor.getPersistenceUnitName()))
+                        .filter(descriptor -> blazePersistenceInstanceConfig.persistenceUnit().get().equals(descriptor.getPersistenceUnitName()))
                         .findFirst()
                         .orElseThrow(() -> new ConfigurationException(
                                 String.format("The persistence unit '%1$s' is not configured but the Blaze-Persistence instance '%2$s' uses it.",
-                                        blazePersistenceInstanceConfig.persistenceUnit.get(), namedInstance.getKey())));
+                                        blazePersistenceInstanceConfig.persistenceUnit().get(), namedInstance.getKey())));
             } else {
                 if (!BlazePersistenceInstanceUtil.isDefaultBlazePersistenceInstance(namedInstance.getKey())) {
                     // if it's not the default Blaze-Persistence instance, we mandate a persistence unit to prevent common errors
@@ -235,7 +228,6 @@ class BlazePersistenceProcessor {
 
             blazePersistenceDescriptorBuildItemProducer.produce(new BlazePersistenceInstanceDescriptorBuildItem(
                     namedInstance.getKey(),
-                    namedInstance.getValue(),
                     entityViewClassesPerBlazePersistenceInstance.getOrDefault(namedInstance.getKey(), Collections.emptySet()),
                     entityViewListenerClassesPerBlazePersistenceInstance.getOrDefault(namedInstance.getKey(), Collections.emptySet())));
         }
@@ -457,24 +449,15 @@ class BlazePersistenceProcessor {
                         "Mixing Quarkus configuration and @BlazePersistenceInstance annotations to define the Blaze-Persistence instances is not supported. Ignoring the annotations.");
             }
 
-            // handle the default persistence unit
-            if (enableDefaultBlazePersistenceInstance) {
-                if (!blazePersistenceConfig.defaultBlazePersistence.packages.isPresent()) {
-                    throw new ConfigurationException("Packages must be configured for the default Blaze-Persistence instance.");
-                }
-
-                for (String packageName : blazePersistenceConfig.defaultBlazePersistence.packages.get()) {
-                    packageRules.computeIfAbsent(normalizePackage(packageName), p -> new HashSet<>())
-                            .add(BlazePersistenceInstanceUtil.DEFAULT_BLAZE_PERSISTENCE_NAME);
-                }
-            }
-
-            // handle the named Blaze-Persistence instances
-            for (Map.Entry<String, BlazePersistenceInstanceConfiguration> candidateBlazePersistenceInstanceEntry : blazePersistenceConfig.blazePersistenceInstances
+            for (Map.Entry<String, BlazePersistenceInstanceConfiguration> candidateBlazePersistenceInstanceEntry : blazePersistenceConfig.blazePersistenceInstances()
                     .entrySet()) {
                 String candidateBlazePersistenceInstanceName = candidateBlazePersistenceInstanceEntry.getKey();
 
-                Set<String> candidateBlazePersistenceInstancePackages = candidateBlazePersistenceInstanceEntry.getValue().packages
+                if (BlazePersistenceInstanceUtil.isDefaultBlazePersistenceInstance(candidateBlazePersistenceInstanceName) && !enableDefaultBlazePersistenceInstance) {
+                    continue;
+                }
+
+                Set<String> candidateBlazePersistenceInstancePackages = candidateBlazePersistenceInstanceEntry.getValue().packages()
                         .orElseThrow(() -> new ConfigurationException(String.format(
                                 "Packages must be configured for Blaze-Persistence instance '%s'.", candidateBlazePersistenceInstanceName)));
 
@@ -507,12 +490,8 @@ class BlazePersistenceProcessor {
     }
 
     private static boolean hasPackagesInQuarkusConfig(BlazePersistenceConfiguration blazePersistenceConfig) {
-        if (blazePersistenceConfig.defaultBlazePersistence.packages.isPresent()) {
-            return true;
-        }
-
-        for (BlazePersistenceInstanceConfiguration blazePersistenceInstanceConfig : blazePersistenceConfig.blazePersistenceInstances.values()) {
-            if (blazePersistenceInstanceConfig.packages.isPresent()) {
+        for (BlazePersistenceInstanceConfiguration blazePersistenceInstanceConfig : blazePersistenceConfig.blazePersistenceInstances().values()) {
+            if (blazePersistenceInstanceConfig.packages().isPresent()) {
                 return true;
             }
         }

--- a/integration/quarkus-3/pom.xml
+++ b/integration/quarkus-3/pom.xml
@@ -16,9 +16,9 @@
     </modules>
 
     <properties>
-        <main.java.version>11</main.java.version>
+        <main.java.version>17</main.java.version>
 
-        <version.jandex>3.0.5</version.jandex>
+        <version.jandex>3.1.6</version.jandex>
     </properties>
 
     <dependencyManagement>

--- a/integration/quarkus-3/runtime/pom.xml
+++ b/integration/quarkus-3/runtime/pom.xml
@@ -13,7 +13,7 @@
     <description>Advanced SQL support for JPA and Entity-Views as efficient DTOs</description>
 
     <properties>
-        <version.graal-sdk>19.3.1</version.graal-sdk>
+        <version.graal-sdk>23.1.2</version.graal-sdk>
         <module.name>com.blazebit.persistence.integration.quarkus</module.name>
     </properties>
 
@@ -58,8 +58,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
-            <artifactId>svm</artifactId>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>nativeimage</artifactId>
             <version>${version.graal-sdk}</version>
             <scope>provided</scope>
         </dependency>
@@ -115,11 +115,6 @@
                             <goal>process</goal>
                         </goals>
                         <phase>compile</phase>
-                        <configuration>
-                            <optionMap>
-                                <legacyConfigRoot>true</legacyConfigRoot>
-                            </optionMap>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/integration/quarkus-3/runtime/src/main/java/com/blazebit/persistence/integration/quarkus/runtime/BlazePersistenceConfiguration.java
+++ b/integration/quarkus-3/runtime/src/main/java/com/blazebit/persistence/integration/quarkus/runtime/BlazePersistenceConfiguration.java
@@ -6,29 +6,39 @@ package com.blazebit.persistence.integration.quarkus.runtime;
 
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigDocSection;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithParentName;
+import io.smallrye.config.WithUnnamedKey;
 
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * @author Moritz Becker
  * @since 1.5.0
  */
-@ConfigRoot
-public class BlazePersistenceConfiguration {
-
-    /**
-     * Configuration for the default Blaze-Persistence instance.
-     */
-    @ConfigItem(name = ConfigItem.PARENT)
-    public BlazePersistenceInstanceConfiguration defaultBlazePersistence;
+@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+@ConfigMapping(prefix = "quarkus.blaze-persistence")
+public interface BlazePersistenceConfiguration {
 
     /**
      * Additional named Blaze-Persistence instances.
      */
     @ConfigDocSection
     @ConfigDocMapKey("blaze-persistence-instance-name")
-    @ConfigItem(name = ConfigItem.PARENT)
-    public Map<String, BlazePersistenceInstanceConfiguration> blazePersistenceInstances;
+    @WithParentName
+    @WithUnnamedKey(BlazePersistenceInstanceUtil.DEFAULT_BLAZE_PERSISTENCE_NAME)
+    Map<String, BlazePersistenceInstanceConfiguration> blazePersistenceInstances();
+
+    default BlazePersistenceInstanceConfiguration defaultBlazePersistenceInstance() {
+        return blazePersistenceInstances().get(BlazePersistenceInstanceUtil.DEFAULT_BLAZE_PERSISTENCE_NAME);
+    }
+
+    default Map<String, BlazePersistenceInstanceConfiguration> namedBlazePersistenceInstances() {
+        Map<String, BlazePersistenceInstanceConfiguration> map = new TreeMap<>(blazePersistenceInstances());
+        map.remove(BlazePersistenceInstanceUtil.DEFAULT_BLAZE_PERSISTENCE_NAME);
+        return map;
+    }
 }

--- a/integration/quarkus-3/runtime/src/main/java/com/blazebit/persistence/integration/quarkus/runtime/BlazePersistenceInstanceConfiguration.java
+++ b/integration/quarkus-3/runtime/src/main/java/com/blazebit/persistence/integration/quarkus/runtime/BlazePersistenceInstanceConfiguration.java
@@ -11,7 +11,8 @@ import com.blazebit.persistence.spi.CriteriaBuilderConfiguration;
 import com.blazebit.persistence.view.EmptyFlatViewCreation;
 import com.blazebit.persistence.view.spi.EntityViewConfiguration;
 import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
 
 import java.util.Optional;
 import java.util.Set;
@@ -21,43 +22,43 @@ import java.util.Set;
  * @since 1.6.0
  */
 @ConfigGroup
-public class BlazePersistenceInstanceConfiguration {
+public interface BlazePersistenceInstanceConfiguration {
 
     /**
      * The name of the persistence unit which this instance of Blaze-Persistence uses.
      * <p>
      * If undefined, it will use the default persistence unit.
      */
-    public Optional<String> persistenceUnit;
+    Optional<String> persistenceUnit();
 
     /**
      * The packages in which the entity views and entity view listeners assigned to this Blaze-Persistence instance are located.
      */
-    public Optional<Set<String>> packages;
+    Optional<Set<String>> packages();
 
     /**
      * A boolean flag to make it possible to prepare all view template caches on startup.
      * By default the eager loading of the view templates is disabled to have a better startup performance.
      * Valid values for this property are <code>true</code> or <code>false</code>.
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean templateEagerLoading;
+    @WithDefault("false")
+    boolean templateEagerLoading();
 
     /**
      * A boolean flag to make it possible to disable the managed type validation.
      * By default the managed type validation is enabled, but since the validation is not bullet proof, it can be disabled.
      * Valid values for this property are <code>true</code> or <code>false</code>.
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean managedTypeValidationDisabled;
+    @WithDefault("false")
+    boolean managedTypeValidationDisabled();
 
     /**
      * An integer value that defines the default batch size for entity view attributes.
      * By default the value is 1 and can be overridden either via {@linkplain com.blazebit.persistence.view.BatchFetch#size()}
      * or by setting this property via {@linkplain com.blazebit.persistence.view.EntityViewSetting#setProperty}.
      */
-    @ConfigItem(defaultValue = "1")
-    public int defaultBatchSize;
+    @WithDefault("1")
+    int defaultBatchSize();
 
     /**
      * A mode specifying if correlation value, view root or embedded view batching is expected.
@@ -69,24 +70,26 @@ public class BlazePersistenceInstanceConfiguration {
      *  <li><code>embedding_views</code></li>
      * </ul>
      */
-    @ConfigItem(defaultValue = "values")
-    public String expectBatchMode;
+    @WithDefault("values")
+    String expectBatchMode();
 
     /**
      * A boolean flag to make it possible to prepare the entity view updater cache on startup.
      * By default the eager loading of entity view updates is disabled to have a better startup performance.
      * Valid values for this property are <code>true</code> or <code>false</code>.
      */
-    @ConfigItem(name = "updater.eager-loading", defaultValue = "false")
-    public boolean updaterEagerLoading;
+    @WithName("updater.eager-loading")
+    @WithDefault("false")
+    boolean updaterEagerLoading();
 
     /**
      * A boolean flag to make it possible to disable the strict validation that disallows the use of an updatable entity view type for owned relationships.
      * By default the use is disallowed i.e. the default value is <code>true</code>, but since there might be strange models out there, it possible to allow this.
      * Valid values for this property are <code>true</code> or <code>false</code>.
      */
-    @ConfigItem(name = "updater.disallow-owned-updatable-subview", defaultValue = "true")
-    public boolean updaterDisallowOwnedUpdatableSubview;
+    @WithName("updater.disallow-owned-updatable-subview")
+    @WithDefault("true")
+    boolean updaterDisallowOwnedUpdatableSubview();
 
     /**
      * A boolean flag to make it possible to disable the strict cascading check that disallows setting updatable or creatable entity views on non-cascading attributes
@@ -95,8 +98,9 @@ public class BlazePersistenceInstanceConfiguration {
      * By default the use is enabled i.e. the default value is <code>true</code>.
      * Valid values for this property are <code>true</code> or <code>false</code>.
      */
-    @ConfigItem(name = "updater.strict-cascading-check", defaultValue = "true")
-    public boolean updaterStrictCascadingCheck;
+    @WithName("updater.strict-cascading-check")
+    @WithDefault("true")
+    boolean updaterStrictCascadingCheck();
 
     /**
      * A boolean flag that allows to switch from warnings to boot time validation errors when invalid plural attribute setters are encountered while the strict cascading check is enabled.
@@ -105,22 +109,23 @@ public class BlazePersistenceInstanceConfiguration {
      * By default the use is disabled i.e. the default value is <code>false</code>.
      * Valid values for this property are <code>true</code> or <code>false</code>.
      */
-    @ConfigItem(name = "updater.error-on-invalid-plural-setter", defaultValue = "false")
-    public boolean updaterErrorOnInvalidPluralSetter;
+    @WithName("updater.error-on-invalid-plural-setter")
+    @WithDefault("false")
+    boolean updaterErrorOnInvalidPluralSetter();
 
     /**
      * A boolean flag that allows to specify if empty flat views should be created by default if not specified via {@link EmptyFlatViewCreation}.
      * By default the creation of empty flat views is enabled i.e. the default value is <code>true</code>.
      * Valid values for this property are <code>true</code> or <code>false</code>.
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean createEmptyFlatViews;
+    @WithDefault("true")
+    boolean createEmptyFlatViews();
 
     /**
      * The fully qualified expression cache implementation class name.
      */
-    @ConfigItem(defaultValue = "com.blazebit.persistence.parser.expression.ConcurrentHashMapExpressionCache")
-    public String expressionCacheClass;
+    @WithDefault("com.blazebit.persistence.parser.expression.ConcurrentHashMapExpressionCache")
+    String expressionCacheClass();
 
     /**
      * If set to true, the CTE queries are inlined by default.
@@ -133,8 +138,8 @@ public class BlazePersistenceInstanceConfiguration {
      * @see CTEBuilder#with(Class, boolean)
      * @see CTEBuilder#with(Class, CriteriaBuilder, boolean)
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean inlineCtes;
+    @WithDefault("true")
+    boolean inlineCtes();
 
     /**
      * If set to true, the query plans are cached and reused.
@@ -144,41 +149,41 @@ public class BlazePersistenceInstanceConfiguration {
      *
      * The property can be changed for a criteria builder before constructing a query.
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean queryPlanCacheEnabled;
+    @WithDefault("true")
+    boolean queryPlanCacheEnabled();
 
-    public void apply(CriteriaBuilderConfiguration criteriaBuilderConfiguration) {
-        criteriaBuilderConfiguration.setProperty(ConfigurationProperties.EXPRESSION_CACHE_CLASS, expressionCacheClass);
-        criteriaBuilderConfiguration.setProperty(ConfigurationProperties.INLINE_CTES, Boolean.toString(inlineCtes));
-        criteriaBuilderConfiguration.setProperty(ConfigurationProperties.QUERY_PLAN_CACHE_ENABLED, Boolean.toString(queryPlanCacheEnabled));
+    default void apply(CriteriaBuilderConfiguration criteriaBuilderConfiguration) {
+        criteriaBuilderConfiguration.setProperty(ConfigurationProperties.EXPRESSION_CACHE_CLASS, expressionCacheClass());
+        criteriaBuilderConfiguration.setProperty(ConfigurationProperties.INLINE_CTES, Boolean.toString(inlineCtes()));
+        criteriaBuilderConfiguration.setProperty(ConfigurationProperties.QUERY_PLAN_CACHE_ENABLED, Boolean.toString(queryPlanCacheEnabled()));
     }
 
-    public void apply(EntityViewConfiguration entityViewConfiguration) {
-        entityViewConfiguration.setProperty(com.blazebit.persistence.view.ConfigurationProperties.TEMPLATE_EAGER_LOADING, Boolean.toString(templateEagerLoading));
-        entityViewConfiguration.setProperty(com.blazebit.persistence.view.ConfigurationProperties.MANAGED_TYPE_VALIDATION_DISABLED, Boolean.toString(managedTypeValidationDisabled));
-        entityViewConfiguration.setProperty(com.blazebit.persistence.view.ConfigurationProperties.DEFAULT_BATCH_SIZE, Integer.toString(defaultBatchSize));
-        entityViewConfiguration.setProperty(com.blazebit.persistence.view.ConfigurationProperties.EXPECT_BATCH_MODE, expectBatchMode);
-        entityViewConfiguration.setProperty(com.blazebit.persistence.view.ConfigurationProperties.UPDATER_EAGER_LOADING, Boolean.toString(updaterEagerLoading));
-        entityViewConfiguration.setProperty(com.blazebit.persistence.view.ConfigurationProperties.UPDATER_DISALLOW_OWNED_UPDATABLE_SUBVIEW, Boolean.toString(updaterDisallowOwnedUpdatableSubview));
-        entityViewConfiguration.setProperty(com.blazebit.persistence.view.ConfigurationProperties.UPDATER_STRICT_CASCADING_CHECK, Boolean.toString(updaterStrictCascadingCheck));
-        entityViewConfiguration.setProperty(com.blazebit.persistence.view.ConfigurationProperties.UPDATER_ERROR_ON_INVALID_PLURAL_SETTER, Boolean.toString(updaterErrorOnInvalidPluralSetter));
-        entityViewConfiguration.setProperty(com.blazebit.persistence.view.ConfigurationProperties.CREATE_EMPTY_FLAT_VIEWS, Boolean.toString(createEmptyFlatViews));
+    default void apply(EntityViewConfiguration entityViewConfiguration) {
+        entityViewConfiguration.setProperty(com.blazebit.persistence.view.ConfigurationProperties.TEMPLATE_EAGER_LOADING, Boolean.toString(templateEagerLoading()));
+        entityViewConfiguration.setProperty(com.blazebit.persistence.view.ConfigurationProperties.MANAGED_TYPE_VALIDATION_DISABLED, Boolean.toString(managedTypeValidationDisabled()));
+        entityViewConfiguration.setProperty(com.blazebit.persistence.view.ConfigurationProperties.DEFAULT_BATCH_SIZE, Integer.toString(defaultBatchSize()));
+        entityViewConfiguration.setProperty(com.blazebit.persistence.view.ConfigurationProperties.EXPECT_BATCH_MODE, expectBatchMode());
+        entityViewConfiguration.setProperty(com.blazebit.persistence.view.ConfigurationProperties.UPDATER_EAGER_LOADING, Boolean.toString(updaterEagerLoading()));
+        entityViewConfiguration.setProperty(com.blazebit.persistence.view.ConfigurationProperties.UPDATER_DISALLOW_OWNED_UPDATABLE_SUBVIEW, Boolean.toString(updaterDisallowOwnedUpdatableSubview()));
+        entityViewConfiguration.setProperty(com.blazebit.persistence.view.ConfigurationProperties.UPDATER_STRICT_CASCADING_CHECK, Boolean.toString(updaterStrictCascadingCheck()));
+        entityViewConfiguration.setProperty(com.blazebit.persistence.view.ConfigurationProperties.UPDATER_ERROR_ON_INVALID_PLURAL_SETTER, Boolean.toString(updaterErrorOnInvalidPluralSetter()));
+        entityViewConfiguration.setProperty(com.blazebit.persistence.view.ConfigurationProperties.CREATE_EMPTY_FLAT_VIEWS, Boolean.toString(createEmptyFlatViews()));
     }
 
-    public boolean isAnyPropertySet() {
-        return !createEmptyFlatViews ||
-                defaultBatchSize != 1 ||
-                !"values".equals(expectBatchMode) ||
-                !"com.blazebit.persistence.parser.expression.ConcurrentHashMapExpressionCache".equals(expressionCacheClass) ||
-                !queryPlanCacheEnabled ||
-                !inlineCtes ||
-                persistenceUnit.isPresent() ||
-                packages.isPresent() ||
-                templateEagerLoading ||
-                managedTypeValidationDisabled ||
-                !updaterDisallowOwnedUpdatableSubview ||
-                updaterEagerLoading ||
-                updaterErrorOnInvalidPluralSetter ||
-                !updaterStrictCascadingCheck;
+    default boolean isAnyPropertySet() {
+        return !createEmptyFlatViews() ||
+                defaultBatchSize() != 1 ||
+                !"values".equals(expectBatchMode()) ||
+                !"com.blazebit.persistence.parser.expression.ConcurrentHashMapExpressionCache".equals(expressionCacheClass()) ||
+                !queryPlanCacheEnabled() ||
+                !inlineCtes() ||
+                persistenceUnit().isPresent() ||
+                packages().isPresent() ||
+                templateEagerLoading() ||
+                managedTypeValidationDisabled() ||
+                !updaterDisallowOwnedUpdatableSubview() ||
+                updaterEagerLoading() ||
+                updaterErrorOnInvalidPluralSetter() ||
+                !updaterStrictCascadingCheck();
     }
 }

--- a/integration/quarkus-3/runtime/src/main/java/com/blazebit/persistence/integration/quarkus/runtime/EntityViewRecorder.java
+++ b/integration/quarkus-3/runtime/src/main/java/com/blazebit/persistence/integration/quarkus/runtime/EntityViewRecorder.java
@@ -29,10 +29,10 @@ import java.util.function.Supplier;
 @Recorder
 public class EntityViewRecorder {
 
-    public Supplier<CriteriaBuilderFactory> criteriaBuilderFactorySupplier(BlazePersistenceInstanceConfiguration blazePersistenceConfig, String blazePersistenceInstanceName, String persistenceUnitName) {
+    public Supplier<CriteriaBuilderFactory> criteriaBuilderFactorySupplier(BlazePersistenceConfiguration blazePersistenceConfig, String blazePersistenceInstanceName, String persistenceUnitName) {
         return () -> {
             CriteriaBuilderConfiguration criteriaBuilderConfiguration = Criteria.getDefault();
-            blazePersistenceConfig.apply(criteriaBuilderConfiguration);
+            blazePersistenceConfig.blazePersistenceInstances().get(blazePersistenceInstanceName).apply(criteriaBuilderConfiguration);
             Annotation[] cbfQualifiers;
             if (BlazePersistenceInstanceUtil.isDefaultBlazePersistenceInstance(blazePersistenceInstanceName)) {
                 cbfQualifiers = new Annotation[] { new Default.Literal() };
@@ -46,7 +46,7 @@ public class EntityViewRecorder {
         };
     }
 
-    public Supplier<EntityViewManager> entityViewManagerSupplier(BlazePersistenceInstanceConfiguration blazePersistenceConfig,
+    public Supplier<EntityViewManager> entityViewManagerSupplier(BlazePersistenceConfiguration blazePersistenceConfig,
                                                                  String blazePersistenceInstanceName,
                                                                  Set<String> entityViewClasses,
                                                                  Set<String> entityViewListenerClasses) {
@@ -71,7 +71,7 @@ public class EntityViewRecorder {
                     throw new RuntimeException(e);
                 }
             }
-            blazePersistenceConfig.apply(entityViewConfiguration);
+            blazePersistenceConfig.blazePersistenceInstances().get(blazePersistenceInstanceName).apply(entityViewConfiguration);
             entityViewConfiguration.setProperty(ConfigurationProperties.PROXY_UNSAFE_ALLOWED, Boolean.FALSE.toString());
 
             Annotation[] cbfQualifiers;

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -136,7 +136,8 @@
 
         <version.weld>3.1.9.Final</version.weld>
         <version.quarkus>1.11.7.Final</version.quarkus>
-        <version.quarkus-3>3.2.9.Final</version.quarkus-3>
+        <version.quarkus-3>3.8.6</version.quarkus-3>
+        <version.quarkus-3.15>3.15.3</version.quarkus-3.15>
         <version.jandex>2.4.2.Final</version.jandex>
         <version.classgraph>4.8.89</version.classgraph>
 


### PR DESCRIPTION
## Description

Update Quarkus to 3.8 as the minimum version and switch to the new `@ConfigMapping` infrastructure.

## Related Issue

#1998 

## Motivation and Context

At some point in the future, we will retire the legacy config classes so let's migrate to the new @ConfigMapping infrastructure.

I was conservative and only updated to Quarkus 3.8.

Note that there might be more optimizations possible with having all elements in a single map but I tried to be as less intrusive as possible as I don't know the codebase.

