### PR TITLE
[#2114] Fix count and id query omitting joins referred to by the WHERE clause through lazy path references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ None yet
 ### Bug fixes
 
 * Fix `StringIndexOutOfBoundsException` when using a `VALUES` clause and an inline CTE join inside another inline CTE
+* Fix count and id query omitting joins that the WHERE clause refers to through an association path that is implicitly joined in the SELECT clause
 
 ### Backwards-incompatible changes
 

--- a/core/impl/src/main/java/com/blazebit/persistence/impl/AbstractFullQueryBuilder.java
+++ b/core/impl/src/main/java/com/blazebit/persistence/impl/AbstractFullQueryBuilder.java
@@ -356,7 +356,7 @@ public abstract class AbstractFullQueryBuilder<T, X extends FullQueryBuilder<T, 
             } else {
                 // Collect usage of collection join nodes to optimize away the count distinct
                 // Note that we always exclude the nodes with group by dependency. We consider just the ones from the identifiers
-                Set<JoinNode> identifierExpressionsToUseNonRootJoinNodes = getIdentifierExpressionsToUseNonRootJoinNodes();
+                Set<JoinNode> identifierExpressionsToUseNonRootJoinNodes = getCountAndIdQueryAlwaysIncludedNodes(getIdentifierExpressionsToUseNonRootJoinNodes());
                 Set<JoinNode> collectionJoinNodes = joinManager.buildClause(sbSelectFrom, clauseExclusions, null, true, externalRepresentation, true, false, optionalWhereClauseConjuncts, whereClauseConjuncts, explicitVersionEntities, countNodesToFetch, identifierExpressionsToUseNonRootJoinNodes, null, true);
                 boolean hasCollectionJoinUsages = collectionJoinNodes.size() > 0;
 
@@ -459,7 +459,7 @@ public abstract class AbstractFullQueryBuilder<T, X extends FullQueryBuilder<T, 
             } else {
                 // Collect usage of collection join nodes to optimize away the count distinct
                 // Note that we always exclude the nodes with group by dependency. We consider just the ones from the identifiers
-                Set<JoinNode> identifierExpressionsToUseNonRootJoinNodes = getIdentifierExpressionsToUseNonRootJoinNodes();
+                Set<JoinNode> identifierExpressionsToUseNonRootJoinNodes = getCountAndIdQueryAlwaysIncludedNodes(getIdentifierExpressionsToUseNonRootJoinNodes());
                 Set<JoinNode> collectionJoinNodes = joinManager.buildClause(sbSelectFrom, COUNT_QUERY_GROUP_BY_CLAUSE_EXCLUSIONS, null, true, externalRepresentation, true, false, optionalWhereClauseConjuncts, whereClauseConjuncts, explicitVersionEntities, countNodesToFetch, identifierExpressionsToUseNonRootJoinNodes, null, true);
                 boolean hasCollectionJoinUsages = collectionJoinNodes.size() > 0;
 
@@ -603,6 +603,33 @@ public abstract class AbstractFullQueryBuilder<T, X extends FullQueryBuilder<T, 
         }
 
         return joinNodes;
+    }
+
+    protected Set<JoinNode> getCountAndIdQueryAlwaysIncludedNodes(Set<JoinNode> identifierExpressionsToUseNonRootJoinNodes) {
+        // Path expressions in the WHERE clause might lazily resolve to default join nodes that were created
+        // for other clauses only e.g. an implicit join in the SELECT clause. Since such nodes don't have a
+        // WHERE clause dependency registered, they would be omitted from count and id queries even though
+        // the rendered WHERE clause refers to their alias, so we have to include them explicitly
+        List<JoinNode> whereClauseJoinNodes = new ArrayList<>();
+        whereManager.acceptVisitor(new JoinNodeGathererVisitor(whereClauseJoinNodes));
+        Set<JoinNode> alwaysIncludedNodes = null;
+        for (int i = 0; i < whereClauseJoinNodes.size(); i++) {
+            JoinNode node = whereClauseJoinNodes.get(i);
+            while (node != null && node.getParent() != null) {
+                if (alwaysIncludedNodes == null) {
+                    if (identifierExpressionsToUseNonRootJoinNodes.contains(node)) {
+                        break;
+                    }
+                    alwaysIncludedNodes = new HashSet<>(identifierExpressionsToUseNonRootJoinNodes);
+                }
+                if (!alwaysIncludedNodes.add(node)) {
+                    break;
+                }
+                alwaysIncludedNodes.addAll(node.getDependencies());
+                node = node.getParent();
+            }
+        }
+        return alwaysIncludedNodes == null ? identifierExpressionsToUseNonRootJoinNodes : alwaysIncludedNodes;
     }
 
     protected ResolvedExpression[] getIdentifierExpressions() {

--- a/core/impl/src/main/java/com/blazebit/persistence/impl/PaginatedCriteriaBuilderImpl.java
+++ b/core/impl/src/main/java/com/blazebit/persistence/impl/PaginatedCriteriaBuilderImpl.java
@@ -1209,7 +1209,7 @@ public class PaginatedCriteriaBuilderImpl<T> extends AbstractFullQueryBuilder<T,
         // The id query does not have any fetch owners
         // Note that we always exclude the nodes with group by dependency. We consider just the ones from the identifiers
         Set<JoinNode> idNodesToFetch = Collections.emptySet();
-        Set<JoinNode> identifierExpressionsToUseNonRootJoinNodes = getIdentifierExpressionsToUseNonRootJoinNodes();
+        Set<JoinNode> identifierExpressionsToUseNonRootJoinNodes = getCountAndIdQueryAlwaysIncludedNodes(getIdentifierExpressionsToUseNonRootJoinNodes());
         Set<JoinNode> collectionJoins = joinManager.buildClause(sbSelectFrom, ID_QUERY_GROUP_BY_CLAUSE_EXCLUSIONS, null, true, externalRepresentation, true, false, optionalWhereClauseConjuncts, whereClauseConjuncts, explicitVersionEntities, idNodesToFetch, identifierExpressionsToUseNonRootJoinNodes, null, true);
 
         if (keysetMode == KeysetMode.NONE || keysetManager.getKeysetLink().getKeyset().getTuple() == null) {

--- a/core/testsuite/src/test/java/com/blazebit/persistence/testsuite/PaginationTest.java
+++ b/core/testsuite/src/test/java/com/blazebit/persistence/testsuite/PaginationTest.java
@@ -241,6 +241,24 @@ public class PaginationTest extends AbstractCoreTest {
         assertEquals("doc1", result.get(0).getName());
     }
 
+    // Test for #2114
+    @Test
+    public void testPaginatedWhereOnAssociationImplicitlyJoinedInSelect() {
+        String expectedCountQuery = "SELECT " + countPaginated("d.id", false) + " FROM Document d LEFT JOIN d.parent parent_1 WHERE parent_1 IS NULL";
+        String expectedObjectQuery = "SELECT d.id, parent_1.name FROM Document d LEFT JOIN d.parent parent_1 WHERE parent_1 IS NULL ORDER BY d.id ASC";
+        PaginatedCriteriaBuilder<Tuple> cb = cbf.create(em, Tuple.class)
+                .from(Document.class, "d")
+                .where("d.parent").isNull()
+                .select("d.id")
+                .select("d.parent.name")
+                .orderByAsc("d.id")
+                .page(0, 10);
+        assertEquals(expectedCountQuery, cb.getPageCountQueryString());
+        assertEquals(expectedObjectQuery, cb.withInlineCountQuery(false).getQueryString());
+        PagedList<Tuple> result = cb.getResultList();
+        assertEquals(7, result.getTotalSize());
+    }
+
     @Test
     public void testSelectIndexedWithParameter() {
         String expectedCountQuery = "SELECT " + countPaginated("d.id", false) + " FROM Document d JOIN d.owner owner_1 WHERE owner_1.name = :param_0";


### PR DESCRIPTION
Fixes #2114

## Root cause

A predicate on a single valued association like `where("m.reversesMovement").isNull()` does not require a join, so `JoinManager.implicitJoin` produces a `LazyPathReference` and registers the WHERE clause dependency only on the path's base node. When another clause creates a default join node for the same association — in the reported case the SELECT clause, through an entity view self-reference subview mapping — `LazyPathReference.getBaseNode()` resolves to that node at rendering time and the predicate is rendered against the join alias (`reversesMovement_1 IS NULL`).

Since that join node only carries a SELECT clause dependency, the paginated count query (clause exclusions `{SELECT, ORDER_BY, GROUP_BY}`) pruned the join while its rendered WHERE clause still referred to the alias. Hibernate 6+ rejects the resulting JPQL with `SemanticException: Could not interpret path expression 'reversesMovement_1'`; the legacy Hibernate 5 parser silently tolerated it. The same applies to the page id query. Walking the FK (`.id`) sidesteps the bug because the single valued id path never goes through the lazy collapse, which matches the workaround reported in the issue.

## Fix

Registering the WHERE dependency on the collapsed node eagerly at implicit join time is not viable: clause dependencies are copied by `CriteriaBuilder.copy()`, and `SingleValuedAssociationManyToOneTest#manyToOneSingleValuedAssociationIsNullAndSelectCopyResolved` codifies that a copy dropping the SELECT clause must also drop the join and re-render the plain association path.

Instead, when building count and id queries, `getCountAndIdQueryAlwaysIncludedNodes` collects the non-root join nodes that the WHERE clause path expressions *effectively* resolve to (the lazy collapse is final by then, so this also covers default nodes created by later-visited clauses such as ORDER BY) plus their ancestors and ON clause dependencies, and passes them through the pre-existing `alwaysIncludedNodes` mechanism of `JoinManager.buildClause`. No shared state is mutated, so the main query, builder copies and cached query strings are unaffected.

## Testing

- New `PaginationTest#testPaginatedWhereOnAssociationImplicitlyJoinedInSelect` asserts the count query now renders `SELECT COUNT(*) FROM Document d LEFT JOIN d.parent parent_1 WHERE parent_1 IS NULL` (previously the join was missing while the alias was referenced)
- Full core testsuite green on H2 + Hibernate 5.6 (2315 tests) and on the Hibernate 7.2 jakarta runner (1967 tests); entity view testsuite green (6037 tests)
- Verified against the original report's stack (entity view self-reference subview, Hibernate ORM 7.2.12, Jakarta Persistence 3.2, PostgreSQL 17, JDK 25) via the standalone reproducer from the issue: both the failing direct-association form and the `.id` workaround now pass