### PR TITLE
[#1956] Use mysql time/date functions for mariadb

### DIFF
--- a/core/impl/src/main/java/com/blazebit/persistence/impl/CriteriaBuilderConfigurationImpl.java
+++ b/core/impl/src/main/java/com/blazebit/persistence/impl/CriteriaBuilderConfigurationImpl.java
@@ -1160,6 +1160,7 @@ public class CriteriaBuilderConfigurationImpl implements CriteriaBuilderConfigur
         jpqlFunctionGroup.add("microsoft", new SQLServerTimestampIsoFunction());
         jpqlFunctionGroup.add("mysql", new MySQLTimestampIsoFunction());
         jpqlFunctionGroup.add("mysql8", new MySQLTimestampIsoFunction());
+        jpqlFunctionGroup.add("mariadb", new MySQLTimestampIsoFunction());
         registerFunction(jpqlFunctionGroup);
 
         jpqlFunctionGroup = new JpqlFunctionGroup( DateIsoFunction.FUNCTION_NAME, false );
@@ -1169,6 +1170,7 @@ public class CriteriaBuilderConfigurationImpl implements CriteriaBuilderConfigur
         jpqlFunctionGroup.add("microsoft", new SQLServerDateIsoFunction());
         jpqlFunctionGroup.add("mysql", new MySQLDateIsoFunction());
         jpqlFunctionGroup.add("mysql8", new MySQLDateIsoFunction());
+        jpqlFunctionGroup.add("mariadb", new MySQLDateIsoFunction());
         registerFunction(jpqlFunctionGroup);
 
         jpqlFunctionGroup = new JpqlFunctionGroup( TimeIsoFunction.FUNCTION_NAME, false );
@@ -1178,6 +1180,7 @@ public class CriteriaBuilderConfigurationImpl implements CriteriaBuilderConfigur
         jpqlFunctionGroup.add("microsoft", new SQLServerTimeIsoFunction());
         jpqlFunctionGroup.add("mysql", new MySQLTimeIsoFunction());
         jpqlFunctionGroup.add("mysql8", new MySQLTimeIsoFunction());
+        jpqlFunctionGroup.add("mariadb", new MySQLTimeIsoFunction());
         registerFunction(jpqlFunctionGroup);
     }
 


### PR DESCRIPTION
## Description
As nearly every mysql function is registered for MariaDB, MySQLTimestampIsoFunction, MySQLDateIsoFunction and MySQLTimeIsoFunction was not. I added those registrations which fixes #1956 causing timestamps/ZonedDateTime being malformatted. For this i modified `CriteriaBuilderConfigurationImpl`.

## Related Issue
- #1956 


## Motivation and Context
The issue reported is open for over 6 months and without registering the functions myself - which should not be necessary in my opinion - i decided to create this PR.

