### PR TITLE
Add Jackson 3 integration

### DIFF
--- a/dist/bom/pom.xml
+++ b/dist/bom/pom.xml
@@ -512,6 +512,18 @@
                 <scope>compile</scope>
             </dependency>
             <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>blaze-persistence-integration-jackson-3</artifactId>
+                <version>${project.version}</version>
+                <scope>compile</scope>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>blaze-persistence-integration-jackson-3-jakarta</artifactId>
+                <version>${project.version}</version>
+                <scope>compile</scope>
+            </dependency>
+            <dependency>
                 <groupId>com.blazebit</groupId>
                 <artifactId>blaze-persistence-integration-jsonb</artifactId>
                 <version>${project.version}</version>

--- a/dist/full/pom.xml
+++ b/dist/full/pom.xml
@@ -294,6 +294,14 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>blaze-persistence-integration-jackson-3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>blaze-persistence-integration-jackson-3-jakarta</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>blaze-persistence-integration-jsonb</artifactId>
         </dependency>
         <dependency>

--- a/documentation/src/main/asciidoc/entity-view/manual/en_US/serialization_support.adoc
+++ b/documentation/src/main/asciidoc/entity-view/manual/en_US/serialization_support.adoc
@@ -59,11 +59,13 @@ or if you are using Jakarta JPA
 </dependency>
 ----
 
-If you are using JAX-RS, Spring WebMvc or Spring WebFlux, consider using the already existing integrations instead to avoid unnecessary work.
+For Jackson 3 on Java 17 or later, use `blaze-persistence-integration-jackson-3` instead. For Jakarta JPA, use `blaze-persistence-integration-jackson-3-jakarta`.
+
+If you are using JAX-RS, Spring WebMvc or Spring WebFlux, consider using the already existing integrations instead to avoid unnecessary work. The existing framework integrations use Jackson 2.
 
 ==== Usage
 
-The integration happens by adding a module and a custom visibility checker to an existing `ObjectMapper`.
+The integration happens by adding a module and a custom visibility checker to an existing `ObjectMapper`. Jackson 3 `ObjectMapper` instances are immutable, so the Jackson 3 integration returns a rebuilt, configured mapper from `getObjectMapper()`.
 
 [source,java]
 ----
@@ -73,7 +75,7 @@ EntityViewAwareObjectMapper mapper = new EntityViewAwareObjectMapper(evm, existi
 ----
 
 The `EntityViewAwareObjectMapper` class provides utility methods for integrating with JAX-RS, Spring WebMvc and Spring WebFlux,
-but you can use your `ObjectMapper` directly as before as the module and visibility checker is registered in the existing mapper.
+but you can use the mapper returned by `getObjectMapper()` directly.
 
 [[jsonb-integration]]
 === JSONB integration

--- a/integration/jackson-3-jakarta/pom.xml
+++ b/integration/jackson-3-jakarta/pom.xml
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  Copyright Blazebit
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.blazebit</groupId>
+        <artifactId>blaze-persistence-integration</artifactId>
+        <version>1.6.21-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>blaze-persistence-integration-jackson-3-jakarta</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Blazebit Persistence Integration Jackson 3 Jakarta</name>
+
+    <properties>
+        <module.name>com.blazebit.persistence.integration.jackson</module.name>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>blaze-persistence-integration-jackson-3</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>blaze-persistence-entity-view-api-jakarta</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>3.1.2</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>transform-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <property name="plugin_classpath" refid="maven.plugin.classpath" />
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
+                                    <arg value="${com.blazebit:blaze-persistence-integration-jackson-3:jar}" />
+                                    <arg value="${project.build.directory}/${project.build.finalName}.jar" />
+                                    <arg value="-q" />
+                                    <arg value="-o" />
+                                    <arg value="-tr" />
+                                    <arg value="${project.basedir}/../../rules/jakarta-renames.properties" />
+                                    <classpath>
+                                        <pathelement path="${plugin_classpath}" />
+                                    </classpath>
+                                </java>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>transform-sources-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <property name="plugin_classpath" refid="maven.plugin.classpath" />
+                                <ac:propertyregex xmlns:ac="antlib:net.sf.antcontrib" property="source" input="${com.blazebit:blaze-persistence-integration-jackson-3:jar}" regexp="\.jar$" replace="-sources.jar" global="true" />
+                                <java classname="org.eclipse.transformer.cli.JakartaTransformerCLI" fork="true">
+                                    <arg value="${source}" />
+                                    <arg value="${project.build.directory}/${project.build.finalName}-sources.jar" />
+                                    <arg value="-q" />
+                                    <arg value="-o" />
+                                    <arg value="-tr" />
+                                    <arg value="${project.basedir}/../../rules/jakarta-renames.properties" />
+                                    <classpath>
+                                        <pathelement path="${plugin_classpath}" />
+                                    </classpath>
+                                </java>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>unpack-classes</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <unzip src="${project.build.directory}/${project.build.finalName}.jar" dest="${project.build.directory}/classes/" />
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.eclipse.transformer</groupId>
+                        <artifactId>org.eclipse.transformer.cli</artifactId>
+                        <version>0.5.0</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>ant-contrib</groupId>
+                        <artifactId>ant-contrib</artifactId>
+                        <version>1.0b3</version>
+                        <exclusions>
+                            <exclusion>
+                                <groupId>ant</groupId>
+                                <artifactId>ant</artifactId>
+                            </exclusion>
+                        </exclusions>
+                    </dependency>
+                    <dependency>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>biz.aQute.bnd.transform</artifactId>
+                        <version>${version.bnd}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>${project.build.directory}/${project.build.finalName}-sources.jar</file>
+                                    <classifier>sources</classifier>
+                                    <type>jar</type>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-module-infos</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>add-module-info</goal>
+                        </goals>
+                        <configuration>
+                            <module>
+                                <moduleInfoSource>
+                                    module ${module.name} {
+                                        requires transitive com.blazebit.persistence.view;
+                                        requires com.fasterxml.jackson.annotation;
+                                        requires tools.jackson.core;
+                                        requires tools.jackson.databind;
+                                        exports com.blazebit.persistence.integration.jackson;
+                                    }
+                                </moduleInfoSource>
+                            </module>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/integration/jackson-3/pom.xml
+++ b/integration/jackson-3/pom.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  Copyright Blazebit
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.blazebit</groupId>
+        <artifactId>blaze-persistence-integration</artifactId>
+        <version>1.6.21-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>blaze-persistence-integration-jackson-3</artifactId>
+
+    <name>Blazebit Persistence Integration Jackson 3</name>
+
+    <properties>
+        <module.name>com.blazebit.persistence.integration.jackson</module.name>
+        <main.java.version>17</main.java.version>
+        <version.jackson>3.1.2</version.jackson>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>blaze-persistence-entity-view-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${version.jackson}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>blaze-common-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax</groupId>
+            <artifactId>javaee-api</artifactId>
+            <version>7.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>blaze-persistence-core-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>blaze-persistence-entity-view-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-entitymanager</artifactId>
+            <version>${version.hibernate-5.4}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>blaze-persistence-integration-hibernate-5.4</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-module-infos</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>add-module-info</goal>
+                        </goals>
+                        <configuration>
+                            <module>
+                                <moduleInfoSource>
+                                    module ${module.name} {
+                                        requires transitive com.blazebit.persistence.view;
+                                        requires com.blazebit.common.utils;
+                                        requires com.fasterxml.jackson.annotation;
+                                        requires tools.jackson.core;
+                                        requires tools.jackson.databind;
+                                        exports com.blazebit.persistence.integration.jackson;
+                                    }
+                                </moduleInfoSource>
+                            </module>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/integration/jackson-3/src/main/java/com/blazebit/persistence/integration/jackson/EntityViewAwareObjectMapper.java
+++ b/integration/jackson-3/src/main/java/com/blazebit/persistence/integration/jackson/EntityViewAwareObjectMapper.java
@@ -1,0 +1,147 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Blazebit
+ */
+
+package com.blazebit.persistence.integration.jackson;
+
+import com.blazebit.persistence.view.EntityViewManager;
+import com.blazebit.persistence.view.metamodel.ManagedViewType;
+import com.blazebit.persistence.view.metamodel.MethodAttribute;
+import com.blazebit.persistence.view.metamodel.ViewMetamodel;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import tools.jackson.databind.BeanDescription;
+import tools.jackson.databind.DeserializationConfig;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.MapperFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectReader;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.deser.AbstractDeserializer;
+import tools.jackson.databind.deser.ValueDeserializerModifier;
+import tools.jackson.databind.introspect.AnnotatedMethod;
+import tools.jackson.databind.introspect.VisibilityChecker;
+import tools.jackson.databind.module.SimpleModule;
+
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * @author Christian Beikov
+ * @since 1.4.0
+ */
+public class EntityViewAwareObjectMapper {
+
+    private final EntityViewManager entityViewManager;
+    private final ObjectMapper objectMapper;
+
+    public EntityViewAwareObjectMapper(final EntityViewManager entityViewManager, final ObjectMapper objectMapper) {
+        this(entityViewManager, objectMapper, null);
+    }
+
+    public EntityViewAwareObjectMapper(final EntityViewManager entityViewManager, final ObjectMapper objectMapper, final EntityViewIdValueAccessor entityViewIdValueAccessor) {
+        this.entityViewManager = entityViewManager;
+        SimpleModule module = new SimpleModule("Blaze-Persistence");
+
+        module.setDeserializerModifier(new ValueDeserializerModifier() {
+            @Override
+            public ValueDeserializer<?> modifyDeserializer(DeserializationConfig config, BeanDescription.Supplier beanDesc, ValueDeserializer<?> deserializer) {
+                if (deserializer instanceof AbstractDeserializer) {
+                    ManagedViewType<?> view = entityViewManager.getMetamodel().managedView(beanDesc.getBeanClass());
+                    if (view != null) {
+                        return new EntityViewReferenceDeserializer(
+                                entityViewManager,
+                                view,
+                                objectMapper,
+                                beanDesc.get().getIgnoredPropertyNames(),
+                                entityViewIdValueAccessor
+                        );
+                    }
+                }
+                return deserializer;
+            }
+        });
+        this.objectMapper = objectMapper.rebuild()
+                .addModule(module)
+                .disable(MapperFeature.INFER_PROPERTY_MUTATORS)
+                .changeDefaultVisibility(existing -> new VisibilityChecker(JsonAutoDetect.Visibility.DEFAULT) {
+                    @Override
+                    public boolean isSetterVisible(AnnotatedMethod method) {
+                        if (super.isSetterVisible(method)) {
+                            Method member = method.getMember();
+                            Class<?> rawParameterType = member.getParameterTypes()[0];
+                            if (Collection.class.isAssignableFrom(rawParameterType) || Map.class.isAssignableFrom(rawParameterType)) {
+                                return isCollectionSetterVisible(member.getDeclaringClass(), member.getName());
+                            } else {
+                                return true;
+                            }
+                        }
+                        return false;
+                    }
+
+                    private boolean isCollectionSetterVisible(Class<?> declaringClass, String setterName) {
+                        final ViewMetamodel metamodel = entityViewManager.getMetamodel();
+                        ManagedViewType<?> managedViewType = metamodel.managedView(declaringClass);
+                        if (managedViewType == null) {
+                            Class<?> superclass = declaringClass.getSuperclass();
+                            if (superclass != Object.class) {
+                                ManagedViewType<?> managedViewTypeSuper = metamodel.managedView(superclass);
+                                if (managedViewTypeSuper != null) {
+                                    managedViewType = managedViewTypeSuper;
+                                }
+                            }
+                            if (managedViewType == null) {
+                                for (Class<?> interfaceClass : declaringClass.getInterfaces()) {
+                                    ManagedViewType<?> managedViewTypeInterface = metamodel.managedView(interfaceClass);
+                                    if (managedViewTypeInterface != null) {
+                                        managedViewType = managedViewTypeInterface;
+                                        break;
+                                    }
+                                }
+                            }
+                            if (managedViewType == null) {
+                                return true;
+                            }
+                        }
+                        String attributeName = Character.toLowerCase(setterName.charAt(3)) + setterName.substring(4);
+                        MethodAttribute<?, ?> attribute = managedViewType.getAttribute(attributeName);
+                        return attribute == null || !attribute.isCollection();
+                    }
+                })
+                .build();
+    }
+
+    public EntityViewManager getEntityViewManager() {
+        return entityViewManager;
+    }
+
+    public ObjectMapper getObjectMapper() {
+        return objectMapper;
+    }
+
+    public boolean canRead(Class<?> clazz) {
+        return entityViewManager.getMetamodel().managedView(clazz) != null;
+    }
+
+    public boolean canRead(JavaType javaType) {
+        if (!javaType.isContainerType()) {
+            return canRead(javaType.getRawClass());
+        } else if (javaType.isCollectionLikeType()) {
+            return canRead(javaType.getContentType().getRawClass());
+        }
+        return false;
+    }
+
+    public ObjectReader readerFor(JavaType javaType) {
+        if (Collection.class.isAssignableFrom(javaType.getRawClass())) {
+            return objectMapper.readerFor(javaType);
+        } else {
+            return readerFor(javaType.getRawClass());
+        }
+    }
+
+    public ObjectReader readerFor(Class<?> type) {
+        return objectMapper.readerFor(type);
+    }
+}

--- a/integration/jackson-3/src/main/java/com/blazebit/persistence/integration/jackson/EntityViewIdValueAccessor.java
+++ b/integration/jackson-3/src/main/java/com/blazebit/persistence/integration/jackson/EntityViewIdValueAccessor.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Blazebit
+ */
+
+package com.blazebit.persistence.integration.jackson;
+
+import tools.jackson.core.JsonParser;
+
+/**
+ * This interface is used to supply an entity view id from platform specific sources
+ * to the deserializer. The deserializer uses values provided by {@link EntityViewIdValueAccessor}
+ * as fallback in case no ID value extraction via the {@link JsonParser} is possible.
+ *
+ * @author Moritz Becker
+ * @since 1.5.0
+ */
+public interface EntityViewIdValueAccessor {
+
+    /**
+     * Retrieve an ID value for the entity view that is being deserialized at invocation time.
+     *
+     * @param jsonParser The {@link JsonParser} instance used by the deserializer
+     * @param idType The ID type
+     * @param <T> An ID type parameter
+     * @return The ID value or null
+     */
+    <T> T getValue(JsonParser jsonParser, Class<T> idType);
+}

--- a/integration/jackson-3/src/main/java/com/blazebit/persistence/integration/jackson/EntityViewReferenceDeserializer.java
+++ b/integration/jackson-3/src/main/java/com/blazebit/persistence/integration/jackson/EntityViewReferenceDeserializer.java
@@ -1,0 +1,106 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Blazebit
+ */
+
+package com.blazebit.persistence.integration.jackson;
+
+import com.blazebit.persistence.view.EntityViewManager;
+import com.blazebit.persistence.view.metamodel.ManagedViewType;
+import com.blazebit.persistence.view.metamodel.MethodAttribute;
+import com.blazebit.persistence.view.metamodel.ViewType;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.node.ObjectNode;
+
+import java.util.Set;
+
+/**
+ * @author Christian Beikov
+ * @since 1.4.0
+ */
+public class EntityViewReferenceDeserializer extends ValueDeserializer<Object> {
+
+    private final EntityViewManager entityViewManager;
+    private final EntityViewIdValueAccessor entityViewIdValueAccessor;
+    private final Class<?> entityViewClass;
+    private final MethodAttribute<?, ?> idAttribute;
+    private final JavaType idType;
+    private final boolean deserializeIdFromJson;
+    private final boolean updatable;
+    private final boolean creatable;
+
+    public EntityViewReferenceDeserializer(EntityViewManager entityViewManager, ManagedViewType<?> view, ObjectMapper objectMapper, Set<String> ignoredProperties, EntityViewIdValueAccessor entityViewIdValueAccessor) {
+        this.entityViewManager = entityViewManager;
+        this.entityViewClass = view.getJavaType();
+        this.entityViewIdValueAccessor = entityViewIdValueAccessor;
+        if (view instanceof ViewType<?>) {
+            MethodAttribute<?, ?> idAttribute = ((ViewType<?>) view).getIdAttribute();
+            this.deserializeIdFromJson = !ignoredProperties.contains(idAttribute.getName());
+            this.idAttribute = idAttribute;
+            JavaType idType = objectMapper.getTypeFactory().constructType(this.idAttribute.getConvertedJavaType());
+            this.idType = idType;
+        } else {
+            this.idAttribute = null;
+            this.idType = null;
+            this.deserializeIdFromJson = false;
+        }
+        this.updatable = view.isUpdatable();
+        this.creatable = view.isCreatable();
+    }
+
+    @Override
+    public Object deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws JacksonException {
+        JsonNode treeNode = deserializationContext.readTree(jsonParser);
+        Object id = retrieveId(jsonParser, deserializationContext, treeNode, !creatable || updatable);
+        Object reference;
+
+        if (creatable && (!updatable || id == null)) {
+            reference = entityViewManager.create(entityViewClass);
+        } else if (id != null) {
+            reference = entityViewManager.getReference(entityViewClass, id);
+        } else {
+            reference = null;
+        }
+
+        if (reference == null) {
+            return null;
+        }
+
+        jsonParser = deserializationContext.treeAsTokens(treeNode);
+        jsonParser.nextToken();
+        return deserializationContext.findContextualValueDeserializer(deserializationContext.constructType(reference.getClass()), null)
+                .deserialize(jsonParser, deserializationContext, reference);
+    }
+
+    private Object retrieveId(JsonParser rootJsonParser, DeserializationContext deserializationContext, JsonNode treeNode, boolean consume) throws JacksonException {
+        Object id;
+        if (idAttribute == null || idType == null) {
+            id = null;
+        } else {
+            String idAttributeName = idAttribute.getName();
+            JsonNode jsonNode;
+            if (deserializeIdFromJson && (jsonNode = treeNode.get(idAttributeName)) != null) {
+                if (jsonNode.isNull()) {
+                    id = null;
+                } else {
+                    id = deserializationContext.readValue(deserializationContext.treeAsTokens(jsonNode), idType);
+                    if (consume) {
+                        ((ObjectNode) treeNode).without(idAttributeName);
+                    }
+                }
+            } else if (rootJsonParser.streamReadContext().inRoot() && entityViewIdValueAccessor != null) {
+                id = entityViewIdValueAccessor.getValue(rootJsonParser, idType.getRawClass());
+            } else {
+                id = null;
+            }
+        }
+
+        return id;
+    }
+}

--- a/integration/jackson-3/src/test/java/com/blazebit/persistence/integration/jackson/EntityViewAwareObjectMapperTest.java
+++ b/integration/jackson-3/src/test/java/com/blazebit/persistence/integration/jackson/EntityViewAwareObjectMapperTest.java
@@ -1,0 +1,104 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Blazebit
+ */
+
+package com.blazebit.persistence.integration.jackson;
+
+import com.blazebit.persistence.Criteria;
+import com.blazebit.persistence.CriteriaBuilderFactory;
+import com.blazebit.persistence.view.CreatableEntityView;
+import com.blazebit.persistence.view.EntityView;
+import com.blazebit.persistence.view.EntityViews;
+import com.blazebit.persistence.view.IdMapping;
+import com.blazebit.persistence.view.UpdatableEntityView;
+import com.blazebit.persistence.view.spi.EntityViewConfiguration;
+import com.blazebit.persistence.view.spi.type.EntityViewProxy;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectReader;
+
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class EntityViewAwareObjectMapperTest {
+
+    static EntityManagerFactory emf;
+    static CriteriaBuilderFactory cbf;
+
+    @BeforeClass
+    public static void prepare() {
+        emf = Persistence.createEntityManagerFactory("Test");
+        cbf = Criteria.getDefault().createCriteriaBuilderFactory(emf);
+    }
+
+    private static EntityViewAwareObjectMapper mapper(EntityViewIdValueAccessor idValueAccessor, Class<?>... classes) {
+        EntityViewConfiguration configuration = EntityViews.createDefaultConfiguration();
+        for (Class<?> clazz : classes) {
+            configuration.addEntityView(clazz);
+        }
+        return new EntityViewAwareObjectMapper(configuration.createEntityViewManager(cbf), new ObjectMapper(), idValueAccessor);
+    }
+
+    @Test
+    public void deserializesUpdatableEntityView() throws Exception {
+        EntityViewAwareObjectMapper mapper = mapper(null, UpdateView.class);
+        ObjectReader objectReader = mapper.readerFor(UpdateView.class);
+
+        UpdateView view = objectReader.readValue("{\"id\": 1, \"name\": \"test\"}");
+
+        assertFalse(((EntityViewProxy) view).$$_isNew());
+        assertEquals(1L, view.getId());
+        assertEquals("test", view.getName());
+    }
+
+    @Test
+    public void createsCreatableEntityViewWithoutId() throws Exception {
+        EntityViewAwareObjectMapper mapper = mapper(null, CreateView.class);
+        ObjectReader objectReader = mapper.readerFor(CreateView.class);
+
+        CreateView view = objectReader.readValue("{\"name\": \"test\"}");
+
+        assertTrue(((EntityViewProxy) view).$$_isNew());
+        assertEquals("test", view.getName());
+    }
+
+    @Test
+    public void usesIdValueAccessorForRootEntityView() throws Exception {
+        EntityViewAwareObjectMapper mapper = mapper(new EntityViewIdValueAccessor() {
+            @Override
+            @SuppressWarnings("unchecked")
+            public <T> T getValue(tools.jackson.core.JsonParser jsonParser, Class<T> idType) {
+                return (T) (Object) 1L;
+            }
+        }, UpdateView.class);
+
+        UpdateView view = mapper.readerFor(UpdateView.class).readValue("{\"name\": \"test\"}");
+
+        assertEquals(1L, view.getId());
+        assertEquals("test", view.getName());
+    }
+
+    @EntityView(SomeEntity.class)
+    @UpdatableEntityView
+    interface UpdateView {
+        @IdMapping
+        long getId();
+        String getName();
+        void setName(String name);
+    }
+
+    @EntityView(SomeEntity.class)
+    @CreatableEntityView
+    interface CreateView {
+        @IdMapping
+        long getId();
+        String getName();
+        void setName(String name);
+    }
+}

--- a/integration/jackson-3/src/test/java/com/blazebit/persistence/integration/jackson/SomeEntity.java
+++ b/integration/jackson-3/src/test/java/com/blazebit/persistence/integration/jackson/SomeEntity.java
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Blazebit
+ */
+
+package com.blazebit.persistence.integration.jackson;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+@Entity
+public class SomeEntity {
+
+    @Id
+    Long id;
+    String name;
+}

--- a/integration/jackson-3/src/test/resources/META-INF/persistence.xml
+++ b/integration/jackson-3/src/test/resources/META-INF/persistence.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  Copyright Blazebit
+  -->
+<persistence version="2.0" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
+    <persistence-unit name="Test" transaction-type="RESOURCE_LOCAL">
+        <class>com.blazebit.persistence.integration.jackson.SomeEntity</class>
+        <properties>
+            <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -194,6 +194,8 @@
                 <module>jaxrs-jackson-jakarta</module>
                 <module>jaxrs-jsonb-jakarta</module>
                 <module>jackson-jakarta</module>
+                <module>jackson-3</module>
+                <module>jackson-3-jakarta</module>
                 <module>jsonb-jakarta</module>
                 <module>graphql-jakarta</module>
                 <module>graphql-spqr-jakarta</module>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -695,6 +695,16 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>blaze-persistence-integration-jackson-3</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>blaze-persistence-integration-jackson-3-jakarta</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.blazebit</groupId>
                 <artifactId>blaze-persistence-integration-jsonb</artifactId>
                 <version>${project.version}</version>


### PR DESCRIPTION
## Description

Adds Jackson 3 integration through new Java 17+ direct and Jakarta artifacts:

- `blaze-persistence-integration-jackson-3`
- `blaze-persistence-integration-jackson-3-jakarta`

Ports entity-view deserialization to the `tools.jackson.*` API, supports Jackson 3's immutable `ObjectMapper`, and adds deserialization coverage for updatable, creatable, and request-ID-backed entity views.

## Related Issue

Fixes #2111

## Motivation and Context

Jackson 3 uses a new package namespace and immutable mapper configuration, making the existing Jackson 2 integration incompatible. This adds first-class entity-view deserialization support while keeping the Jackson 2 integrations unchanged.