### PR TITLE
[#2120] Fix getTotalSize() violating its -1 contract on a full page when the count query is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ None yet
 
 * Fix `StringIndexOutOfBoundsException` when using a `VALUES` clause and an inline CTE join inside another inline CTE
 * Fix count and id query omitting joins that the WHERE clause refers to through an association path that is implicitly joined in the SELECT clause
+* Fix `PagedList.getTotalSize()` returning the page size instead of the documented `-1` on a full page when the count query is disabled
 
 ### Backwards-incompatible changes
 

--- a/core/impl/src/main/java/com/blazebit/persistence/impl/PaginatedTypedQueryImpl.java
+++ b/core/impl/src/main/java/com/blazebit/persistence/impl/PaginatedTypedQueryImpl.java
@@ -373,7 +373,11 @@ public class PaginatedTypedQueryImpl<X> implements PaginatedTypedQuery<X> {
                 newKeyset = new DefaultKeysetPage(firstRow, pageSize, lowest, highest, keysets);
             }
 
-            totalSize = Math.max(totalSize, firstRow + ids.size());
+            // Don't promote the -1 sentinel that signals a disabled count query, otherwise getTotalSize() would
+            // wrongly report the number of rows seen so far instead of the documented -1
+            if (totalSize != -1) {
+                totalSize = Math.max(totalSize, firstRow + ids.size());
+            }
             List<X> queryResultList = objectQuery.getResultList();
 
             PagedList<X> pagedResultList = new PagedArrayList<X>(queryResultList, newKeyset, totalSize, queryFirstResult, pageSize);
@@ -452,7 +456,11 @@ public class PaginatedTypedQueryImpl<X> implements PaginatedTypedQuery<X> {
                 }
             }
 
-            totalSize = Math.max(totalSize, firstRow + result.size());
+            // Don't promote the -1 sentinel that signals a disabled count query, otherwise getTotalSize() would
+            // wrongly report the number of rows seen so far instead of the documented -1
+            if (totalSize != -1) {
+                totalSize = Math.max(totalSize, firstRow + result.size());
+            }
 
             PagedList<X> pagedResultList = new PagedArrayList<X>(result, newKeyset, totalSize, queryFirstResult, pageSize);
             return pagedResultList;

--- a/core/testsuite/src/test/java/com/blazebit/persistence/testsuite/PaginationTest.java
+++ b/core/testsuite/src/test/java/com/blazebit/persistence/testsuite/PaginationTest.java
@@ -259,6 +259,20 @@ public class PaginationTest extends AbstractCoreTest {
         assertEquals(7, result.getTotalSize());
     }
 
+    // Test for #2120
+    @Test
+    public void testPaginatedDisabledCountQueryKeepsTotalSizeMinusOneOnFullPage() {
+        // There are 7 documents, so a page size of 2 yields a full first page with more rows remaining
+        PaginatedCriteriaBuilder<Document> cb = cbf.create(em, Document.class, "d")
+                .orderByAsc("d.id")
+                .page(0, 2)
+                .withCountQuery(false);
+        PagedList<Document> result = cb.getResultList();
+        assertEquals(2, result.size());
+        // The count query is disabled, so the total size must be -1 per the getTotalSize() contract
+        assertEquals(-1, result.getTotalSize());
+    }
+
     @Test
     public void testSelectIndexedWithParameter() {
         String expectedCountQuery = "SELECT " + countPaginated("d.id", false) + " FROM Document d JOIN d.owner owner_1 WHERE owner_1.name = :param_0";


### PR DESCRIPTION
Fixes #2120

## Root cause

When the count query is disabled (`PaginatedCriteriaBuilder.withCountQuery(false)`, or via the entity-view property `ConfigurationProperties.PAGINATION_DISABLE_COUNT_QUERY`), `PaginatedTypedQueryImpl.getResultList()` initializes `totalSize = -1` and is expected to keep it, per the `PagedList.getTotalSize()` contract:

> Returns the total size of the list or `-1` if the count query was disabled via `PaginatedCriteriaBuilder.withCountQuery(boolean)`.

On a **non-empty** page, however, two statements unconditionally promoted that sentinel:

```java
totalSize = Math.max(totalSize, firstRow + ids.size());    // id query path
totalSize = Math.max(totalSize, firstRow + result.size()); // object query path
```

Since `-1 < firstRow + size`, the `-1` was overwritten with the number of rows seen so far (the page size on a full page), so `getTotalSize()` returned e.g. `2` instead of `-1`. The empty-result paths were already correct because they guard the promotion with `if (totalSize == -1)` / `withCount` / `boundedCount`, which is why the bug only surfaces on full pages.

As reported, this also breaks the GraphQL integration: `GraphQLRelayPageInfo` computes `hasNextPage = size >= maxResults && (totalSize == -1 || firstResult + maxResults < totalSize)`, so a wrongly-promoted total makes the "unknown total" branch unreachable and `hasNextPage` evaluates to `false` on a full page even when more rows exist. `GraphQLEntityViewSupport.createPaginatedSetting` disables the count query automatically whenever the selection set omits `totalCount`, so this is reachable without any explicit opt-out.

## Fix

Guard both promotions so the `-1` sentinel is never raised:

```java
if (totalSize != -1) {
    totalSize = Math.max(totalSize, firstRow + ids.size());
}
```

On these paths `totalSize == -1` is equivalent to "count query disabled": when the count query is enabled `totalSize` is always populated (`>= 0`) beforehand, either from the count query at the top of `getResultList()` or from the inlined count extraction. So the guard preserves the documented `-1` only in the disabled case and leaves the real/bounded/inlined-count behaviour untouched.

## Testing

- New `PaginationTest#testPaginatedDisabledCountQueryKeepsTotalSizeMinusOneOnFullPage` requests a full first page (page size 2 of 7 documents) with `withCountQuery(false)` and asserts `getTotalSize() == -1`; it fails on `main` with `expected:<-1> but was:<2>` and passes with the fix
- All 271 core pagination/keyset tests green on H2 + Hibernate 5.6 (`PaginationTest`, `KeysetPaginationTest`, `OptimizedKeysetPagination*`, `PaginationOneToOneTest`, `IdClassAttributePaginationTest`, …)
- The original report's stack (entity view + `PAGINATION_DISABLE_COUNT_QUERY`, Hibernate ORM 7.2, Jakarta Persistence 3.2, PostgreSQL 17) reaches the same `PaginatedTypedQueryImpl` code path, so it is covered by this provider-independent fix; standalone reproducer: https://github.com/heruan/blaze-issues/pull/3
