### PR TITLE
Fix for #2128 - pass the HttpInputMessage to HttpMessageNotReadableException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ None yet
 
 ### Bug fixes
 
-None yet
+* Use the `HttpInputMessage` bearing `HttpMessageNotReadableException` constructor in `EntityViewAwareMappingJackson2HttpMessageConverter` so that unreadable entity view request bodies do not fail with `NoSuchMethodError` on Spring Framework 7
 
 ### Backwards-incompatible changes
 

--- a/integration/spring-data/testsuite/webmvc/src/test/java/com/blazebit/persistence/spring/data/testsuite/webmvc/AbstractSpringWebMvcTest.java
+++ b/integration/spring-data/testsuite/webmvc/src/test/java/com/blazebit/persistence/spring/data/testsuite/webmvc/AbstractSpringWebMvcTest.java
@@ -104,6 +104,26 @@ public abstract class AbstractSpringWebMvcTest extends AbstractSpringTest {
         }
     }
 
+    protected RequestBuilder putRawJson(String path, Object idParam, byte[] content, String accept) {
+        MockHttpServletRequestBuilder builder = idParam == null ? put(path) : put(path, idParam);
+        if (CONTENT != null) {
+            try {
+                CONTENT.invoke(builder, content);
+                CONTENT_TYPE.invoke(builder, MediaType.APPLICATION_JSON);
+                if (accept != null) {
+                    ACCEPT.invoke(builder, (Object) new String[]{ accept });
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            return builder;
+        } else {
+            builder.content(content)
+                    .contentType(MediaType.APPLICATION_JSON);
+            return accept == null ? builder : builder.accept(accept);
+        }
+    }
+
     protected RequestBuilder postJson(String path, Object createView) throws JsonProcessingException {
         MockHttpServletRequestBuilder builder = post(path);
         if (CONTENT != null) {

--- a/integration/spring-data/testsuite/webmvc/src/test/java/com/blazebit/persistence/spring/data/testsuite/webmvc/DocumentControllerTest.java
+++ b/integration/spring-data/testsuite/webmvc/src/test/java/com/blazebit/persistence/spring/data/testsuite/webmvc/DocumentControllerTest.java
@@ -24,6 +24,7 @@ import com.blazebit.persistence.spring.data.testsuite.webmvc.view.DocumentCreate
 import com.blazebit.persistence.spring.data.testsuite.webmvc.view.DocumentCreateOrUpdateViewBuilder;
 import com.blazebit.persistence.spring.data.testsuite.webmvc.view.DocumentUpdateView;
 import com.blazebit.persistence.spring.data.webmvc.impl.BlazePersistenceWebConfiguration;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -144,6 +145,18 @@ public class DocumentControllerTest extends AbstractSpringWebMvcTest {
         // attempted because the entity view used is both updatable and creatable. The update would fail like before.
         mockMvc.perform(postJson("/documents", createView))
             .andExpect(status().isOk());
+    }
+
+    // Test for #2128
+    @Test
+    public void testUnreadableRequestBodyIsReportedAsBadRequest() throws Exception {
+        // Given
+        Document d1 = createDocument("D1");
+        byte[] truncatedJson = "{\"name\":".getBytes(StandardCharsets.UTF_8);
+
+        // When / Then
+        mockMvc.perform(putRawJson("/documents/{id}", d1.getId(), truncatedJson, APPLICATION_VND_BLAZEBIT_UPDATE_1_JSON))
+            .andExpect(status().isBadRequest());
     }
 
     private Document createDocument(String name) {

--- a/integration/spring-data/webmvc-jakarta/src/main/java/com/blazebit/persistence/spring/data/webmvc/impl/json/EntityViewAwareMappingJackson2HttpMessageConverter.java
+++ b/integration/spring-data/webmvc-jakarta/src/main/java/com/blazebit/persistence/spring/data/webmvc/impl/json/EntityViewAwareMappingJackson2HttpMessageConverter.java
@@ -77,7 +77,7 @@ public class EntityViewAwareMappingJackson2HttpMessageConverter extends MappingJ
             }
             return entityViewAwareObjectMapper.readerFor(javaType).readValue(inputMessage.getBody());
         } catch (IOException ex) {
-            throw new HttpMessageNotReadableException("Could not read document: " + ex.getMessage(), ex);
+            throw new HttpMessageNotReadableException("Could not read document: " + ex.getMessage(), ex, inputMessage);
         }
     }
 }

--- a/integration/spring-data/webmvc/src/main/java/com/blazebit/persistence/spring/data/webmvc/impl/json/EntityViewAwareMappingJackson2HttpMessageConverter.java
+++ b/integration/spring-data/webmvc/src/main/java/com/blazebit/persistence/spring/data/webmvc/impl/json/EntityViewAwareMappingJackson2HttpMessageConverter.java
@@ -76,7 +76,7 @@ public class EntityViewAwareMappingJackson2HttpMessageConverter extends MappingJ
             }
             return entityViewAwareObjectMapper.readerFor(javaType).readValue(inputMessage.getBody());
         } catch (IOException ex) {
-            throw new HttpMessageNotReadableException("Could not read document: " + ex.getMessage(), ex);
+            throw new HttpMessageNotReadableException("Could not read document: " + ex.getMessage(), ex, inputMessage);
         }
     }
 }


### PR DESCRIPTION
Fixes #2128.

`EntityViewAwareMappingJackson2HttpMessageConverter.readJavaType` throws through `HttpMessageNotReadableException(String, Throwable)`. That constructor was deprecated in Spring 5.1 and **removed in Spring Framework 7.0**, so on Spring Boot 4 the `throw` itself fails with `NoSuchMethodError` before the exception is constructed:

```
java.lang.NoSuchMethodError: org.springframework.http.converter.HttpMessageNotReadableException: method 'void <init>(java.lang.String, java.lang.Throwable)' not found
    at com.blazebit.persistence.spring.data.webmvc.impl.json.EntityViewAwareMappingJackson2HttpMessageConverter.readJavaType(EntityViewAwareMappingJackson2HttpMessageConverter.java:80)
```

The in-flight `IOException` is discarded rather than attached as a cause, the response becomes a 500 instead of a 400, and any `@ExceptionHandler` registered for `HttpMessageNotReadableException` never runs.

`readJavaType` already has the `inputMessage` in hand, so the three-arg `(String, Throwable, HttpInputMessage)` overload is a drop-in. It has existed since Spring 5.1, so this compiles unchanged on every Spring version the build targets — no version branching, no profile-specific source.

## Changes

- `integration/spring-data/webmvc/.../EntityViewAwareMappingJackson2HttpMessageConverter.java` — pass `inputMessage`.
- `integration/spring-data/webmvc-jakarta/.../EntityViewAwareMappingJackson2HttpMessageConverter.java` — same, the jakarta copy of the class.
- `DocumentControllerTest` — `// Test for #2128`, a `PUT` with a truncated JSON body expecting `400`. Committed separately as `Test for #2128`, per CONTRIBUTING.
- `AbstractSpringWebMvcTest` — `putRawJson(...)`, so a test can send a body that is deliberately not valid JSON. Mirrors the existing reflective `putJson(...)` so it keeps working across the Spring versions the testsuite compiles against.
- `CHANGELOG.md` — bug-fix entry under 1.6.21-SNAPSHOT.

## Verification

The new test reproduces the failure only when the testsuite runs against Spring 7, i.e. `-Pspring-data-4.0.x` (`version.spring-data-4.0-spring` = 7.0.8). On earlier Spring versions the removed constructor still exists, so it passes with or without the fix — it is a regression guard for the 4.0 profile.

I was not able to run the full Maven testsuite locally. What I did verify directly: compiling the patched `webmvc-jakarta` converter against `spring-web-7.0.8` succeeds, and the emitted call site is now the surviving constructor.

```
$ javap -c ... EntityViewAwareMappingJackson2HttpMessageConverter | grep 'HttpMessageNotReadableException."<init>"'
75: invokespecial #86  // Method org/springframework/http/converter/HttpMessageNotReadableException."<init>":(Ljava/lang/String;Ljava/lang/Throwable;Lorg/springframework/http/HttpInputMessage;)V
```

Happy to adjust the test's placement (a dedicated `Issue2128Test` rather than a case on `DocumentControllerTest`) or anything else you'd prefer.