### PR TITLE
fix(core): keep WITH outside Oracle ROWNUM pagination (#2091)

### DIFF
--- a/core/impl/src/main/java/com/blazebit/persistence/impl/dialect/OracleDbmsDialect.java
+++ b/core/impl/src/main/java/com/blazebit/persistence/impl/dialect/OracleDbmsDialect.java
@@ -182,7 +182,17 @@ public class OracleDbmsDialect extends DefaultDbmsDialect {
             }
         }
         if (limit != null) {
-            appendLimit(sqlSb, isSubquery, limit, offset);
+            // OracleDbmsLimitHandler.limitIncludesOffset(): the limit argument is the inclusive upper ROWNUM
+            // bound. appendExtendedSql receives raw maxResults/firstResult strings, so pre-sum here.
+            String effectiveLimit = limit;
+            if (offset != null && !"?".equals(limit) && !"?".equals(offset)) {
+                try {
+                    effectiveLimit = Integer.toString(Integer.parseInt(limit) + Integer.parseInt(offset));
+                } catch (NumberFormatException ex) {
+                    effectiveLimit = "(" + limit + "+" + offset + ")";
+                }
+            }
+            appendLimit(sqlSb, isSubquery, effectiveLimit, offset);
         }
 
         if (returningColumns != null) {

--- a/core/impl/src/main/java/com/blazebit/persistence/impl/dialect/OracleDbmsLimitHandler.java
+++ b/core/impl/src/main/java/com/blazebit/persistence/impl/dialect/OracleDbmsLimitHandler.java
@@ -13,6 +13,20 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
 /**
+ * Oracle limit/offset handler based on {@code ROWNUM}.
+ * <p>
+ * Important details:
+ * <ul>
+ * <li>{@link SqlUtils#indexOfSelect(CharSequence)} is used so a leading {@code WITH} clause stays
+ * outside of the pagination wrapper. Wrapping the whole statement including the CTE (as Hibernate's
+ * native limit handler does for overridden SQL) produces invalid Oracle SQL and parameter binding
+ * mismatches (see issue #2091).</li>
+ * <li>When both limit and offset are present, the upper {@code ROWNUM} bound is the limit value
+ * argument. Callers that already know the inclusive max row ({@code limit + offset}) must pass that
+ * as {@code limit} when using string arguments; the integer-based entry points and parameter binding
+ * do this automatically via {@link #limitIncludesOffset()}.</li>
+ * </ul>
+ *
  * @author Christian Beikov
  * @since 1.2.0
  */
@@ -74,7 +88,10 @@ public class OracleDbmsLimitHandler extends AbstractDbmsLimitHandler {
 
         if (offset != null) {
             if (limit != null) {
-                sqlSb.insert(forUpdateIndex, " ) row_ where rownum <= (" + limit + "+" + offset + ")" + ") where rownum_ > " + offset);
+                // limit already represents the inclusive upper bound (limit+offset) for inlined/variable
+                // application via AbstractDbmsLimitHandler when limitIncludesOffset() is true, and for
+                // appendExtendedSql callers that pre-sum. A single placeholder/value is used — not (limit+offset).
+                sqlSb.insert(forUpdateIndex, " ) row_ where rownum <= " + limit + ") where rownum_ > " + offset);
             } else {
                 sqlSb.insert(forUpdateIndex, " ) where rownum > " + offset);
             }
@@ -87,9 +104,10 @@ public class OracleDbmsLimitHandler extends AbstractDbmsLimitHandler {
     public int bindLimitParametersAtEndOfQuery(Integer limit, Integer offset, PreparedStatement statement, int index) throws SQLException {
         if (offset != null) {
             if (limit != null) {
+                // SQL: rownum <= ? ) where rownum_ > ?
+                // First placeholder is the inclusive max row (limit + offset), second is offset.
                 statement.setInt(index, limit + offset);
                 statement.setInt(index + 1, offset);
-                statement.setInt(index + 2, offset);
                 return 2;
             } else {
                 statement.setInt(index, offset);

--- a/core/impl/src/main/java/com/blazebit/persistence/impl/plan/CustomSelectQueryPlan.java
+++ b/core/impl/src/main/java/com/blazebit/persistence/impl/plan/CustomSelectQueryPlan.java
@@ -5,6 +5,7 @@
 
 package com.blazebit.persistence.impl.plan;
 
+import com.blazebit.persistence.spi.DbmsDialect;
 import com.blazebit.persistence.spi.ExtendedQuerySupport;
 import com.blazebit.persistence.spi.ServiceProvider;
 
@@ -42,16 +43,37 @@ public class CustomSelectQueryPlan<T> implements SelectQueryPlan<T> {
         this.queryPlanCacheEnabled = queryPlanCacheEnabled;
     }
 
+    /**
+     * Applies limit/offset via the Blaze {@link com.blazebit.persistence.spi.DbmsLimitHandler} so that a
+     * leading {@code WITH} clause stays outside of Oracle's {@code ROWNUM} pagination wrapper.
+     * Relying on the JPA provider's limit handler for custom/CTE SQL wraps the whole statement
+     * (including the CTE), which produces invalid Oracle SQL and parameter index errors (#2091).
+     */
+    private String applyLimitOffset(String sql) {
+        if (firstResult == 0 && maxResults == Integer.MAX_VALUE) {
+            extendedQuerySupport.applyFirstResultMaxResults(baseQuery, firstResult, maxResults);
+            return sql;
+        }
+        Integer limit = maxResults == Integer.MAX_VALUE ? null : maxResults;
+        Integer offset = firstResult == 0 ? null : firstResult;
+        String limitedSql = serviceProvider.getService(DbmsDialect.class)
+                .createLimitHandler()
+                .applySqlInlined(sql, false, limit, offset);
+        // Clear provider-side first/max so the limit is not applied a second time on the overridden SQL
+        extendedQuerySupport.applyFirstResultMaxResults(baseQuery, 0, Integer.MAX_VALUE);
+        return limitedSql;
+    }
+
     @Override
     public List<T> getResultList() {
-        extendedQuerySupport.applyFirstResultMaxResults(baseQuery, firstResult, maxResults);
-        return extendedQuerySupport.getResultList(serviceProvider, participatingQueries, delegate, sql, queryPlanCacheEnabled);
+        String finalSql = applyLimitOffset(sql);
+        return extendedQuerySupport.getResultList(serviceProvider, participatingQueries, delegate, finalSql, queryPlanCacheEnabled);
     }
 
     @Override
     public T getSingleResult() {
-        extendedQuerySupport.applyFirstResultMaxResults(baseQuery, firstResult, maxResults);
-        return (T) extendedQuerySupport.getSingleResult(serviceProvider, participatingQueries, delegate, sql, queryPlanCacheEnabled);
+        String finalSql = applyLimitOffset(sql);
+        return (T) extendedQuerySupport.getSingleResult(serviceProvider, participatingQueries, delegate, finalSql, queryPlanCacheEnabled);
     }
 
     @Override
@@ -65,7 +87,7 @@ public class CustomSelectQueryPlan<T> implements SelectQueryPlan<T> {
 
     @Override
     public Stream<T> getResultStream() {
-        extendedQuerySupport.applyFirstResultMaxResults(baseQuery, firstResult, maxResults);
-        return (Stream<T>) extendedQuerySupport.getResultStream(serviceProvider, participatingQueries, delegate, sql, queryPlanCacheEnabled);
+        String finalSql = applyLimitOffset(sql);
+        return (Stream<T>) extendedQuerySupport.getResultStream(serviceProvider, participatingQueries, delegate, finalSql, queryPlanCacheEnabled);
     }
 }

--- a/core/impl/src/test/java/com/blazebit/persistence/impl/dialect/OracleDbmsLimitHandlerTest.java
+++ b/core/impl/src/test/java/com/blazebit/persistence/impl/dialect/OracleDbmsLimitHandlerTest.java
@@ -1,0 +1,84 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Blazebit
+ */
+
+package com.blazebit.persistence.impl.dialect;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Regression tests for Oracle CTE + pagination (#2091).
+ * <p>
+ * The limit wrapper must keep a leading {@code WITH} clause outside of the {@code ROWNUM}
+ * subselect and must not generate a mismatched number of limit placeholders vs bound values.
+ */
+public class OracleDbmsLimitHandlerTest {
+
+    private final OracleDbmsLimitHandler handler = new OracleDbmsLimitHandler();
+
+    @Test
+    public void limitOnlyKeepsWithOutsideRownumWrapper() {
+        String sql = "with cte AS (select 1 as id from dual) select id from t order by id";
+        String result = handler.applySqlInlined(sql, false, 3, null);
+
+        Assert.assertTrue("WITH must remain at the start of the statement", result.startsWith("with cte"));
+        Assert.assertTrue(result.contains("rownum <= 3") || result.contains("rownum<=3"));
+        Assert.assertFalse("WITH must not be nested inside select * from (",
+                result.matches("(?is)select \\* from \\(\\s*with.*"));
+    }
+
+    @Test
+    public void limitAndOffsetKeepsWithOutsideRownumWrapper() {
+        String sql = "with GroupCTE(id) AS (select e.id from Entity e) select g.id from Group g join GroupCTE c on g.id = c.id order by g.id";
+        String result = handler.applySqlInlined(sql, false, 3, 2);
+
+        Assert.assertTrue("WITH must remain at the start of the statement", startsWithIgnoreCase(result, "with "));
+        // Inclusive upper bound is limit + offset = 5; lower bound is offset = 2
+        Assert.assertTrue("Upper ROWNUM bound should be limit+offset", result.contains("rownum <= 5") || result.contains("rownum<=5"));
+        Assert.assertTrue("Offset filter should use rownum_", result.contains("rownum_ > 2") || result.contains("rownum_>2"));
+        Assert.assertFalse("WITH must not be nested inside the outer select * from (",
+                result.matches("(?is)select \\* from \\(\\s*with.*")
+                        || result.matches("(?is)select .* from \\(\\s*select row_\\.\\*.*from \\(\\s*with.*"));
+        // Variable form must not use (?+?) which previously bound limit+offset incorrectly
+        Assert.assertFalse(result.contains("(?+?)"));
+        Assert.assertFalse(result.contains("(3+2)"));
+    }
+
+    @Test
+    public void variableLimitAndOffsetPlaceholdersMatchBindCount() {
+        String sql = "with cte AS (select 1 as id from dual) select id from t order by id";
+        String result = handler.applySql(sql, false, 3, 2);
+
+        Assert.assertTrue(startsWithIgnoreCase(result, "with "));
+        // Two placeholders: inclusive max row and offset
+        int placeholders = countOccurrences(result, '?');
+        Assert.assertEquals("Expected two limit/offset placeholders", 2, placeholders);
+        Assert.assertTrue(result.contains("rownum <= ?") || result.contains("rownum<=?"));
+        Assert.assertTrue(result.contains("rownum_ > ?") || result.contains("rownum_>?"));
+        Assert.assertFalse(result.contains("(?+?)"));
+    }
+
+    @Test
+    public void limitOnlyWithoutWith() {
+        String sql = "select id from t order by id";
+        String result = handler.applySqlInlined(sql, false, 10, null);
+        Assert.assertTrue(result.startsWith("select * from ("));
+        Assert.assertTrue(result.contains("rownum <= 10") || result.contains("rownum<=10"));
+    }
+
+    private static boolean startsWithIgnoreCase(String value, String prefix) {
+        return value.regionMatches(true, 0, prefix, 0, prefix.length());
+    }
+
+    private static int countOccurrences(String value, char c) {
+        int count = 0;
+        for (int i = 0; i < value.length(); i++) {
+            if (value.charAt(i) == c) {
+                count++;
+            }
+        }
+        return count;
+    }
+}

--- a/core/testsuite/src/test/java/com/blazebit/persistence/testsuite/Issue2091Test.java
+++ b/core/testsuite/src/test/java/com/blazebit/persistence/testsuite/Issue2091Test.java
@@ -1,0 +1,134 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Blazebit
+ */
+
+package com.blazebit.persistence.testsuite;
+
+import com.blazebit.persistence.CriteriaBuilder;
+import com.blazebit.persistence.testsuite.base.jpa.category.NoDatanucleus;
+import com.blazebit.persistence.testsuite.base.jpa.category.NoEclipselink;
+import com.blazebit.persistence.testsuite.base.jpa.category.NoMySQLOld;
+import com.blazebit.persistence.testsuite.base.jpa.category.NoOpenJPA;
+import com.blazebit.persistence.testsuite.base.jpa.category.NoOracle;
+import com.blazebit.persistence.testsuite.entity.RecursiveEntity;
+import com.blazebit.persistence.testsuite.entity.TestCTE;
+import com.blazebit.persistence.testsuite.tx.TxVoidWork;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test for issue #2091.
+ * <p>
+ * Oracle CTE pagination previously wrapped the entire statement (including {@code WITH}) with a
+ * {@code ROWNUM} filter via the JPA provider limit handler, causing invalid SQL / invalid column index
+ * when offset+limit were used. Pagination must keep the CTE at the top level and still return the
+ * correct page.
+ * <p>
+ * Oracle recursive CTEs need a cycle clause (#295), so runtime is skipped on Oracle; the SQL-shape
+ * unit coverage lives in {@code OracleDbmsLimitHandlerTest}.
+ *
+ * @author arimu1
+ * @since 1.6.21
+ */
+public class Issue2091Test extends AbstractCoreTest {
+
+    @Override
+    protected Class<?>[] getEntityClasses() {
+        return new Class<?>[]{
+            RecursiveEntity.class,
+            TestCTE.class
+        };
+    }
+
+    @Override
+    public void setUpOnce() {
+        cleanDatabase();
+        transactional(new TxVoidWork() {
+            @Override
+            public void work(EntityManager em) {
+                RecursiveEntity root1 = new RecursiveEntity("root1");
+                RecursiveEntity child1_1 = new RecursiveEntity("child1_1", root1);
+                RecursiveEntity child1_2 = new RecursiveEntity("child1_2", root1);
+                RecursiveEntity child1_1_1 = new RecursiveEntity("child1_1_1", child1_1);
+                RecursiveEntity child1_2_1 = new RecursiveEntity("child1_2_1", child1_2);
+
+                em.persist(root1);
+                em.persist(child1_1);
+                em.persist(child1_2);
+                em.persist(child1_1_1);
+                em.persist(child1_2_1);
+            }
+        });
+    }
+
+    // TODO: Oracle requires a cycle clause #295 — SQL shape is covered by OracleDbmsLimitHandlerTest
+    @Test
+    @Category({ NoDatanucleus.class, NoEclipselink.class, NoOpenJPA.class, NoMySQLOld.class, NoOracle.class })
+    public void testCtePaginationWithOffsetAndLimit() {
+        CriteriaBuilder<TestCTE> cb = cbf.create(em, TestCTE.class);
+        cb.withRecursive(TestCTE.class)
+                .from(RecursiveEntity.class, "e")
+                .bind("id").select("e.id")
+                .bind("name").select("e.name")
+                .bind("level").select("0")
+                .where("e.parent").isNull()
+        .unionAll()
+                .from(TestCTE.class, "t")
+                .innerJoinOn(RecursiveEntity.class, "e")
+                    .on("t.id").eqExpression("e.parent.id")
+                .end()
+                .bind("id").select("e.id")
+                .bind("name").select("e.name")
+                .bind("level").select("t.level + 1")
+        .end();
+        cb.from(TestCTE.class, "t")
+                .where("t.level").ltExpression("2")
+                .orderByAsc("t.level")
+                .orderByAsc("t.id")
+                .setFirstResult(2)
+                .setMaxResults(3);
+
+        List<TestCTE> resultList = cb.getResultList();
+        // levels < 2: root1, child1_1, child1_2 — offset 2, limit 3 → only child1_2
+        assertEquals(1, resultList.size());
+        assertEquals("child1_2", resultList.get(0).getName());
+    }
+
+    // TODO: Oracle requires a cycle clause #295
+    @Test
+    @Category({ NoDatanucleus.class, NoEclipselink.class, NoOpenJPA.class, NoMySQLOld.class, NoOracle.class })
+    public void testCtePaginationLimitOnly() {
+        CriteriaBuilder<TestCTE> cb = cbf.create(em, TestCTE.class);
+        cb.withRecursive(TestCTE.class)
+                .from(RecursiveEntity.class, "e")
+                .bind("id").select("e.id")
+                .bind("name").select("e.name")
+                .bind("level").select("0")
+                .where("e.parent").isNull()
+        .unionAll()
+                .from(TestCTE.class, "t")
+                .innerJoinOn(RecursiveEntity.class, "e")
+                    .on("t.id").eqExpression("e.parent.id")
+                .end()
+                .bind("id").select("e.id")
+                .bind("name").select("e.name")
+                .bind("level").select("t.level + 1")
+        .end();
+        cb.from(TestCTE.class, "t")
+                .where("t.level").ltExpression("2")
+                .orderByAsc("t.level")
+                .orderByAsc("t.id")
+                .setMaxResults(2);
+
+        List<TestCTE> resultList = cb.getResultList();
+        assertEquals(2, resultList.size());
+        assertEquals("root1", resultList.get(0).getName());
+        assertEquals("child1_1", resultList.get(1).getName());
+    }
+}


### PR DESCRIPTION
## Description

Fixes Oracle CTE pagination that wrapped the entire statement (including `WITH`) using `ROWNUM`, which produced invalid SQL and `invalid column index` parameter mismatches when `offset` + `limit` were set.

**Root cause**
- Custom/CTE SQL overrides force the JPA provider’s limit handler onto the final SQL.
- Hibernate’s Oracle handler wraps the *whole* string: `select * from ( with ... select ... ) where rownum <= ?`.
- Blaze’s `OracleDbmsLimitHandler` also used `rownum <= (?+?)` while binding only two values incorrectly for three placeholders.

**Fix**
1. `OracleDbmsLimitHandler` – upper bound is a single value/placeholder (`limit + offset` when both are present); bind count matches placeholders; `SqlUtils.indexOfSelect` keeps `WITH` outside the wrapper.
2. `OracleDbmsDialect.appendExtendedSql` – pre-sums raw `maxResults` + `firstResult` for the inclusive upper bound.
3. `CustomSelectQueryPlan` – applies Blaze `DbmsLimitHandler` to custom/CTE SQL and clears provider first/max so Hibernate does not wrap the CTE again.

Example shape after the fix:

```sql
with GroupCTE(...) 
select id from (
  select row_.*, rownum rownum_ from (
    select ...
  ) row_ where rownum <= 5
) where rownum_ > 2
```

## Related issue

Fixes #2091

## Checklist

- [x] No open prior PR for #2091
- [x] Unit test for Oracle SQL shape with leading `WITH` (`OracleDbmsLimitHandlerTest`)
- [x] Integration-style CTE pagination test (`Issue2091Test`; Oracle runtime still skipped for recursive cycle #295)
- [x] Smoke-verified SQL generation for CTE + limit/offset

## Test plan

- `OracleDbmsLimitHandlerTest` (4 tests) – CTE stays outside ROWNUM wrapper; two placeholders for limit+offset; no `(?+?)`
- `Issue2091Test` – recursive CTE with `setFirstResult`/`setMaxResults` returns the expected page (non-Oracle DBs; Oracle recursive needs cycle clause #295)