### PR TITLE
#2002 Play nice with jakarta 3.x and disabled inline id queries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ If all you wanted to do is create a test case for the issue, then all you are le
 
 In general, the first thing you should do is analyze the problem. If the change required to fix the issue is rather small, just go ahead and try it out.
 If a fix would require massive changes, you should first discuss the findings of your analysis and how you would fix the problem on the issue on GitHub.
-The maintainers will tell you if the solution is appropriate or what you should do differntly. Maybe the massive changes aren't required at all!
+The maintainers will tell you if the solution is appropriate or what you should do differently. Maybe the massive changes aren't required at all!
 
 Other than that, there is not much to say about how to fix an issue. Just make sure your code aligns with our checkstyle rules and everything else will be discussed on a case by case basis.
 

--- a/core/impl/src/main/java/com/blazebit/persistence/impl/PaginatedCriteriaBuilderImpl.java
+++ b/core/impl/src/main/java/com/blazebit/persistence/impl/PaginatedCriteriaBuilderImpl.java
@@ -1001,7 +1001,7 @@ public class PaginatedCriteriaBuilderImpl<T> extends AbstractFullQueryBuilder<T,
 
     private TypedQuery<Object> getIdQuery(String idQueryString, boolean normalQueryMode, Set<JoinNode> keyRestrictedLeftJoins, List<JoinNode> entityFunctions) {
         if (normalQueryMode && isEmpty(keyRestrictedLeftJoins, ID_QUERY_CLAUSE_EXCLUSIONS)) {
-            TypedQuery<Object> idQuery = em.createQuery(idQueryString, Object.class);
+            TypedQuery<Object> idQuery = (TypedQuery<Object>) em.createQuery(idQueryString);
             if (isCacheable()) {
                 mainQuery.jpaProvider.setCacheable(idQuery);
             }
@@ -1014,7 +1014,7 @@ public class PaginatedCriteriaBuilderImpl<T> extends AbstractFullQueryBuilder<T,
             return parameterManager.getCriteriaNameMapping() == null ? idQuery : new TypedQueryWrapper<>(idQuery, parameterManager.getCriteriaNameMapping());
         }
 
-        TypedQuery<Object> baseQuery = em.createQuery(idQueryString, Object.class);
+        TypedQuery<Object> baseQuery = (TypedQuery<Object>) em.createQuery(idQueryString);
         Set<String> parameterListNames = parameterManager.getParameterListNames(baseQuery);
 
         List<String> keyRestrictedLeftJoinAliases = getKeyRestrictedLeftJoinAliases(baseQuery, keyRestrictedLeftJoins, ID_QUERY_CLAUSE_EXCLUSIONS);

--- a/core/impl/src/main/java/com/blazebit/persistence/impl/PaginatedCriteriaBuilderImpl.java
+++ b/core/impl/src/main/java/com/blazebit/persistence/impl/PaginatedCriteriaBuilderImpl.java
@@ -999,9 +999,9 @@ public class PaginatedCriteriaBuilderImpl<T> extends AbstractFullQueryBuilder<T,
         return new AbstractMap.SimpleEntry<TypedQuery<T>, ObjectBuilder<T>>(query, objectBuilder);
     }
 
-    private TypedQuery<Object[]> getIdQuery(String idQueryString, boolean normalQueryMode, Set<JoinNode> keyRestrictedLeftJoins, List<JoinNode> entityFunctions) {
+    private TypedQuery<Object> getIdQuery(String idQueryString, boolean normalQueryMode, Set<JoinNode> keyRestrictedLeftJoins, List<JoinNode> entityFunctions) {
         if (normalQueryMode && isEmpty(keyRestrictedLeftJoins, ID_QUERY_CLAUSE_EXCLUSIONS)) {
-            TypedQuery<Object[]> idQuery = em.createQuery(idQueryString, Object[].class);
+            TypedQuery<Object> idQuery = em.createQuery(idQueryString, Object.class);
             if (isCacheable()) {
                 mainQuery.jpaProvider.setCacheable(idQuery);
             }
@@ -1014,7 +1014,7 @@ public class PaginatedCriteriaBuilderImpl<T> extends AbstractFullQueryBuilder<T,
             return parameterManager.getCriteriaNameMapping() == null ? idQuery : new TypedQueryWrapper<>(idQuery, parameterManager.getCriteriaNameMapping());
         }
 
-        TypedQuery<Object[]> baseQuery = em.createQuery(idQueryString, Object[].class);
+        TypedQuery<Object> baseQuery = em.createQuery(idQueryString, Object.class);
         Set<String> parameterListNames = parameterManager.getParameterListNames(baseQuery);
 
         List<String> keyRestrictedLeftJoinAliases = getKeyRestrictedLeftJoinAliases(baseQuery, keyRestrictedLeftJoins, ID_QUERY_CLAUSE_EXCLUSIONS);
@@ -1026,7 +1026,7 @@ public class PaginatedCriteriaBuilderImpl<T> extends AbstractFullQueryBuilder<T,
                 mainQuery.cteManager.isRecursive(), ctes, shouldRenderCteNodes, mainQuery.getQueryConfiguration().isQueryPlanCacheEnabled(), null
         );
 
-        CustomSQLTypedQuery<Object[]> idQuery = new CustomSQLTypedQuery<Object[]>(
+        CustomSQLTypedQuery<Object> idQuery = new CustomSQLTypedQuery<Object>(
                 querySpecification,
                 baseQuery,
                 parameterManager.getCriteriaNameMapping(),

--- a/core/testsuite/src/test/java/com/blazebit/persistence/testsuite/PaginationTest.java
+++ b/core/testsuite/src/test/java/com/blazebit/persistence/testsuite/PaginationTest.java
@@ -287,8 +287,10 @@ public class PaginationTest extends AbstractCoreTest {
 
     @Test
     public void testSelectJoinManyWithParameterForceIdQuery() {
-        String expectedCountQuery = "SELECT " + countTupleDistinct("d.id") + " FROM Document d LEFT JOIN d.contacts contacts_1 WHERE contacts_1.name = :param_0";
-        String expectedIdQuery = "SELECT d.id FROM Document d LEFT JOIN d.contacts contacts_1 WHERE contacts_1.name = :param_0 GROUP BY d.id ORDER BY d.id ASC";
+        String expectedCountQuery = "SELECT " + countTupleDistinct("d.id") + " FROM Document d LEFT JOIN d.contacts contacts_1 WHERE "
+            + joinAliasValue("contacts_1", "name") + " = :param_0";
+        String expectedIdQuery = "SELECT d.id FROM Document d LEFT JOIN d.contacts contacts_1 WHERE "
+            + joinAliasValue("contacts_1", "name") + " = :param_0 GROUP BY d.id ORDER BY d.id ASC";
         String expectedObjectQuery = "SELECT d FROM Document d WHERE d.id IN :ids ORDER BY d.id ASC";
         String expectedInlineObjectQuery = "SELECT d, (" + expectedCountQuery + ") FROM Document d"
             + " WHERE d.id IN (" + expectedIdQuery + " LIMIT 1) ORDER BY d.id ASC";


### PR DESCRIPTION
## Description
Changed response type for getIdQuery from `TypedQuery<Object[]>` to `TypedQuery<Object>` to avoid doubly listing the ID parameters

## Related Issue
#2002


## Motivation and Context
Solves getting paginated results on jakarta 3.x with inline ID query disabled

