### PR TITLE
[#2106] Preserve KeysetAwarePage type for JPA Query Methods

### DIFF
--- a/integration/spring-data/base-3.1/src/main/java/com/blazebit/persistence/spring/data/base/query/KeysetAwarePageImpl.java
+++ b/integration/spring-data/base-3.1/src/main/java/com/blazebit/persistence/spring/data/base/query/KeysetAwarePageImpl.java
@@ -10,10 +10,12 @@ import com.blazebit.persistence.PagedList;
 import com.blazebit.persistence.spring.data.repository.KeysetAwarePage;
 import com.blazebit.persistence.spring.data.repository.KeysetPageRequest;
 import com.blazebit.persistence.spring.data.repository.KeysetPageable;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * @author Christian Beikov
@@ -42,6 +44,11 @@ public class KeysetAwarePageImpl<T> extends PageImpl<T> implements KeysetAwarePa
     @Override
     public KeysetPage getKeysetPage() {
         return keysetPage;
+    }
+
+    @Override
+    public <U> Page<U> map(Function<? super T, ? extends U> converter) {
+        return new KeysetAwarePageImpl<U>(this.getConvertedContent(converter), this.getTotalElements(), this.keysetPage, this.getPageable());
     }
 
     @Override

--- a/integration/spring-data/base-3.3/src/main/java/com/blazebit/persistence/spring/data/base/query/KeysetAwarePageImpl.java
+++ b/integration/spring-data/base-3.3/src/main/java/com/blazebit/persistence/spring/data/base/query/KeysetAwarePageImpl.java
@@ -10,10 +10,12 @@ import com.blazebit.persistence.PagedList;
 import com.blazebit.persistence.spring.data.repository.KeysetAwarePage;
 import com.blazebit.persistence.spring.data.repository.KeysetPageRequest;
 import com.blazebit.persistence.spring.data.repository.KeysetPageable;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * @author Christian Beikov
@@ -42,6 +44,11 @@ public class KeysetAwarePageImpl<T> extends PageImpl<T> implements KeysetAwarePa
     @Override
     public KeysetPage getKeysetPage() {
         return keysetPage;
+    }
+
+    @Override
+    public <U> Page<U> map(Function<? super T, ? extends U> converter) {
+        return new KeysetAwarePageImpl<U>(this.getConvertedContent(converter), this.getTotalElements(), this.keysetPage, this.getPageable());
     }
 
     @Override

--- a/integration/spring-data/base-4.0/src/main/java/com/blazebit/persistence/spring/data/base/query/KeysetAwarePageImpl.java
+++ b/integration/spring-data/base-4.0/src/main/java/com/blazebit/persistence/spring/data/base/query/KeysetAwarePageImpl.java
@@ -10,10 +10,12 @@ import com.blazebit.persistence.PagedList;
 import com.blazebit.persistence.spring.data.repository.KeysetAwarePage;
 import com.blazebit.persistence.spring.data.repository.KeysetPageRequest;
 import com.blazebit.persistence.spring.data.repository.KeysetPageable;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * @author Christian Beikov
@@ -42,6 +44,11 @@ public class KeysetAwarePageImpl<T> extends PageImpl<T> implements KeysetAwarePa
     @Override
     public KeysetPage getKeysetPage() {
         return keysetPage;
+    }
+
+    @Override
+    public <U> Page<U> map(Function<? super T, ? extends U> converter) {
+        return new KeysetAwarePageImpl<U>(this.getConvertedContent(converter), this.getTotalElements(), this.keysetPage, this.getPageable());
     }
 
     @Override

--- a/integration/spring-data/base/src/main/java/com/blazebit/persistence/spring/data/base/query/KeysetAwarePageImpl.java
+++ b/integration/spring-data/base/src/main/java/com/blazebit/persistence/spring/data/base/query/KeysetAwarePageImpl.java
@@ -10,10 +10,12 @@ import com.blazebit.persistence.PagedList;
 import com.blazebit.persistence.spring.data.repository.KeysetAwarePage;
 import com.blazebit.persistence.spring.data.repository.KeysetPageRequest;
 import com.blazebit.persistence.spring.data.repository.KeysetPageable;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * @author Christian Beikov
@@ -41,6 +43,11 @@ public class KeysetAwarePageImpl<T> extends PageImpl<T> implements KeysetAwarePa
     @Override
     public KeysetPage getKeysetPage() {
         return keysetPage;
+    }
+
+    @Override
+    public <U> Page<U> map(Function<? super T, ? extends U> converter) {
+        return new KeysetAwarePageImpl<U>(this.getConvertedContent(converter), this.getTotalElements(), this.keysetPage, this.getPageable());
     }
 
     @Override


### PR DESCRIPTION
## Description
Fixes keyset page type loss during Spring Data result mapping for JPA query methods.

`AbstractJpaQuery` uses a `ResultProcessor` that maps slice/page results via `Slice#map(...)`.  
When the source is `KeysetAwarePageImpl`, inherited `PageImpl#map(...)` returns a plain `PageImpl`, which drops keyset-aware type information.

This change overrides `map(...)` in `KeysetAwarePageImpl` so mapped results remain `KeysetAwarePageImpl`, preserving keyset metadata and pageable semantics.

## Related Issue
#2106

## Motivation and Context
The runtime failure occurs in proxy/interceptor paths that expect `KeysetAwarePage`, after Spring Data re-materializes mapped results as `PageImpl`.

Observed exception:
`java.lang.ClassCastException: org.springframework.data.domain.PageImpl cannot be cast to com.blazebit.persistence.spring.data.repository.KeysetAwarePage`

By preserving the concrete keyset-aware page type in `map(...)`, the expected runtime contract remains intact and keyset pagination metadata is retained.
