### PR TITLE
[#2113] Fix SIOOBE when a VALUES clause and an inline CTE join are nested inside another inline CTE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ None yet
 
 ### Bug fixes
 
-None yet
+* Fix `StringIndexOutOfBoundsException` when using a `VALUES` clause and an inline CTE join inside another inline CTE
 
 ### Backwards-incompatible changes
 

--- a/core/impl/src/main/java/com/blazebit/persistence/impl/function/entity/EntityFunction.java
+++ b/core/impl/src/main/java/com/blazebit/persistence/impl/function/entity/EntityFunction.java
@@ -57,26 +57,54 @@ public class EntityFunction implements JpqlFunction {
         // We remove the synthetic predicate here and later extract the values clause alias of it so we can insert the proper SQL values clause at the right place
         String subquery = functionRenderContext.getArgument(0);
         StringBuilder sb = new StringBuilder();
-        int subqueryEndIndex = subquery.lastIndexOf(AND_MARKER);
-        if (subquery.regionMatches(subqueryEndIndex - NULL_IS_NULL.length(), NULL_IS_NULL, 0, NULL_IS_NULL.length())) {
-            subqueryEndIndex -= NULL_IS_NULL.length();
-        } else if (subquery.regionMatches(subqueryEndIndex - NULL_IS_NULL_IN_PARENTHESIS.length(), NULL_IS_NULL_IN_PARENTHESIS, 0, NULL_IS_NULL_IN_PARENTHESIS.length())) {
-            subqueryEndIndex -= NULL_IS_NULL_IN_PARENTHESIS.length();
-        }
-        int aliasEndIndex = subquery.indexOf('.', subqueryEndIndex) ;
-        int aliasStartIndex = aliasEndIndex - 1;
-        while (aliasStartIndex > subqueryEndIndex) {
-            if (!SqlUtils.isIdentifier(subquery.charAt(aliasStartIndex))) {
-                aliasStartIndex++;
-                break;
-            }
-            aliasStartIndex--;
-        }
 
         String entityName = JpqlFunctionUtil.unquoteSingleQuotes(functionRenderContext.getArgument(1));
         String valuesClause = JpqlFunctionUtil.unquoteSingleQuotes(functionRenderContext.getArgument(2));
         String valuesAliases = JpqlFunctionUtil.unquoteSingleQuotes(functionRenderContext.getArgument(3));
         String syntheticPredicate = JpqlFunctionUtil.unquoteSingleQuotes(functionRenderContext.getArgument(4));
+
+        // The subquery may contain multiple marker predicates when e.g. a VALUES clause and an inline CTE
+        // are joined within the same query, so we have to find the marker predicate that belongs to this
+        // entity function invocation. Marker predicates of VALUES clauses are preceded by the synthetic predicate,
+        // whereas marker predicates of inline CTEs are preceded by a "null is null" placeholder predicate.
+        // If no marker predicate matches, we fall back to the last marker predicate
+        int subqueryEndIndex = -1;
+        int aliasStartIndex = -1;
+        int aliasEndIndex = -1;
+        for (int candidateMarkerIndex = subquery.lastIndexOf(AND_MARKER); candidateMarkerIndex != -1; candidateMarkerIndex = subquery.lastIndexOf(AND_MARKER, candidateMarkerIndex - 1)) {
+            int candidateEndIndex = candidateMarkerIndex;
+            if (subquery.regionMatches(candidateEndIndex - NULL_IS_NULL.length(), NULL_IS_NULL, 0, NULL_IS_NULL.length())) {
+                candidateEndIndex -= NULL_IS_NULL.length();
+            } else if (subquery.regionMatches(candidateEndIndex - NULL_IS_NULL_IN_PARENTHESIS.length(), NULL_IS_NULL_IN_PARENTHESIS, 0, NULL_IS_NULL_IN_PARENTHESIS.length())) {
+                candidateEndIndex -= NULL_IS_NULL_IN_PARENTHESIS.length();
+            }
+            int candidateAliasEndIndex = subquery.indexOf('.', candidateEndIndex);
+            int candidateAliasStartIndex = candidateAliasEndIndex - 1;
+            while (candidateAliasStartIndex > candidateEndIndex) {
+                if (!SqlUtils.isIdentifier(subquery.charAt(candidateAliasStartIndex))) {
+                    candidateAliasStartIndex++;
+                    break;
+                }
+                candidateAliasStartIndex--;
+            }
+            boolean markerMatches;
+            if (syntheticPredicate.isEmpty()) {
+                markerMatches = candidateEndIndex != candidateMarkerIndex;
+            } else {
+                String candidateAlias = subquery.substring(candidateAliasStartIndex, candidateAliasEndIndex);
+                String expectedPredicate = syntheticPredicate.replace(syntheticPredicate.substring(0, syntheticPredicate.indexOf('.')), candidateAlias);
+                markerMatches = subquery.regionMatches(candidateMarkerIndex - expectedPredicate.length(), expectedPredicate, 0, expectedPredicate.length());
+            }
+            if (markerMatches || subqueryEndIndex == -1) {
+                subqueryEndIndex = candidateEndIndex;
+                aliasStartIndex = candidateAliasStartIndex;
+                aliasEndIndex = candidateAliasEndIndex;
+                if (markerMatches) {
+                    break;
+                }
+            }
+        }
+
         String valuesTableSqlAlias = subquery.substring(aliasStartIndex, aliasEndIndex);
         appendSubqueryPart(sb, subquery, 1, subqueryEndIndex, subquery.length() - 1);
 

--- a/core/testsuite/src/test/java/com/blazebit/persistence/testsuite/InlineCTETest.java
+++ b/core/testsuite/src/test/java/com/blazebit/persistence/testsuite/InlineCTETest.java
@@ -27,6 +27,7 @@ import com.blazebit.persistence.testsuite.entity.ParameterOrderCteB;
 import com.blazebit.persistence.testsuite.entity.ParameterOrderEntity;
 import com.blazebit.persistence.testsuite.entity.Person;
 import com.blazebit.persistence.testsuite.entity.RecursiveEntity;
+import com.blazebit.persistence.testsuite.entity.StringIdCTE;
 import com.blazebit.persistence.testsuite.entity.TestAdvancedCTE1;
 import com.blazebit.persistence.testsuite.entity.TestAdvancedCTE2;
 import com.blazebit.persistence.testsuite.entity.TestCTE;
@@ -62,6 +63,7 @@ public class InlineCTETest extends AbstractCoreTest {
             IntIdEntity.class,
             DocumentCTE.class,
             RecursiveEntity.class,
+            StringIdCTE.class,
             TestCTE.class,
             TestAdvancedCTE1.class,
             TestAdvancedCTE2.class,
@@ -590,6 +592,52 @@ public class InlineCTETest extends AbstractCoreTest {
         assertEquals(expected, cb.getQueryString());
         List<RecursiveEntity> resultList = cb.getResultList();
         assertEquals(1, resultList.size());
+    }
+
+    // Test for #2113
+    // NOTE: Entity joins are only supported on Hibernate 5.1+
+    @Test
+    @Category({ NoDatanucleus.class, NoEclipselink.class, NoOpenJPA.class, NoHibernate42.class, NoHibernate43.class, NoHibernate50.class })
+    public void testJoinInlineEntityInsideInlineCte() {
+        CriteriaBuilder<TestCTE> cb = cbf.create(em, TestCTE.class, "t");
+        cb.with(TestCTE.class, true)
+                .fromValues(RecursiveEntity.class, "name", "val", Collections.singletonList("child1_1"))
+                .leftJoinOn(RecursiveEntity.class, "r")
+                    .on("r.name").eqExpression("val")
+                .end()
+                .bind("id").select("r.id")
+                .bind("name").select("val")
+                .bind("level").select("1")
+                .end();
+
+        List<TestCTE> resultList = cb.getResultList();
+        assertEquals(1, resultList.size());
+        assertEquals("child1_1", resultList.get(0).getName());
+    }
+
+    // Test for #2113
+    // NOTE: Entity joins are only supported on Hibernate 5.1+
+    @Test
+    @Category({ NoDatanucleus.class, NoEclipselink.class, NoOpenJPA.class, NoHibernate42.class, NoHibernate43.class, NoHibernate50.class })
+    public void testJoinInlineCteInsideInlineCte() {
+        CriteriaBuilder<StringIdCTE> cb = cbf.create(em, StringIdCTE.class, "c");
+        cb.with(TestCTE.class, true)
+                .from(RecursiveEntity.class, "e")
+                .bind("id").select("e.id")
+                .bind("name").select("e.name")
+                .bind("level").select("0")
+                .end();
+        cb.with(StringIdCTE.class, true)
+                .fromValues(RecursiveEntity.class, "name", "val", Collections.singletonList("child1_1"))
+                .leftJoinOn(TestCTE.class, "t")
+                    .on("t.name").eqExpression("val")
+                .end()
+                .bind("id").select("val")
+                .end();
+
+        List<StringIdCTE> resultList = cb.getResultList();
+        assertEquals(1, resultList.size());
+        assertEquals("child1_1", resultList.get(0).getId());
     }
 
     // NOTE: H2 and old MySQL do not support lateral joins


### PR DESCRIPTION
Fixes #2113

## Root cause

`JoinManager.buildClause` emits a synthetic marker group (`... and 999=999 and (<alias>.<attr> is null)`) for every VALUES clause and inline CTE node, and one `entity_function` wrapper per node is supposed to consume its own group during SQL rendering. `EntityFunction.render` located "its" marker with a blind `lastIndexOf(" and 999=999")`.

When a CTE body contains both a `fromValues(...)` and a `leftJoinOn(...)` of another inline CTE, `asExpression` wraps the body in nested `entity_function` calls (VALUES node innermost) and the innermost render call sees both marker groups. It picked the inline CTE join's marker, derived the wrong values table alias from it, substituted that alias into the synthetic predicate, and then could not find the predicate in the SQL (`indexOf` returning `-1`), crashing with `StringIndexOutOfBoundsException` at `EntityFunction.removeSyntheticPredicate`. The same shape in the main query works because that path (`CustomQuerySpecification.applySqlTransformations`) iterates over all nodes.

## Fix

`render` now scans marker candidates from last to first and picks the one that verifiably belongs to the current invocation:

- VALUES clause node (non-empty synthetic predicate): the alias-substituted synthetic predicate must immediately precede the marker
- inline CTE node (empty synthetic predicate): the `null is null` placeholder rendered from `NULLFN` must immediately precede the marker

If no candidate matches, it falls back to the last marker, i.e. the previous behavior, so currently working shapes cannot regress.

## Testing

- New `InlineCTETest#testJoinInlineCteInsideInlineCte` reproduces the exact SIOOBE without the fix; `testJoinInlineEntityInsideInlineCte` covers the plain entity join variant
- Full core testsuite green on H2 + Hibernate 5.6 (2313 tests) and on the Hibernate 7.2 jakarta runner (1966 tests)
- Verified against the original report's stack (Hibernate ORM 7.2.12, Jakarta Persistence 3.2, PostgreSQL 17, Java 25) via the standalone reproducer from the issue