### PR TITLE
Remove finalFieldsWritable from reflection producer

### DIFF
--- a/integration/quarkus-3/deployment/src/main/java/com/blazebit/persistence/integration/quarkus/deployment/BlazePersistenceProcessor.java
+++ b/integration/quarkus-3/deployment/src/main/java/com/blazebit/persistence/integration/quarkus/deployment/BlazePersistenceProcessor.java
@@ -256,7 +256,6 @@ class BlazePersistenceProcessor {
                     .constructors(true)
                     .fields(true)
                     .methods(true)
-                    .finalFieldsWritable(true)
                     .build()
             );
             // For static metamodel classes, we only need the fields


### PR DESCRIPTION
The method had been deprecated and was finally removed in https://github.com/quarkusio/quarkus/commit/4557b4ab75a9fb639461689a933bb8d7931cbe14.

## Description
Removed the `finalFieldsWritable` method call as it was removed in Quarkus 3.29+.

## Related Issue
See issue #2089.

## Motivation and Context
Support Quarkus 3.29+
