### PR TITLE
[#2014] Copying criteria builder with CTE throws exception

### DIFF
--- a/core/impl/src/main/java/com/blazebit/persistence/impl/AbstractCommonQueryBuilder.java
+++ b/core/impl/src/main/java/com/blazebit/persistence/impl/AbstractCommonQueryBuilder.java
@@ -370,13 +370,14 @@ public abstract class AbstractCommonQueryBuilder<QueryResultType, BuilderType, S
     abstract AbstractCommonQueryBuilder<QueryResultType, BuilderType, SetReturn, SubquerySetReturn, FinalSetReturn> copy(QueryContext queryContext, Map<JoinManager, JoinManager> joinManagerMapping, ExpressionCopyContext copyContext);
 
     ExpressionCopyContext applyFrom(AbstractCommonQueryBuilder<?, ?, ?, ?, ?> builder, boolean copyMainQuery, boolean copySelect, boolean fixedSelect, boolean copyOrderBy, Set<ClauseType> clauseExclusions, Set<JoinNode> alwaysIncludedNodes, Map<JoinManager, JoinManager> joinManagerMapping, ExpressionCopyContext copyContext) {
+        joinManagerMapping.put(builder.joinManager, joinManager);
+
         if (copyMainQuery) {
             copyContext = new ExpressionCopyContextMap(parameterManager.copyFrom(builder.parameterManager));
             mainQuery.cteManager.applyFrom(builder.mainQuery.cteManager, joinManagerMapping, copyContext);
         }
-        copyContext = new ExpressionCopyContextForQuery(copyContext, builder.aliasManager.getAliasedExpressions());
 
-        joinManagerMapping.put(builder.joinManager, joinManager);
+        copyContext = new ExpressionCopyContextForQuery(copyContext, builder.aliasManager.getAliasedExpressions());
         aliasManager.applyFrom(builder.aliasManager);
         Map<JoinNode, JoinNode> nodeMapping = joinManager.applyFrom(builder.joinManager, clauseExclusions, alwaysIncludedNodes, copyContext);
         windowManager.applyFrom(builder.windowManager, copyContext);

--- a/core/impl/src/main/java/com/blazebit/persistence/impl/CTEManager.java
+++ b/core/impl/src/main/java/com/blazebit/persistence/impl/CTEManager.java
@@ -56,7 +56,9 @@ public class CTEManager extends CTEBuilderListenerImpl {
                 mainQuery.parameterManager.collectParameterRegistrations(cteInfo.recursiveCriteriaBuilder, ClauseType.CTE);
             }
 
-            ctes.put(entry.getKey(), cteInfo);
+            CTEKey cteKey = new CTEKey(entry.getKey().getName(), joinManagerMapping.get(entry.getKey().getOwner()));
+
+            ctes.put(cteKey, cteInfo);
         }
     }
 

--- a/core/testsuite/src/main/java/com/blazebit/persistence/testsuite/AbstractCoreTest.java
+++ b/core/testsuite/src/main/java/com/blazebit/persistence/testsuite/AbstractCoreTest.java
@@ -19,6 +19,7 @@ import com.blazebit.persistence.spi.JpqlFunctionGroup;
 import com.blazebit.persistence.testsuite.base.AbstractPersistenceTest;
 import com.blazebit.persistence.testsuite.base.jpa.assertion.AssertStatementBuilder;
 import com.blazebit.persistence.testsuite.entity.Document;
+import com.blazebit.persistence.testsuite.entity.DocumentNodeCTE;
 import com.blazebit.persistence.testsuite.entity.IntIdEntity;
 import com.blazebit.persistence.testsuite.entity.Person;
 import com.blazebit.persistence.testsuite.entity.PolymorphicBase;
@@ -587,7 +588,8 @@ public abstract class AbstractCoreTest extends AbstractPersistenceTest {
             Version.class,
             Person.class,
             Workflow.class,
-            IntIdEntity.class
+            IntIdEntity.class,
+            DocumentNodeCTE.class
         };
     }
 

--- a/core/testsuite/src/test/java/com/blazebit/persistence/testsuite/QueryBuilderCopyTest.java
+++ b/core/testsuite/src/test/java/com/blazebit/persistence/testsuite/QueryBuilderCopyTest.java
@@ -5,9 +5,17 @@
 
 package com.blazebit.persistence.testsuite;
 
+import com.blazebit.persistence.testsuite.base.jpa.category.NoDatanucleus;
+import com.blazebit.persistence.testsuite.base.jpa.category.NoEclipselink;
+import com.blazebit.persistence.testsuite.base.jpa.category.NoHibernate42;
+import com.blazebit.persistence.testsuite.base.jpa.category.NoHibernate43;
+import com.blazebit.persistence.testsuite.base.jpa.category.NoHibernate50;
+import com.blazebit.persistence.testsuite.base.jpa.category.NoOracle;
 import com.blazebit.persistence.testsuite.entity.Document;
+import com.blazebit.persistence.testsuite.entity.DocumentNodeCTE;
 import com.blazebit.persistence.testsuite.entity.Person;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * @author Christian Beikov
@@ -38,5 +46,26 @@ public class QueryBuilderCopyTest extends AbstractCoreTest {
                 .copy(String.class)
                 .select("name")
                 .getResultList();
+    }
+
+    @Test
+    @Category({NoDatanucleus.class, NoEclipselink.class, NoHibernate42.class, NoHibernate43.class, NoHibernate50.class, NoOracle.class})
+    public void testQueryCopyingWithCte() {
+        cbf.create(em, String.class)
+            .from(Document.class, "doc")
+            .select("doc.owner.localized")
+            .innerJoinOn(Person.class, "o")
+                .on("o.friend.localized").eq("pers1")
+            .end()
+            .innerJoinOnSubquery(DocumentNodeCTE.class, "dn")
+                .from(Document.class, "dd")
+                    .bind("id").select("dd.id", "id")
+                    .bind("parentId").select("dd.parent.id", "parentId")
+                .end()
+                .on("doc.id").eqExpression("dn.id")
+            .end()
+            .copy(String.class)
+            .select("doc.name")
+            .getResultList();
     }
 }


### PR DESCRIPTION
## Description
Build CTE Key using copied join manager instead of original so that the CTE can be found during selection.

## Related Issue
Fixes #2014


## Motivation and Context
See ticket above

