### PR TITLE
[#1814] Fixed Pageable.unpaged() in repository methods with Slice return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ None yet
 ### Bug fixes
 
 * Fix duplicate GraphQL type error when using converted view types through e.g. `Optional` wrapper
+* Fix unpaged Spring Data repository invocation with `Slice` return type
 
 ### Backwards-incompatible changes
 

--- a/integration/spring-data/1.x/src/main/java/com/blazebit/persistence/spring/data/impl/query/PartTreeBlazePersistenceQuery.java
+++ b/integration/spring-data/1.x/src/main/java/com/blazebit/persistence/spring/data/impl/query/PartTreeBlazePersistenceQuery.java
@@ -95,10 +95,15 @@ public class PartTreeBlazePersistenceQuery extends AbstractPartTreeBlazePersiste
         @Override
         @SuppressWarnings("unchecked")
         protected Object doExecute(AbstractJpaQuery repositoryQuery, Object[] values) {
-            Query paginatedCriteriaBuilder = ((PartTreeBlazePersistenceQuery) repositoryQuery).createPaginatedQuery(values, false);
-            PagedList<Object> resultList = (PagedList<Object>) paginatedCriteriaBuilder.getResultList();
             ParameterAccessor accessor = new ParametersParameterAccessor(repositoryQuery.getQueryMethod().getParameters(), values);
             Pageable pageable = accessor.getPageable();
+            if (pageable == null) {
+                List<Object> unpagedResult = ((PartTreeBlazePersistenceQuery) repositoryQuery).createQuery(values).getResultList();
+                return new KeysetAwareSliceImpl<>(unpagedResult);
+            }
+
+            Query paginatedCriteriaBuilder = ((PartTreeBlazePersistenceQuery) repositoryQuery).createPaginatedQuery(values, false);
+            PagedList<Object> resultList = (PagedList<Object>) paginatedCriteriaBuilder.getResultList();
 
             return new KeysetAwareSliceImpl<>(resultList, pageable);
         }

--- a/integration/spring-data/2.0/src/main/java/com/blazebit/persistence/spring/data/impl/query/PartTreeBlazePersistenceQuery.java
+++ b/integration/spring-data/2.0/src/main/java/com/blazebit/persistence/spring/data/impl/query/PartTreeBlazePersistenceQuery.java
@@ -95,10 +95,15 @@ public class PartTreeBlazePersistenceQuery extends AbstractPartTreeBlazePersiste
         @Override
         @SuppressWarnings("unchecked")
         protected Object doExecute(AbstractJpaQuery repositoryQuery, Object[] values) {
-            Query paginatedCriteriaBuilder = ((PartTreeBlazePersistenceQuery) repositoryQuery).createPaginatedQuery(values, false);
-            PagedList<Object> resultList = (PagedList<Object>) paginatedCriteriaBuilder.getResultList();
             ParameterAccessor accessor = new ParametersParameterAccessor(repositoryQuery.getQueryMethod().getParameters(), values);
             Pageable pageable = accessor.getPageable();
+            if (pageable.isUnpaged()) {
+                List<Object> unpagedResult = ((PartTreeBlazePersistenceQuery) repositoryQuery).createQuery(values).getResultList();
+                return new KeysetAwareSliceImpl<>(unpagedResult);
+            }
+
+            Query paginatedCriteriaBuilder = ((PartTreeBlazePersistenceQuery) repositoryQuery).createPaginatedQuery(values, false);
+            PagedList<Object> resultList = (PagedList<Object>) paginatedCriteriaBuilder.getResultList();
 
             return new KeysetAwareSliceImpl<>(resultList, pageable);
         }

--- a/integration/spring-data/2.1/src/main/java/com/blazebit/persistence/spring/data/impl/query/PartTreeBlazePersistenceQuery.java
+++ b/integration/spring-data/2.1/src/main/java/com/blazebit/persistence/spring/data/impl/query/PartTreeBlazePersistenceQuery.java
@@ -96,10 +96,15 @@ public class PartTreeBlazePersistenceQuery extends AbstractPartTreeBlazePersiste
         @Override
         @SuppressWarnings("unchecked")
         protected Object doExecute(AbstractJpaQuery repositoryQuery, Object[] values) {
-            Query paginatedCriteriaBuilder = ((PartTreeBlazePersistenceQuery) repositoryQuery).createPaginatedQuery(values, false);
-            PagedList<Object> resultList = (PagedList<Object>) paginatedCriteriaBuilder.getResultList();
             ParameterAccessor accessor = new ParametersParameterAccessor(repositoryQuery.getQueryMethod().getParameters(), values);
             Pageable pageable = accessor.getPageable();
+            if (pageable.isUnpaged()) {
+                List<Object> unpagedResult = ((PartTreeBlazePersistenceQuery) repositoryQuery).createQuery(values).getResultList();
+                return new KeysetAwareSliceImpl<>(unpagedResult);
+            }
+
+            Query paginatedCriteriaBuilder = ((PartTreeBlazePersistenceQuery) repositoryQuery).createPaginatedQuery(values, false);
+            PagedList<Object> resultList = (PagedList<Object>) paginatedCriteriaBuilder.getResultList();
 
             return new KeysetAwareSliceImpl<>(resultList, pageable);
         }

--- a/integration/spring-data/2.2/src/main/java/com/blazebit/persistence/spring/data/impl/query/PartTreeBlazePersistenceQuery.java
+++ b/integration/spring-data/2.2/src/main/java/com/blazebit/persistence/spring/data/impl/query/PartTreeBlazePersistenceQuery.java
@@ -96,9 +96,14 @@ public class PartTreeBlazePersistenceQuery extends AbstractPartTreeBlazePersiste
         @Override
         @SuppressWarnings("unchecked")
         protected Object doExecute(AbstractJpaQuery repositoryQuery, JpaParametersParameterAccessor jpaParametersParameterAccessor) {
+            Pageable pageable = jpaParametersParameterAccessor.getPageable();
+            if (pageable.isUnpaged()) {
+                List<Object> unpagedResult = ((PartTreeBlazePersistenceQuery) repositoryQuery).createQuery(jpaParametersParameterAccessor).getResultList();
+                return new KeysetAwareSliceImpl<>(unpagedResult);
+            }
+
             Query paginatedCriteriaBuilder = ((PartTreeBlazePersistenceQuery) repositoryQuery).createPaginatedQuery(jpaParametersParameterAccessor.getValues(), false);
             PagedList<Object> resultList = (PagedList<Object>) paginatedCriteriaBuilder.getResultList();
-            Pageable pageable = jpaParametersParameterAccessor.getPageable();
 
             return new KeysetAwareSliceImpl<>(resultList, pageable);
         }

--- a/integration/spring-data/2.3/src/main/java/com/blazebit/persistence/spring/data/impl/query/PartTreeBlazePersistenceQuery.java
+++ b/integration/spring-data/2.3/src/main/java/com/blazebit/persistence/spring/data/impl/query/PartTreeBlazePersistenceQuery.java
@@ -96,9 +96,14 @@ public class PartTreeBlazePersistenceQuery extends AbstractPartTreeBlazePersiste
         @Override
         @SuppressWarnings("unchecked")
         protected Object doExecute(AbstractJpaQuery repositoryQuery, JpaParametersParameterAccessor jpaParametersParameterAccessor) {
+            Pageable pageable = jpaParametersParameterAccessor.getPageable();
+            if (pageable.isUnpaged()) {
+                List<Object> unpagedResult = ((PartTreeBlazePersistenceQuery) repositoryQuery).createQuery(jpaParametersParameterAccessor).getResultList();
+                return new KeysetAwareSliceImpl<>(unpagedResult);
+            }
+
             Query paginatedCriteriaBuilder = ((PartTreeBlazePersistenceQuery) repositoryQuery).createPaginatedQuery(jpaParametersParameterAccessor.getValues(), false);
             PagedList<Object> resultList = (PagedList<Object>) paginatedCriteriaBuilder.getResultList();
-            Pageable pageable = jpaParametersParameterAccessor.getPageable();
 
             return new KeysetAwareSliceImpl<>(resultList, pageable);
         }

--- a/integration/spring-data/2.4/src/main/java/com/blazebit/persistence/spring/data/impl/query/PartTreeBlazePersistenceQuery.java
+++ b/integration/spring-data/2.4/src/main/java/com/blazebit/persistence/spring/data/impl/query/PartTreeBlazePersistenceQuery.java
@@ -98,9 +98,14 @@ public class PartTreeBlazePersistenceQuery extends AbstractPartTreeBlazePersiste
         @Override
         @SuppressWarnings("unchecked")
         protected Object doExecute(AbstractJpaQuery repositoryQuery, JpaParametersParameterAccessor jpaParametersParameterAccessor) {
+            Pageable pageable = jpaParametersParameterAccessor.getPageable();
+            if (pageable.isUnpaged()) {
+                List<Object> unpagedResult = ((PartTreeBlazePersistenceQuery) repositoryQuery).createQuery(jpaParametersParameterAccessor).getResultList();
+                return new KeysetAwareSliceImpl<>(unpagedResult);
+            }
+
             Query paginatedCriteriaBuilder = ((PartTreeBlazePersistenceQuery) repositoryQuery).createPaginatedQuery(jpaParametersParameterAccessor.getValues(), false);
             PagedList<Object> resultList = (PagedList<Object>) paginatedCriteriaBuilder.getResultList();
-            Pageable pageable = jpaParametersParameterAccessor.getPageable();
 
             return new KeysetAwareSliceImpl<>(resultList, pageable);
         }

--- a/integration/spring-data/2.5/src/main/java/com/blazebit/persistence/spring/data/impl/query/PartTreeBlazePersistenceQuery.java
+++ b/integration/spring-data/2.5/src/main/java/com/blazebit/persistence/spring/data/impl/query/PartTreeBlazePersistenceQuery.java
@@ -98,9 +98,14 @@ public class PartTreeBlazePersistenceQuery extends AbstractPartTreeBlazePersiste
         @Override
         @SuppressWarnings("unchecked")
         protected Object doExecute(AbstractJpaQuery repositoryQuery, JpaParametersParameterAccessor jpaParametersParameterAccessor) {
+            Pageable pageable = jpaParametersParameterAccessor.getPageable();
+            if (pageable.isUnpaged()) {
+                List<Object> unpagedResult = ((PartTreeBlazePersistenceQuery) repositoryQuery).createQuery(jpaParametersParameterAccessor).getResultList();
+                return new KeysetAwareSliceImpl<>(unpagedResult);
+            }
+
             Query paginatedCriteriaBuilder = ((PartTreeBlazePersistenceQuery) repositoryQuery).createPaginatedQuery(jpaParametersParameterAccessor.getValues(), false);
             PagedList<Object> resultList = (PagedList<Object>) paginatedCriteriaBuilder.getResultList();
-            Pageable pageable = jpaParametersParameterAccessor.getPageable();
 
             return new KeysetAwareSliceImpl<>(resultList, pageable);
         }

--- a/integration/spring-data/2.6/src/main/java/com/blazebit/persistence/spring/data/impl/query/PartTreeBlazePersistenceQuery.java
+++ b/integration/spring-data/2.6/src/main/java/com/blazebit/persistence/spring/data/impl/query/PartTreeBlazePersistenceQuery.java
@@ -98,9 +98,14 @@ public class PartTreeBlazePersistenceQuery extends AbstractPartTreeBlazePersiste
         @Override
         @SuppressWarnings("unchecked")
         protected Object doExecute(AbstractJpaQuery repositoryQuery, JpaParametersParameterAccessor jpaParametersParameterAccessor) {
+            Pageable pageable = jpaParametersParameterAccessor.getPageable();
+            if (pageable.isUnpaged()) {
+                List<Object> unpagedResult = ((PartTreeBlazePersistenceQuery) repositoryQuery).createQuery(jpaParametersParameterAccessor).getResultList();
+                return new KeysetAwareSliceImpl<>(unpagedResult);
+            }
+
             Query paginatedCriteriaBuilder = ((PartTreeBlazePersistenceQuery) repositoryQuery).createPaginatedQuery(jpaParametersParameterAccessor.getValues(), false);
             PagedList<Object> resultList = (PagedList<Object>) paginatedCriteriaBuilder.getResultList();
-            Pageable pageable = jpaParametersParameterAccessor.getPageable();
 
             return new KeysetAwareSliceImpl<>(resultList, pageable);
         }

--- a/integration/spring-data/2.7/src/main/java/com/blazebit/persistence/spring/data/impl/query/PartTreeBlazePersistenceQuery.java
+++ b/integration/spring-data/2.7/src/main/java/com/blazebit/persistence/spring/data/impl/query/PartTreeBlazePersistenceQuery.java
@@ -98,9 +98,14 @@ public class PartTreeBlazePersistenceQuery extends AbstractPartTreeBlazePersiste
         @Override
         @SuppressWarnings("unchecked")
         protected Object doExecute(AbstractJpaQuery repositoryQuery, JpaParametersParameterAccessor jpaParametersParameterAccessor) {
+            Pageable pageable = jpaParametersParameterAccessor.getPageable();
+            if (pageable.isUnpaged()) {
+                List<Object> unpagedResult = ((PartTreeBlazePersistenceQuery) repositoryQuery).createQuery(jpaParametersParameterAccessor).getResultList();
+                return new KeysetAwareSliceImpl<>(unpagedResult);
+            }
+
             Query paginatedCriteriaBuilder = ((PartTreeBlazePersistenceQuery) repositoryQuery).createPaginatedQuery(jpaParametersParameterAccessor.getValues(), false);
             PagedList<Object> resultList = (PagedList<Object>) paginatedCriteriaBuilder.getResultList();
-            Pageable pageable = jpaParametersParameterAccessor.getPageable();
 
             return new KeysetAwareSliceImpl<>(resultList, pageable);
         }

--- a/integration/spring-data/3.1/src/main/java/com/blazebit/persistence/spring/data/impl/query/PartTreeBlazePersistenceQuery.java
+++ b/integration/spring-data/3.1/src/main/java/com/blazebit/persistence/spring/data/impl/query/PartTreeBlazePersistenceQuery.java
@@ -99,9 +99,14 @@ public class PartTreeBlazePersistenceQuery extends AbstractPartTreeBlazePersiste
         @Override
         @SuppressWarnings("unchecked")
         protected Object doExecute(AbstractJpaQuery repositoryQuery, JpaParametersParameterAccessor jpaParametersParameterAccessor) {
+            Pageable pageable = jpaParametersParameterAccessor.getPageable();
+            if (pageable.isUnpaged()) {
+                List<Object> unpagedResult = ((PartTreeBlazePersistenceQuery) repositoryQuery).createQuery(jpaParametersParameterAccessor).getResultList();
+                return new KeysetAwareSliceImpl<>(unpagedResult);
+            }
+
             Query paginatedCriteriaBuilder = ((PartTreeBlazePersistenceQuery) repositoryQuery).createPaginatedQuery(jpaParametersParameterAccessor.getValues(), false);
             PagedList<Object> resultList = (PagedList<Object>) paginatedCriteriaBuilder.getResultList();
-            Pageable pageable = jpaParametersParameterAccessor.getPageable();
 
             return new KeysetAwareSliceImpl<>(resultList, pageable);
         }

--- a/integration/spring-data/3.3/src/main/java/com/blazebit/persistence/spring/data/impl/query/PartTreeBlazePersistenceQuery.java
+++ b/integration/spring-data/3.3/src/main/java/com/blazebit/persistence/spring/data/impl/query/PartTreeBlazePersistenceQuery.java
@@ -99,9 +99,14 @@ public class PartTreeBlazePersistenceQuery extends AbstractPartTreeBlazePersiste
         @Override
         @SuppressWarnings("unchecked")
         protected Object doExecute(AbstractJpaQuery repositoryQuery, JpaParametersParameterAccessor jpaParametersParameterAccessor) {
+            Pageable pageable = jpaParametersParameterAccessor.getPageable();
+            if (pageable.isUnpaged()) {
+                List<Object> unpagedResult = ((PartTreeBlazePersistenceQuery) repositoryQuery).createQuery(jpaParametersParameterAccessor).getResultList();
+                return new KeysetAwareSliceImpl<>(unpagedResult);
+            }
+
             Query paginatedCriteriaBuilder = ((PartTreeBlazePersistenceQuery) repositoryQuery).createPaginatedQuery(jpaParametersParameterAccessor.getValues(), false);
             PagedList<Object> resultList = (PagedList<Object>) paginatedCriteriaBuilder.getResultList();
-            Pageable pageable = jpaParametersParameterAccessor.getPageable();
 
             return new KeysetAwareSliceImpl<>(resultList, pageable);
         }

--- a/integration/spring-data/3.4/src/main/java/com/blazebit/persistence/spring/data/impl/query/PartTreeBlazePersistenceQuery.java
+++ b/integration/spring-data/3.4/src/main/java/com/blazebit/persistence/spring/data/impl/query/PartTreeBlazePersistenceQuery.java
@@ -99,9 +99,14 @@ public class PartTreeBlazePersistenceQuery extends AbstractPartTreeBlazePersiste
         @Override
         @SuppressWarnings("unchecked")
         protected Object doExecute(AbstractJpaQuery repositoryQuery, JpaParametersParameterAccessor jpaParametersParameterAccessor) {
+            Pageable pageable = jpaParametersParameterAccessor.getPageable();
+            if (pageable.isUnpaged()) {
+                List<Object> unpagedResult = ((PartTreeBlazePersistenceQuery) repositoryQuery).createQuery(jpaParametersParameterAccessor).getResultList();
+                return new KeysetAwareSliceImpl<>(unpagedResult);
+            }
+
             Query paginatedCriteriaBuilder = ((PartTreeBlazePersistenceQuery) repositoryQuery).createPaginatedQuery(jpaParametersParameterAccessor.getValues(), false);
             PagedList<Object> resultList = (PagedList<Object>) paginatedCriteriaBuilder.getResultList();
-            Pageable pageable = jpaParametersParameterAccessor.getPageable();
 
             return new KeysetAwareSliceImpl<>(resultList, pageable);
         }

--- a/integration/spring-data/testsuite/webmvc/src/test/java/com/blazebit/persistence/spring/data/testsuite/webmvc/ParameterizedReadOnlyDocumentRepositoryTest.java
+++ b/integration/spring-data/testsuite/webmvc/src/test/java/com/blazebit/persistence/spring/data/testsuite/webmvc/ParameterizedReadOnlyDocumentRepositoryTest.java
@@ -36,7 +36,6 @@ import com.blazebit.persistence.view.EntityViewManager;
 import com.blazebit.persistence.view.EntityViewSetting;
 import com.blazebit.persistence.view.Sorters;
 
-import java.util.stream.Collectors;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
@@ -844,20 +843,60 @@ public class ParameterizedReadOnlyDocumentRepositoryTest extends AbstractSpringT
     }
 
     @Test
-    public void testUnpaged() {
+    public void testUnpagedWithPage() {
         // Given
         final Document d1 = createDocument("D1");
         final Document d2 = createDocument("D2");
 
         // When
+        Specification<Document> specification = (root, query, criteriaBuilder) -> null;
         Page<DocumentAccessor> result = DocumentAccessors.of(readOnlyDocumentRepository.findAll(
-            new Specification<Document>() {
-                @Override
-                public Predicate toPredicate(Root<Document> root, CriteriaQuery<?> query, CriteriaBuilder criteriaBuilder) {
-                    return null;
-                }
-            },
+            specification,
             UNPAGED
+        ));
+
+        // Then
+        List<Long> actualIds = getIdsFromViews(result);
+
+        // Then
+        assertEquals(2, actualIds.size());
+        assertTrue(actualIds.contains(d1.getId()));
+        assertTrue(actualIds.contains(d2.getId()));
+    }
+
+    @Test
+    public void testUnpagedWithList() {
+        // Given
+        final Document d1 = createDocument("D1");
+        final Document d2 = createDocument("D2");
+
+        // When
+        Specification<Document> specification = (root, query, criteriaBuilder) -> null;
+        List<DocumentAccessor> result = DocumentAccessors.of(readOnlyDocumentRepository.findListBy(
+                specification,
+                UNPAGED
+        ));
+
+        // Then
+        List<Long> actualIds = getIdsFromViews(result);
+
+        // Then
+        assertEquals(2, actualIds.size());
+        assertTrue(actualIds.contains(d1.getId()));
+        assertTrue(actualIds.contains(d2.getId()));
+    }
+
+    @Test
+    public void testUnpagedWithSlice() {
+        // Given
+        final Document d1 = createDocument("D1");
+        final Document d2 = createDocument("D2");
+
+        // When
+        Specification<Document> specification = (root, query, criteriaBuilder) -> null;
+        Slice<DocumentAccessor> result = DocumentAccessors.of(readOnlyDocumentRepository.findSliceBy(
+                specification,
+                UNPAGED
         ));
 
         // Then

--- a/integration/spring-data/testsuite/webmvc/src/test/java/com/blazebit/persistence/spring/data/testsuite/webmvc/accessor/DocumentAccessors.java
+++ b/integration/spring-data/testsuite/webmvc/src/test/java/com/blazebit/persistence/spring/data/testsuite/webmvc/accessor/DocumentAccessors.java
@@ -53,32 +53,31 @@ public class DocumentAccessors {
         return new PageImpl<>(of(page.getContent()), getPageable(page), page.getTotalElements());
     }
 
-    private static Pageable getPageable(Page<?> page) {
+    private static Pageable getPageable(Slice<?> slice) {
         try {
             return (Pageable) Class.forName("org.springframework.data.domain.Slice").getMethod("getPageable")
-                .invoke(page);
+                .invoke(slice);
         } catch (Exception e) {
             // Ignore
         }
-        if (page.getSize() < 1) {
+        if (slice == null || slice.getSize() < 1) {
             return null;
         }
-        return new PageRequest(page.getNumber(), page.getSize());
+        return new PageRequest(slice.getNumber(), slice.getSize());
     }
 
     public static KeysetAwarePage<DocumentAccessor> of(KeysetAwarePage<?> page) {
         KeysetPageRequest keysetPageRequest;
         if (getPageable(page) == unpaged()) {
             keysetPageRequest = new KeysetPageRequest(page.getKeysetPage(), page.getSort(), 0, page.getSize());
-        }
-        else {
+        } else {
             keysetPageRequest = new KeysetPageRequest(page.getKeysetPage(), page.getSort(), page.getNumber() * page.getSize(), page.getSize());
         }
         return new KeysetAwarePageImpl<>(of(page.getContent()), (int) page.getTotalElements(), page.getKeysetPage(), keysetPageRequest);
     }
 
     public static Slice<DocumentAccessor> of(Slice<?> slice) {
-        return new SliceImpl<>(of(slice.getContent()), new PageRequest(slice.getNumber() * slice.getSize(), slice.getSize()), slice.hasNext());
+        return new SliceImpl<>(of(slice.getContent()), getPageable(slice), slice.hasNext());
     }
 
     private static Pageable unpaged() {
@@ -97,7 +96,6 @@ public class DocumentAccessors {
         public DocumentEntityAccessor(Document document) {
             this.document = document;
         }
-
 
         @Override
         public Long getId() {

--- a/integration/spring-data/testsuite/webmvc/src/test/java/com/blazebit/persistence/spring/data/testsuite/webmvc/repository/ReadOnlyDocumentRepository.java
+++ b/integration/spring-data/testsuite/webmvc/src/test/java/com/blazebit/persistence/spring/data/testsuite/webmvc/repository/ReadOnlyDocumentRepository.java
@@ -101,4 +101,8 @@ public interface ReadOnlyDocumentRepository<T> extends EntityViewRepository<T, L
     int countDocumentsByStatus(MyEnum status);
 
     <V> Page<V> findByName(String name, Class<V> type, Pageable pageable);
+
+    List<DocumentView> findListBy(Specification<Document> specification, Pageable pageable);
+
+    Slice<DocumentView> findSliceBy(Specification<Document> specification, Pageable pageable);
 }


### PR DESCRIPTION
## Description
I added `Pageable.unpaged()` support for `SlicedExecution` objects. I also added tests covering return types such as `List` and `Slice`.

## Related Issue
https://github.com/Blazebit/blaze-persistence/issues/1814

## Motivation and Context
Adds a missing feature analogous to Spring Data JPA.