### PR TITLE
[#2042] Fix LazyKeysetLink#initialize using the same orderByExpression in every loop iteration

### DIFF
--- a/core/impl/src/main/java/com/blazebit/persistence/impl/keyset/LazyKeysetLink.java
+++ b/core/impl/src/main/java/com/blazebit/persistence/impl/keyset/LazyKeysetLink.java
@@ -33,7 +33,7 @@ public class LazyKeysetLink extends AbstractKeysetLink {
         Serializable[] tuple = new Serializable[orderByExpressions.size()];
 
         for (int i = 0; i < tuple.length; i++) {
-            String expressionString = orderByExpressions.get(0).getExpression().toString();
+            String expressionString = orderByExpressions.get(i).getExpression().toString();
             Object value = keysetValues.get(expressionString);
 
             if (value == null) {

--- a/core/impl/src/test/java/com/blazebit/persistence/impl/keyset/LazyKeysetLinkTest.java
+++ b/core/impl/src/test/java/com/blazebit/persistence/impl/keyset/LazyKeysetLinkTest.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Blazebit
+ */
+
+package com.blazebit.persistence.impl.keyset;
+
+import com.blazebit.persistence.impl.OrderByExpression;
+import com.blazebit.persistence.parser.expression.PropertyExpression;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+public class LazyKeysetLinkTest {
+
+    @Test
+    public void testReturningCorrectValuesInTuple() {
+        final PropertyExpression property1 = new PropertyExpression("property1");
+        final PropertyExpression property2 = new PropertyExpression("property2");
+
+        final Map<String, Object> keysetValues = new HashMap<>();
+        keysetValues.put(property1.getProperty(), 1);
+        keysetValues.put(property2.getProperty(), 2);
+
+        final ArrayList<OrderByExpression> orderByExpressions = new ArrayList<>();
+        orderByExpressions.add(new OrderByExpression(true, false, property1, false, false, false));
+        orderByExpressions.add(new OrderByExpression(true, false, property2, false, false, false));
+
+        final LazyKeysetLink lazyKeysetLink = new LazyKeysetLink(keysetValues, KeysetMode.NEXT);
+        lazyKeysetLink.initialize(orderByExpressions);
+
+        Assert.assertArrayEquals(new Serializable[] {1, 2}, lazyKeysetLink.getKeyset().getTuple());
+    }
+
+}


### PR DESCRIPTION
## Description
LazyKeysetLink#initialize now uses the loops actual orderByExpression instead of reusing the first one over and over again.

## Related Issue
#2042 


## Motivation and Context
This change makes it possible to use the `afterKeyset().with("expression", "value")`, with multiple `with` statements. Before it would reuse the value of the first `with` expression for the whole keyset, this is now fixed.

